### PR TITLE
Pin Windows download-and-run on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**Windows:** [Download and run](https://github.com/prodBirdy/openNook/releases/download/0.0.2a/openNook_0.1.0_x64-setup.exe)
+
 # <img width="32" height="32" alt="Subject" src="https://github.com/user-attachments/assets/5f5b3858-2055-4b66-b3ca-f9206eb19247" /> openNook 
 
 openNook is an open-source dynamic island client inspired by [notchNook](https://lo.cafe/notchnook). It brings the utility and aesthetic of the dynamic island to your desktop, currently built with performance and design in mind.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Windows is the beachhead. Getting started should be download-and-run, not a Tauri build guide.

This PR puts the current Windows installer on the **first line** of the README, using the real `.exe` already on the latest GitHub release (no new build).

**Download:** https://github.com/prodBirdy/openNook/releases/download/0.0.2a/openNook_0.1.0_x64-setup.exe

The same asset on [openNook v0.1.0](https://github.com/prodBirdy/openNook/releases/tag/0.0.2a) is labeled **Windows — download and run** so it is the obvious click among the other platform files. Release notes on GitHub were updated via `gh` (not in-repo).

`WINDOWS_BUILD.md` and the local-dev Getting Started steps stay as-is for people who want to build from source.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09618139-70c1-462d-9e28-89dd441df6ad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09618139-70c1-462d-9e28-89dd441df6ad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

