### PR TITLE
Hide the island when another app is maximized

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -58,6 +58,7 @@ windows = { version = "0.52", features = [
     "Win32_UI_WindowsAndMessaging",
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
+    "Win32_Graphics_Dwm",
     "Media_Control",
     "Storage_Streams",
     "Foundation",

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ pub mod audio;
 pub mod calendar;
 pub mod database;
 pub mod files;
+pub mod maximized;
 pub mod models;
 pub mod notes;
 pub mod plugins;
@@ -30,6 +31,7 @@ pub fn run() {
             window::get_window_settings,
             window::update_window_settings,
             window::open_settings,
+            maximized::set_hide_when_maximized,
             audio::get_now_playing,
             audio::get_audio_levels,
             audio::media_play_pause,
@@ -178,6 +180,7 @@ pub fn run() {
                 let _ = window::setup_fixed_window_size(&window);
 
                 window::setup_mouse_monitoring(app.handle().clone());
+                maximized::setup_maximized_monitoring(app.handle().clone());
                 audio::setup_audio_monitoring(app.handle().clone());
             }
             Ok(())

--- a/src-tauri/src/maximized.rs
+++ b/src-tauri/src/maximized.rs
@@ -1,0 +1,373 @@
+use std::sync::atomic::{AtomicBool, Ordering};
+use tauri::AppHandle;
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use tauri::{Emitter, Manager};
+
+/// User setting: hide the island when another app is maximized/fullscreen.
+/// Defaults to true so the requested behavior is on unless the user opts out.
+static HIDE_WHEN_MAXIMIZED_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Latest OS detection result (another app is maximized/fullscreen on the island's display).
+static OTHER_APP_MAXIMIZED: AtomicBool = AtomicBool::new(false);
+
+#[tauri::command]
+pub fn set_hide_when_maximized(enabled: bool) {
+    HIDE_WHEN_MAXIMIZED_ENABLED.store(enabled, Ordering::Relaxed);
+}
+
+/// True when the island should stay hidden and click-through.
+pub fn should_hide_for_maximized() -> bool {
+    HIDE_WHEN_MAXIMIZED_ENABLED.load(Ordering::Relaxed)
+        && OTHER_APP_MAXIMIZED.load(Ordering::Relaxed)
+}
+
+pub fn setup_maximized_monitoring(app_handle: AppHandle) {
+    #[cfg(any(target_os = "macos", target_os = "windows"))]
+    {
+        std::thread::spawn(move || {
+            const POLL_MS: u64 = 200;
+            loop {
+                let maximized = other_app_is_maximized();
+                let was_maximized = OTHER_APP_MAXIMIZED.swap(maximized, Ordering::Relaxed);
+                if maximized != was_maximized {
+                    if maximized {
+                        log::debug!("[maximized] another app is maximized/fullscreen");
+                        let _ = app_handle.emit("app-maximized", ());
+                    } else {
+                        log::debug!("[maximized] no maximized/fullscreen app");
+                        let _ = app_handle.emit("app-unmaximized", ());
+                    }
+
+                    // Keep the overlay click-through while hidden so hover monitoring
+                    // cannot steal clicks from the maximized app.
+                    if should_hide_for_maximized() {
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.set_ignore_cursor_events(true);
+                        }
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
+            }
+        });
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let _ = app_handle;
+        let _ = should_hide_for_maximized();
+        log::info!("Maximized-window monitoring is not implemented on Linux.");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn other_app_is_maximized() -> bool {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use objc2::{Encode, Encoding};
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CGSize {
+        width: f64,
+        height: f64,
+    }
+
+    unsafe impl Encode for CGSize {
+        const ENCODING: Encoding = Encoding::Struct("CGSize", &[f64::ENCODING, f64::ENCODING]);
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CGPoint {
+        x: f64,
+        y: f64,
+    }
+
+    unsafe impl Encode for CGPoint {
+        const ENCODING: Encoding = Encoding::Struct("CGPoint", &[f64::ENCODING, f64::ENCODING]);
+    }
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CGRect {
+        origin: CGPoint,
+        size: CGSize,
+    }
+
+    unsafe impl Encode for CGRect {
+        const ENCODING: Encoding =
+            Encoding::Struct("CGRect", &[CGPoint::ENCODING, CGSize::ENCODING]);
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGWindowListCopyWindowInfo(
+            option: u32,
+            relative_to_window: u32,
+        ) -> *mut std::ffi::c_void;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: *mut std::ffi::c_void);
+    }
+
+    // On-screen windows, exclude desktop wallpaper elements.
+    const K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY: u32 = 1 << 0;
+    const K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS: u32 = 1 << 4;
+
+    let our_pid = std::process::id() as i32;
+
+    unsafe {
+        let pool: *mut AnyObject = msg_send![class!(NSAutoreleasePool), new];
+
+        let main_screen: *mut AnyObject = msg_send![class!(NSScreen), mainScreen];
+        if main_screen.is_null() {
+            let _: () = msg_send![pool, drain];
+            return false;
+        }
+
+        let frame: CGRect = msg_send![main_screen, frame];
+        let visible: CGRect = msg_send![main_screen, visibleFrame];
+        let screen_width = frame.size.width;
+        let screen_height = frame.size.height;
+        // Zoomed windows fill visibleFrame; fullscreen windows are at least that large.
+        let target_width = visible.size.width;
+        let target_height = visible.size.height;
+
+        let info = CGWindowListCopyWindowInfo(
+            K_CG_WINDOW_LIST_OPTION_ON_SCREEN_ONLY | K_CG_WINDOW_LIST_EXCLUDE_DESKTOP_ELEMENTS,
+            0,
+        );
+        if info.is_null() {
+            let _: () = msg_send![pool, drain];
+            return false;
+        }
+
+        let array = info as *mut AnyObject;
+        let count: usize = msg_send![array, count];
+
+        let pid_key: *mut AnyObject = msg_send![
+            class!(NSString),
+            stringWithUTF8String: b"kCGWindowOwnerPID\0".as_ptr() as *const i8
+        ];
+        let layer_key: *mut AnyObject = msg_send![
+            class!(NSString),
+            stringWithUTF8String: b"kCGWindowLayer\0".as_ptr() as *const i8
+        ];
+        let bounds_key: *mut AnyObject = msg_send![
+            class!(NSString),
+            stringWithUTF8String: b"kCGWindowBounds\0".as_ptr() as *const i8
+        ];
+        let x_key: *mut AnyObject =
+            msg_send![class!(NSString), stringWithUTF8String: b"X\0".as_ptr() as *const i8];
+        let y_key: *mut AnyObject =
+            msg_send![class!(NSString), stringWithUTF8String: b"Y\0".as_ptr() as *const i8];
+        let w_key: *mut AnyObject =
+            msg_send![class!(NSString), stringWithUTF8String: b"Width\0".as_ptr() as *const i8];
+        let h_key: *mut AnyObject =
+            msg_send![class!(NSString), stringWithUTF8String: b"Height\0".as_ptr() as *const i8];
+
+        let mut found = false;
+        const SIZE_SLOP: f64 = 40.0;
+
+        for i in 0..count {
+            let dict: *mut AnyObject = msg_send![array, objectAtIndex: i];
+            if dict.is_null() {
+                continue;
+            }
+
+            let layer_obj: *mut AnyObject = msg_send![dict, objectForKey: layer_key];
+            if !layer_obj.is_null() {
+                let layer: i32 = msg_send![layer_obj, intValue];
+                // Layer 0 is normal app windows (Dock/menu bar/overlays use higher layers).
+                if layer != 0 {
+                    continue;
+                }
+            }
+
+            let pid_obj: *mut AnyObject = msg_send![dict, objectForKey: pid_key];
+            if pid_obj.is_null() {
+                continue;
+            }
+            let pid: i32 = msg_send![pid_obj, intValue];
+            if pid == our_pid || pid <= 0 {
+                continue;
+            }
+
+            let bounds: *mut AnyObject = msg_send![dict, objectForKey: bounds_key];
+            if bounds.is_null() {
+                continue;
+            }
+
+            let x_obj: *mut AnyObject = msg_send![bounds, objectForKey: x_key];
+            let y_obj: *mut AnyObject = msg_send![bounds, objectForKey: y_key];
+            let w_obj: *mut AnyObject = msg_send![bounds, objectForKey: w_key];
+            let h_obj: *mut AnyObject = msg_send![bounds, objectForKey: h_key];
+            if w_obj.is_null() || h_obj.is_null() || x_obj.is_null() || y_obj.is_null() {
+                continue;
+            }
+
+            let x: f64 = msg_send![x_obj, doubleValue];
+            let y: f64 = msg_send![y_obj, doubleValue];
+            let width: f64 = msg_send![w_obj, doubleValue];
+            let height: f64 = msg_send![h_obj, doubleValue];
+
+            // CGWindow bounds origin is top-left of the primary display.
+            let cx = x + width / 2.0;
+            let cy = y + height / 2.0;
+            let on_main = cx >= 0.0 && cx < screen_width && cy >= 0.0 && cy < screen_height;
+            if !on_main {
+                continue;
+            }
+
+            if width >= target_width - SIZE_SLOP && height >= target_height - SIZE_SLOP {
+                found = true;
+                break;
+            }
+        }
+
+        CFRelease(info);
+        let _: () = msg_send![pool, drain];
+        found
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn other_app_is_maximized() -> bool {
+    use windows::Win32::Foundation::{BOOL, HWND, LPARAM, RECT};
+    use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_CLOAKED};
+    use windows::Win32::Graphics::Gdi::{
+        GetMonitorInfoW, MonitorFromWindow, MONITORINFO, MONITOR_DEFAULTTONEAREST,
+    };
+    use windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetClassNameW, GetWindowRect, GetWindowThreadProcessId, IsIconic,
+        IsWindowVisible, IsZoomed, MONITORINFOF_PRIMARY,
+    };
+
+    struct EnumState {
+        our_pid: u32,
+        found: bool,
+    }
+
+    fn is_cloaked(hwnd: HWND) -> bool {
+        let mut cloaked: u32 = 0;
+        let result = unsafe {
+            DwmGetWindowAttribute(
+                hwnd,
+                DWMWA_CLOAKED,
+                &mut cloaked as *mut u32 as *mut std::ffi::c_void,
+                std::mem::size_of::<u32>() as u32,
+            )
+        };
+        result.is_ok() && cloaked != 0
+    }
+
+    fn class_name(hwnd: HWND) -> String {
+        let mut buf = [0u16; 256];
+        let len = unsafe { GetClassNameW(hwnd, &mut buf) };
+        if len <= 0 {
+            return String::new();
+        }
+        String::from_utf16_lossy(&buf[..len as usize])
+    }
+
+    fn is_shell_window(class: &str) -> bool {
+        matches!(
+            class,
+            "Progman"
+                | "WorkerW"
+                | "Shell_TrayWnd"
+                | "Shell_SecondaryTrayWnd"
+                | "NotifyIconOverflowWindow"
+                | "ForegroundStaging"
+                | "XamlExplorerHostIslandWindow"
+        )
+    }
+
+    fn is_on_primary(hwnd: HWND) -> bool {
+        unsafe {
+            let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+            let mut info = MONITORINFO {
+                cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                rcMonitor: RECT::default(),
+                rcWork: RECT::default(),
+                dwFlags: 0,
+            };
+            if !GetMonitorInfoW(monitor, &mut info).as_bool() {
+                return false;
+            }
+            info.dwFlags & MONITORINFOF_PRIMARY != 0
+        }
+    }
+
+    fn covers_monitor(hwnd: HWND) -> bool {
+        unsafe {
+            let monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+            let mut info = MONITORINFO {
+                cbSize: std::mem::size_of::<MONITORINFO>() as u32,
+                rcMonitor: RECT::default(),
+                rcWork: RECT::default(),
+                dwFlags: 0,
+            };
+            if !GetMonitorInfoW(monitor, &mut info).as_bool() {
+                return false;
+            }
+            let mut rect = RECT::default();
+            if GetWindowRect(hwnd, &mut rect).is_err() {
+                return false;
+            }
+            const SLOP: i32 = 4;
+            rect.left <= info.rcMonitor.left + SLOP
+                && rect.top <= info.rcMonitor.top + SLOP
+                && rect.right >= info.rcMonitor.right - SLOP
+                && rect.bottom >= info.rcMonitor.bottom - SLOP
+        }
+    }
+
+    fn is_hide_worthy(hwnd: HWND, our_pid: u32) -> bool {
+        unsafe {
+            if !IsWindowVisible(hwnd).as_bool() || IsIconic(hwnd).as_bool() {
+                return false;
+            }
+            if is_cloaked(hwnd) {
+                return false;
+            }
+
+            let mut pid: u32 = 0;
+            GetWindowThreadProcessId(hwnd, Some(&mut pid as *mut u32));
+            if pid == 0 || pid == our_pid {
+                return false;
+            }
+
+            let class = class_name(hwnd);
+            if is_shell_window(&class) {
+                return false;
+            }
+
+            if !is_on_primary(hwnd) {
+                return false;
+            }
+
+            IsZoomed(hwnd).as_bool() || covers_monitor(hwnd)
+        }
+    }
+
+    unsafe extern "system" fn enum_cb(hwnd: HWND, lparam: LPARAM) -> BOOL {
+        let state = unsafe { &mut *(lparam.0 as *mut EnumState) };
+        if is_hide_worthy(hwnd, state.our_pid) {
+            state.found = true;
+            BOOL(0)
+        } else {
+            BOOL(1)
+        }
+    }
+
+    let mut state = EnumState {
+        our_pid: std::process::id(),
+        found: false,
+    };
+    let _ = unsafe { EnumWindows(Some(enum_cb), LPARAM(&mut state as *mut EnumState as isize)) };
+    state.found
+}

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -744,6 +744,18 @@ pub fn setup_mouse_monitoring(app_handle: tauri::AppHandle) {
         const POLL_MS: u64 = 20; // ~50fps
 
         loop {
+            // Hide-when-maximized: force click-through and skip hover activation.
+            if crate::maximized::should_hide_for_maximized() {
+                if IS_INSIDE.swap(false, Ordering::Relaxed) {
+                    let _ = app_handle.emit("mouse-exited-notch", ());
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        let _ = window.set_ignore_cursor_events(true);
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
+                continue;
+            }
+
             // Refresh settings and dimensions on every iteration to handle runtime toggles
             let settings = get_window_settings();
             let effective_notch_width = if settings.non_notch_mode {
@@ -900,6 +912,18 @@ pub fn setup_mouse_monitoring(app_handle: tauri::AppHandle) {
         const POLL_MS: u64 = 20;
 
         loop {
+            // Hide-when-maximized: force click-through and skip hover activation.
+            if crate::maximized::should_hide_for_maximized() {
+                if IS_INSIDE.swap(false, Ordering::Relaxed) {
+                    let _ = app_handle.emit("mouse-exited-notch", ());
+                    if let Some(window) = app_handle.get_webview_window("main") {
+                        let _ = window.set_ignore_cursor_events(true);
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
+                continue;
+            }
+
             // Refresh settings on every iteration to handle runtime toggles
             // This is intentional - settings can be changed via update_window_settings
             // and we need to immediately reflect those changes in mouse detection

--- a/src/components/island/DynamicIsland.tsx
+++ b/src/components/island/DynamicIsland.tsx
@@ -55,6 +55,8 @@ export function DynamicIsland() {
         setLastModeCycleTime,
         isPopoverOpen,
         setIsPopoverOpen,
+        isAppMaximized,
+        setIsAppMaximized,
     } = useDynamicIslandStore();
 
     const islandRef = useRef<HTMLDivElement>(null);
@@ -127,6 +129,7 @@ export function DynamicIsland() {
 
     // Toggle expanded mode
     const handleIslandClick = useCallback(() => {
+        if (settings.hideWhenMaximized && isAppMaximized) return;
         setExpanded(prev => {
             if (!prev) {
                 setIsAnimating(true);
@@ -135,7 +138,7 @@ export function DynamicIsland() {
             invoke('trigger_haptics').catch(console.error);
             return !prev;
         });
-    }, [mode, setExpanded, setIsAnimating, setActiveTab]);
+    }, [mode, setExpanded, setIsAnimating, setActiveTab, settings.hideWhenMaximized, isAppMaximized]);
 
     // Hover handlers for haptics
     const handleHoverStart = useCallback(() => {
@@ -172,14 +175,18 @@ export function DynamicIsland() {
         // Mouse hover listeners
         const unlistenEnter = listen('mouse-entered-notch', () => setIsHovered(true));
         const unlistenExit = listen('mouse-exited-notch', () => setIsHovered(false));
+        const unlistenMaximized = listen('app-maximized', () => setIsAppMaximized(true));
+        const unlistenUnmaximized = listen('app-unmaximized', () => setIsAppMaximized(false));
 
         return () => {
             if (resizeTimeout) clearTimeout(resizeTimeout);
             window.removeEventListener('resize', handleResize);
             unlistenEnter.then(fn => fn());
             unlistenExit.then(fn => fn());
+            unlistenMaximized.then(fn => fn());
+            unlistenUnmaximized.then(fn => fn());
         };
-    }, [setWindowSize, setIsHovered]);
+    }, [setWindowSize, setIsHovered, setIsAppMaximized]);
 
     // Load settings
     useEffect(() => {
@@ -191,6 +198,11 @@ export function DynamicIsland() {
         window.addEventListener('storage', handleStorage);
         return () => window.removeEventListener('storage', handleStorage);
     }, [loadSettings]);
+
+    // Keep native monitoring in sync with the frontend setting
+    useEffect(() => {
+        invoke('set_hide_when_maximized', { enabled: settings.hideWhenMaximized }).catch(console.error);
+    }, [settings.hideWhenMaximized]);
 
     // Media player polling
     useEffect(() => {
@@ -246,8 +258,14 @@ export function DynamicIsland() {
         baseNotchWidth: notchInfo?.notch_width ?? 160,
     }), [notchInfo?.notch_height, notchInfo?.notch_width]);
 
+    const hideForMaximized = settings.hideWhenMaximized && isAppMaximized;
+
     // Memoize target dimensions
     const { targetWidth, targetHeight } = useMemo(() => {
+        if (hideForMaximized) {
+            return { targetWidth: baseNotchWidth, targetHeight: 1 };
+        }
+
         if (expanded) {
             return {
                 targetWidth: Math.min(windowSize.width - 40, 600),
@@ -269,7 +287,14 @@ export function DynamicIsland() {
         }
 
         return { targetWidth: baseNotchWidth + 120, targetHeight: notchHeight };
-    }, [expanded, isHovered, mode, baseNotchWidth, notchHeight, windowSize.width, windowSize.height, settings.nonNotchMode]);
+    }, [hideForMaximized, expanded, isHovered, mode, baseNotchWidth, notchHeight, windowSize.width, windowSize.height, settings.nonNotchMode]);
+
+    // Collapse the island while a maximized app is covering the display
+    useEffect(() => {
+        if (hideForMaximized && expanded) {
+            setExpanded(false);
+        }
+    }, [hideForMaximized, expanded, setExpanded]);
 
     // Reset popover state when island collapses
     useEffect(() => {
@@ -286,7 +311,7 @@ export function DynamicIsland() {
     }, [isHovered, expanded, isAnimating, isPopoverOpen, setExpanded]);
 
     const handleWheel = useCallback((e: React.WheelEvent) => {
-        if (isAnimating) return;
+        if (isAnimating || hideForMaximized) return;
 
         if (!expanded && e.deltaY < -20) {
             setExpanded(true);
@@ -307,7 +332,7 @@ export function DynamicIsland() {
                 cycleMode(e.deltaX > 20 ? 'next' : 'prev');
             }
         }
-    }, [expanded, isAnimating, activeTab, cycleMode, setExpanded, setIsAnimating, setActiveTab, lastModeCycleTime, setLastModeCycleTime]);
+    }, [expanded, isAnimating, hideForMaximized, activeTab, cycleMode, setExpanded, setIsAnimating, setActiveTab, lastModeCycleTime, setLastModeCycleTime]);
 
     const handleChildWheel = useCallback((e: React.WheelEvent) => {
         if (Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
@@ -422,7 +447,8 @@ export function DynamicIsland() {
                     "before:bg-[radial-gradient(circle_at_0_100%,transparent_6px,black_6px)]",
                     "after:content-[''] after:absolute after:top-0 after:-right-[6px] after:w-[6px] after:h-[6px] after:z-10 after:pointer-events-none",
                     "after:bg-[radial-gradient(circle_at_100%_100%,transparent_6px,black_6px)]",
-                    (settings.nonNotchMode && mode === 'idle' && !isHovered && !expanded) && "before:hidden after:hidden"
+                    ((settings.nonNotchMode && mode === 'idle' && !isHovered && !expanded) || hideForMaximized) && "before:hidden after:hidden",
+                    hideForMaximized && "pointer-events-none"
                 )}
                 initial={false}
                 onAnimationComplete={() => setIsAnimating(false)}
@@ -430,12 +456,13 @@ export function DynamicIsland() {
                     width: targetWidth,
                     height: targetHeight,
                     borderRadius: '0px 0px 18px 18px',
+                    opacity: hideForMaximized ? 0 : 1,
                 }}
                 transition={springTransition}
-                onHoverStart={handleHoverStart}
+                onHoverStart={hideForMaximized ? undefined : handleHoverStart}
                 onClick={handleIslandClick}
                 onWheel={handleWheel}
-                style={{ cursor: 'pointer' }}
+                style={{ cursor: hideForMaximized ? 'default' : 'pointer' }}
             >
                 <AnimatePresence mode="wait">
                     <motion.div
@@ -469,7 +496,7 @@ export function DynamicIsland() {
                     </motion.div>
                 </AnimatePresence>
 
-                {!expanded && (
+                {!expanded && !hideForMaximized && (
                     <ModeIndicator
                         availableModes={availableModes}
                         currentMode={mode}

--- a/src/stores/useDynamicIslandStore.ts
+++ b/src/stores/useDynamicIslandStore.ts
@@ -7,6 +7,7 @@ interface Settings {
     showMedia: boolean;
     liquidGlassMode: boolean;
     nonNotchMode: boolean;
+    hideWhenMaximized: boolean;
 }
 
 interface DynamicIslandState {
@@ -19,6 +20,7 @@ interface DynamicIslandState {
     isAnimating: boolean;
     activeTab: 'widgets' | 'files';
     isPopoverOpen: boolean;
+    isAppMaximized: boolean;
 
     // Content state
     notes: string;
@@ -43,6 +45,7 @@ interface DynamicIslandActions {
     setIsAnimating: (value: boolean) => void;
     setActiveTab: (tab: 'widgets' | 'files') => void;
     setIsPopoverOpen: (value: boolean) => void;
+    setIsAppMaximized: (value: boolean) => void;
 
     // Content actions
     setNotes: (notes: string) => void;
@@ -72,6 +75,7 @@ const DEFAULT_SETTINGS: Settings = {
     showMedia: true,
     liquidGlassMode: false,
     nonNotchMode: false,
+    hideWhenMaximized: true,
 };
 
 export const useDynamicIslandStore = create<DynamicIslandStore>((set, get) => ({
@@ -82,6 +86,7 @@ export const useDynamicIslandStore = create<DynamicIslandStore>((set, get) => ({
     isAnimating: false,
     activeTab: 'widgets',
     isPopoverOpen: false,
+    isAppMaximized: false,
     notes: '',
     windowSize: { width: window.innerWidth, height: window.innerHeight },
     settings: DEFAULT_SETTINGS,
@@ -102,6 +107,7 @@ export const useDynamicIslandStore = create<DynamicIslandStore>((set, get) => ({
     setIsAnimating: (value) => set({ isAnimating: value }),
     setActiveTab: (tab) => set({ activeTab: tab }),
     setIsPopoverOpen: (value) => set({ isPopoverOpen: value }),
+    setIsAppMaximized: (value) => set({ isAppMaximized: value }),
 
     // Content actions
     setNotes: (notes) => set({ notes }),

--- a/src/windows/Settings/Settings.tsx
+++ b/src/windows/Settings/Settings.tsx
@@ -17,6 +17,7 @@ interface SettingsState {
     showMedia: boolean;
     liquidGlassMode: boolean;
     nonNotchMode: boolean;
+    hideWhenMaximized: boolean;
 }
 
 type Tab = 'general' | 'appearance' | 'media' | 'widgets' | 'plugins';
@@ -29,6 +30,7 @@ export default function Settings() {
         showMedia: true,
         liquidGlassMode: false,
         nonNotchMode: false,
+        hideWhenMaximized: true,
     });
     const [activeTab, setActiveTab] = useState<Tab>('general');
 
@@ -50,19 +52,25 @@ export default function Settings() {
 
     useEffect(() => {
         const saved = localStorage.getItem('app-settings');
+        let hideWhenMaximized = true;
         if (saved) {
             try {
                 const parsed = JSON.parse(saved);
+                hideWhenMaximized = parsed.hideWhenMaximized ?? true;
                 setSettings({
                     showMedia: true,
                     liquidGlassMode: false,
                     nonNotchMode: false,
+                    hideWhenMaximized: true,
                     ...parsed
                 });
             } catch (e) {
                 console.error("Failed to parse settings", e);
             }
         }
+        import('@tauri-apps/api/core').then(({ invoke }) => {
+            invoke('set_hide_when_maximized', { enabled: hideWhenMaximized }).catch(console.error);
+        });
     }, []);
 
     const updateSetting = <K extends keyof SettingsState>(key: K, value: SettingsState[K]) => {
@@ -80,6 +88,9 @@ export default function Settings() {
                     extraWidth: 400.0,
                     extraHeight: 800.0,
                     non_notch_mode: next.nonNotchMode
+                }).catch(console.error);
+                invoke('set_hide_when_maximized', {
+                    enabled: next.hideWhenMaximized
                 }).catch(console.error);
             });
 
@@ -181,6 +192,18 @@ export default function Settings() {
                                     <Switch
                                         checked={settings.nonNotchMode}
                                         onCheckedChange={(c) => updateSetting('nonNotchMode', c)}
+                                    />
+                                </div>
+                            </div>
+                            <div className="bg-card rounded-2xl mb-6 overflow-hidden border border-border">
+                                <div className="flex items-center justify-between p-3 px-4 border-b border-border last:border-b-0">
+                                    <div className="flex flex-col">
+                                        <Label className="text-[15px] font-normal">Hide When Maximized</Label>
+                                        <span className="text-xs text-muted-foreground mt-0.5">Hide island when another app is maximized</span>
+                                    </div>
+                                    <Switch
+                                        checked={settings.hideWhenMaximized}
+                                        onCheckedChange={(c) => updateSetting('hideWhenMaximized', c)}
                                     />
                                 </div>
                             </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements one slice of #42: **hide/disable the island when another app is maximized**.

This is not a frontend-only guess. The overlay is always-on-top, so maximized/fullscreen detection has to come from the OS. A monitor thread now polls native window state (same pattern as mouse hover monitoring) and the island hides or returns from that.

Does **not** include island color (#43) or free positioning.

## What shipped

- Settings → Appearance → **Hide When Maximized** (stored in `app-settings` like the other appearance toggles)
- Default **on**. Turn it off to keep the island visible over maximized apps
- macOS: `CGWindowListCopyWindowInfo` — hide when a layer-0 window from another process fills the main screen’s visible frame (zoomed or fullscreen), including fullscreen spaces the island joins
- Windows: `EnumWindows` + `IsZoomed` / monitor-covering bounds, skipping cloaked (other-desktop) and shell windows, primary monitor only
- While hidden: island collapses to 1px / opacity 0, and hover monitoring stays click-through so it does not steal clicks from the maximized app
- Linux: no-op (same as hover monitoring). Setting is still shown; it does nothing there

## Still open from #42

- Move the island freely
- Island color (separate PR #43)
- Any other customization beyond hide-when-maximized

## Test plan

No existing test suite in the repo. Verify manually on macOS or Windows:

1. Open Settings → Appearance. Confirm **Hide When Maximized** appears below Non-Notch Mode and is on by default.
2. Maximize another app on the primary display (or native fullscreen). The island should disappear within ~200ms.
3. Restore / exit fullscreen. The island should come back.
4. With a maximized app, confirm you can click through the top of the screen (the island must not intercept hover/clicks).
5. Turn **Hide When Maximized** off. Maximize again — the island should stay visible.
6. Turn it back on while the other app is still maximized — the island should hide.
7. Quit and relaunch. The setting should persist via `app-settings`.
8. `npx tsc --noEmit` passes.

Related to #42 (does not close it).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4c744f1-ae9c-43f7-9f72-9e22a8ffc2d9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4c744f1-ae9c-43f7-9f72-9e22a8ffc2d9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

