### PR TITLE
Add island color setting

### DIFF
--- a/src/components/island/DynamicIsland.tsx
+++ b/src/components/island/DynamicIsland.tsx
@@ -2,7 +2,7 @@ import { motion, AnimatePresence } from 'motion/react';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { getCurrentWindow } from '@tauri-apps/api/window';
-import { useEffect, useCallback, useRef, useMemo } from 'react';
+import { useEffect, useCallback, useRef, useMemo, type CSSProperties } from 'react';
 import { useNotchInfo } from '../../hooks/useNotchInfo';
 import { cn } from '../../lib/utils';
 import { CompactMedia } from './CompactMedia';
@@ -360,6 +360,13 @@ export function DynamicIsland() {
 
     const fadeTransition = useMemo(() => ({ duration: 0.3 }), []);
 
+    const islandColor = /^#[0-9a-fA-F]{6}$/.test(settings.islandColor)
+        ? settings.islandColor
+        : '#000000';
+    const islandBackground = settings.liquidGlassMode
+        ? `color-mix(in srgb, ${islandColor} 65%, transparent)`
+        : islandColor;
+
     // Get active widget for compact mode
     const activeWidget = useMemo(() =>
         enabledCompactWidgets.find(w => w.id === mode),
@@ -412,16 +419,16 @@ export function DynamicIsland() {
             <motion.div
                 ref={islandRef}
                 className={cn(
-                    "pointer-events-auto bg-black rounded-b-[20px] overflow-visible flex items-center justify-center relative will-change-[width,height,border-radius]",
+                    "pointer-events-auto rounded-b-[20px] overflow-visible flex items-center justify-center relative will-change-[width,height,border-radius]",
                     // Expanded
                     expanded && "rounded-b-[18px] flex-col justify-start",
                     // Liquid Glass
-                    settings.liquidGlassMode && "bg-black/65 backdrop-blur-[25px] backdrop-saturate-[180%] border border-white/10 shadow-[0_10px_40px_rgba(0,0,0,0.5)]",
+                    settings.liquidGlassMode && "backdrop-blur-[25px] backdrop-saturate-[180%] border border-white/10 shadow-[0_10px_40px_rgba(0,0,0,0.5)]",
                     // Wings
                     "before:content-[''] before:absolute before:top-0 before:-left-[6px] before:w-[6px] before:h-[6px] before:z-10 before:pointer-events-none",
-                    "before:bg-[radial-gradient(circle_at_0_100%,transparent_6px,black_6px)]",
+                    "before:bg-[radial-gradient(circle_at_0_100%,transparent_6px,var(--island-color)_6px)]",
                     "after:content-[''] after:absolute after:top-0 after:-right-[6px] after:w-[6px] after:h-[6px] after:z-10 after:pointer-events-none",
-                    "after:bg-[radial-gradient(circle_at_100%_100%,transparent_6px,black_6px)]",
+                    "after:bg-[radial-gradient(circle_at_100%_100%,transparent_6px,var(--island-color)_6px)]",
                     (settings.nonNotchMode && mode === 'idle' && !isHovered && !expanded) && "before:hidden after:hidden"
                 )}
                 initial={false}
@@ -435,7 +442,11 @@ export function DynamicIsland() {
                 onHoverStart={handleHoverStart}
                 onClick={handleIslandClick}
                 onWheel={handleWheel}
-                style={{ cursor: 'pointer' }}
+                style={{
+                    cursor: 'pointer',
+                    backgroundColor: islandBackground,
+                    '--island-color': islandColor,
+                } as CSSProperties}
             >
                 <AnimatePresence mode="wait">
                     <motion.div

--- a/src/stores/useDynamicIslandStore.ts
+++ b/src/stores/useDynamicIslandStore.ts
@@ -7,6 +7,7 @@ interface Settings {
     showMedia: boolean;
     liquidGlassMode: boolean;
     nonNotchMode: boolean;
+    islandColor: string;
 }
 
 interface DynamicIslandState {
@@ -72,6 +73,7 @@ const DEFAULT_SETTINGS: Settings = {
     showMedia: true,
     liquidGlassMode: false,
     nonNotchMode: false,
+    islandColor: '#000000',
 };
 
 export const useDynamicIslandStore = create<DynamicIslandStore>((set, get) => ({

--- a/src/windows/Settings/Settings.tsx
+++ b/src/windows/Settings/Settings.tsx
@@ -17,6 +17,7 @@ interface SettingsState {
     showMedia: boolean;
     liquidGlassMode: boolean;
     nonNotchMode: boolean;
+    islandColor: string;
 }
 
 type Tab = 'general' | 'appearance' | 'media' | 'widgets' | 'plugins';
@@ -29,6 +30,7 @@ export default function Settings() {
         showMedia: true,
         liquidGlassMode: false,
         nonNotchMode: false,
+        islandColor: '#000000',
     });
     const [activeTab, setActiveTab] = useState<Tab>('general');
 
@@ -57,6 +59,7 @@ export default function Settings() {
                     showMedia: true,
                     liquidGlassMode: false,
                     nonNotchMode: false,
+                    islandColor: '#000000',
                     ...parsed
                 });
             } catch (e) {
@@ -181,6 +184,21 @@ export default function Settings() {
                                     <Switch
                                         checked={settings.nonNotchMode}
                                         onCheckedChange={(c) => updateSetting('nonNotchMode', c)}
+                                    />
+                                </div>
+                            </div>
+                            <div className="bg-card rounded-2xl mb-6 overflow-hidden border border-border">
+                                <div className="flex items-center justify-between p-3 px-4 border-b border-border last:border-b-0">
+                                    <div className="flex flex-col">
+                                        <Label className="text-[15px] font-normal">Island Color</Label>
+                                        <span className="text-xs text-muted-foreground mt-0.5">Background color of the dynamic island</span>
+                                    </div>
+                                    <input
+                                        type="color"
+                                        aria-label="Island color"
+                                        value={/^#[0-9a-fA-F]{6}$/.test(settings.islandColor) ? settings.islandColor : '#000000'}
+                                        onChange={(e) => updateSetting('islandColor', e.target.value)}
+                                        className="h-8 w-8 cursor-pointer rounded-md border border-border bg-transparent p-0.5"
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements one slice of #42: **change the dynamic island color**.

The island already had Appearance settings (`liquidGlassMode`, `nonNotchMode`) stored in `localStorage` under `app-settings`. This adds `islandColor` to that same path instead of introducing a new settings system.

## What shipped

- Settings → Appearance → **Island Color** color picker
- Applies to the island body and the notch “wings”
- Works with Liquid Glass (color at 65% opacity + existing blur)
- Default remains `#000000` (current look)
- Invalid stored values fall back to black

## Still open from #42

- Move the island freely (left/center/right or drag). Mouse hit-testing currently recenters UI bounds, so position is not a frontend-only change.
- Hide/disable the island when another app is maximized (needs OS-level window monitoring)
- Any other customization beyond color

## Test plan

No existing test suite in the repo. Verify manually:

1. Open Settings → Appearance. Confirm **Island Color** appears below Non-Notch Mode and defaults to black.
2. Pick a color (e.g. `#1a1a2e`). The island body and wings should update immediately (or after switching back to the island window).
3. Toggle **Liquid Glass Mode**. The island should keep the chosen color at reduced opacity with blur.
4. Toggle Liquid Glass off. Solid custom color should return.
5. Set the picker back to `#000000` and confirm the original black island look.
6. Quit and relaunch. The chosen color should persist via `app-settings`.
7. `npx tsc --noEmit` passes.

Related to #42 (does not close it).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9c5adb5-1d8d-4f12-a592-4a4aed9f8002?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9c5adb5-1d8d-4f12-a592-4a4aed9f8002&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

