### PR TITLE
Linux hover: poll X11 pointer so the Dynamic Island can expand

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -39,6 +39,7 @@ dependencies = [
  "tokio",
  "windows 0.52.0",
  "winreg",
+ "x11rb",
  "zbus 4.4.0",
 ]
 
@@ -1406,6 +1407,16 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5969,6 +5980,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xdg-home"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,3 +69,5 @@ winreg = "0.55"
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = "4.0"
 futures = "0.3"
+# Pure-Rust X11 client for global pointer polling (no libX11/libxcb link).
+x11rb = "0.13"

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -1,10 +1,10 @@
 use crate::database::{get_connection, log_sql};
 use crate::models::NotchInfo;
 use serde::{Deserialize, Serialize};
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::RwLock;
-#[cfg(any(target_os = "macos", target_os = "windows"))]
+#[cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))]
 use tauri::Emitter;
 use tauri::{
     AppHandle, LogicalPosition, LogicalSize, Manager, WebviewUrl, WebviewWindow,
@@ -1021,9 +1021,129 @@ pub fn setup_mouse_monitoring(app_handle: tauri::AppHandle) {
 
 #[cfg(target_os = "linux")]
 pub fn setup_mouse_monitoring(app_handle: tauri::AppHandle) {
-    let _ = app_handle;
-    // Mouse monitoring on Linux (Wayland/X11) is complex to do globally without heavy dependencies.
-    // For now, we will rely on window events if possible, or disable the hover feature.
-    // To avoid busy looping or useless threads, we just log a message.
-    log::info!("Global mouse monitoring not implemented for Linux yet.");
+    use x11rb::connection::Connection;
+    use x11rb::protocol::xproto::ConnectionExt as _;
+
+    if std::env::var_os("DISPLAY").is_none() {
+        log::info!("DISPLAY unset; skipping Linux mouse monitoring (pure Wayland?).");
+        return;
+    }
+
+    let (conn, screen_num) = match x11rb::connect(None) {
+        Ok(pair) => pair,
+        Err(err) => {
+            log::info!("X11 connect failed ({err}); skipping Linux mouse monitoring.");
+            return;
+        }
+    };
+    let root = conn.setup().roots[screen_num].root;
+
+    // Track whether mouse is currently in the UI area
+    static IS_INSIDE: AtomicBool = AtomicBool::new(false);
+
+    let (screen_width, _screen_height, _notch_height, notch_width) =
+        get_screen_info(Some(&app_handle));
+
+    log::info!("Linux mouse monitoring started (X11 QueryPointer).");
+
+    std::thread::spawn(move || {
+        const POLL_MS: u64 = 20;
+
+        loop {
+            // Refresh settings on every iteration to handle runtime toggles
+            // This is intentional - settings can be changed via update_window_settings
+            // and we need to immediately reflect those changes in mouse detection
+            let settings = get_window_settings();
+
+            let effective_notch_width = if settings.non_notch_mode {
+                0.0
+            } else {
+                notch_width
+            };
+
+            // Get actual window position instead of calculating it
+            // This ensures we match the real window position even with DPI scaling
+            let (window_x, win_width, scale_factor) =
+                if let Some(window) = app_handle.get_webview_window("main") {
+                    if let (Ok(pos), Ok(size)) = (window.outer_position(), window.outer_size()) {
+                        let scale = window.scale_factor().unwrap_or(1.0);
+                        ((pos.x as f64) / scale, (size.width as f64) / scale, scale)
+                    } else {
+                        // Fallback calculation
+                        let win_w = if effective_notch_width > 0.0 {
+                            effective_notch_width + 160.0 + settings.extra_width
+                        } else {
+                            800.0 + settings.extra_width
+                        };
+                        ((screen_width - win_w) / 2.0, win_w, 1.0)
+                    }
+                } else {
+                    // Fallback if window not available
+                    let win_w = if effective_notch_width > 0.0 {
+                        effective_notch_width + 160.0 + settings.extra_width
+                    } else {
+                        800.0 + settings.extra_width
+                    };
+                    ((screen_width - win_w) / 2.0, win_w, 1.0)
+                };
+
+            if let Ok(cookie) = conn.query_pointer(root) {
+                if let Ok(reply) = cookie.reply() {
+                    // Convert X11 root coordinates to logical pixels (same as Windows)
+                    let mouse_x = (reply.root_x as f64) / scale_factor;
+                    let mouse_y = (reply.root_y as f64) / scale_factor;
+
+                    let was_inside = IS_INSIDE.load(Ordering::Relaxed);
+
+                    // Logic adapted from the Windows / macOS versions
+                    let padding = if was_inside { 30.0 } else { 20.0 };
+
+                    let in_ui_area = if let Ok(guard) = get_ui_bounds_store().try_read() {
+                        if let Some(bounds) = *guard {
+                            // Center the bounds within the window (same as Windows)
+                            let screen_x = window_x + (win_width - bounds.width) / 2.0;
+                            let screen_y = bounds.y;
+                            mouse_x >= (screen_x - padding)
+                                && mouse_x <= (screen_x + bounds.width + padding)
+                                && mouse_y >= (screen_y - padding)
+                                && mouse_y <= (screen_y + bounds.height + padding)
+                        } else {
+                            // Fallback zone at top center
+                            // In non-notch mode we use a very small height for fallback
+                            let fallback_height = if settings.non_notch_mode { 1.0 } else { 100.0 };
+
+                            mouse_x >= (window_x - padding)
+                                && mouse_x <= (window_x + win_width + padding)
+                                && mouse_y >= 0.0
+                                && mouse_y <= (fallback_height + padding)
+                        }
+                    } else {
+                        let fallback_height = if settings.non_notch_mode { 1.0 } else { 100.0 };
+
+                        mouse_x >= (window_x - padding)
+                            && mouse_x <= (window_x + win_width + padding)
+                            && mouse_y >= 0.0
+                            && mouse_y <= (fallback_height + padding)
+                    };
+
+                    if in_ui_area && !was_inside {
+                        IS_INSIDE.store(true, Ordering::Relaxed);
+                        let _ = app_handle.emit("mouse-entered-notch", ());
+
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.set_ignore_cursor_events(false);
+                        }
+                    } else if !in_ui_area && was_inside {
+                        IS_INSIDE.store(false, Ordering::Relaxed);
+                        let _ = app_handle.emit("mouse-exited-notch", ());
+                        if let Some(window) = app_handle.get_webview_window("main") {
+                            let _ = window.set_ignore_cursor_events(true);
+                        }
+                    }
+                }
+            }
+
+            std::thread::sleep(std::time::Duration::from_millis(POLL_MS));
+        }
+    });
 }

--- a/src/components/island/DynamicIsland.tsx
+++ b/src/components/island/DynamicIsland.tsx
@@ -127,6 +127,9 @@ export function DynamicIsland() {
 
     // Toggle expanded mode
     const handleIslandClick = useCallback(() => {
+        // Mark hovered first so auto-collapse (!isHovered && expanded) cannot
+        // undo this click when Tauri enter events are missing or late.
+        setIsHovered(true);
         setExpanded(prev => {
             if (!prev) {
                 setIsAnimating(true);
@@ -135,12 +138,17 @@ export function DynamicIsland() {
             invoke('trigger_haptics').catch(console.error);
             return !prev;
         });
-    }, [mode, setExpanded, setIsAnimating, setActiveTab]);
+    }, [mode, setExpanded, setIsAnimating, setActiveTab, setIsHovered]);
 
-    // Hover handlers for haptics
+    // Hover: DOM pointer plus existing Tauri mouse-entered/exited listeners
     const handleHoverStart = useCallback(() => {
+        setIsHovered(true);
         invoke('trigger_haptics').catch(console.error);
-    }, []);
+    }, [setIsHovered]);
+
+    const handleHoverEnd = useCallback(() => {
+        setIsHovered(false);
+    }, [setIsHovered]);
 
     // Initialization and listeners
     useEffect(() => {
@@ -168,6 +176,7 @@ export function DynamicIsland() {
             }, 100);
         };
         window.addEventListener('resize', handleResize);
+        setWindowSize({ width: window.innerWidth, height: window.innerHeight });
 
         // Mouse hover listeners
         const unlistenEnter = listen('mouse-entered-notch', () => setIsHovered(true));
@@ -433,6 +442,7 @@ export function DynamicIsland() {
                 }}
                 transition={springTransition}
                 onHoverStart={handleHoverStart}
+                onHoverEnd={handleHoverEnd}
                 onClick={handleIslandClick}
                 onWheel={handleWheel}
                 style={{ cursor: 'pointer' }}

--- a/src/components/island/DynamicIsland.tsx
+++ b/src/components/island/DynamicIsland.tsx
@@ -140,14 +140,13 @@ export function DynamicIsland() {
         });
     }, [mode, setExpanded, setIsAnimating, setActiveTab, setIsHovered]);
 
-    // Hover: DOM pointer plus existing Tauri mouse-entered/exited listeners
+    // Hover: DOM enter only. Do not clear isHovered on onHoverEnd — the
+    // motion.div resize on expand briefly reports the pointer as outside
+    // the old compact box and auto-collapse would fold immediately.
+    // Exit is owned by the Tauri mouse-exited-notch listener (X11 poll).
     const handleHoverStart = useCallback(() => {
         setIsHovered(true);
         invoke('trigger_haptics').catch(console.error);
-    }, [setIsHovered]);
-
-    const handleHoverEnd = useCallback(() => {
-        setIsHovered(false);
     }, [setIsHovered]);
 
     // Initialization and listeners
@@ -442,7 +441,6 @@ export function DynamicIsland() {
                 }}
                 transition={springTransition}
                 onHoverStart={handleHoverStart}
-                onHoverEnd={handleHoverEnd}
                 onClick={handleIslandClick}
                 onWheel={handleWheel}
                 style={{ cursor: 'pointer' }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linux `setup_mouse_monitoring` was a no-op, so `mouse-entered-notch` / `mouse-exited-notch` never fired, the window stayed click-through, and the island could not expand.

**Backend:** ports the Windows 20ms poll to Linux via `x11rb` `QueryPointer`. Hit-tests `UI_BOUNDS` (or the same top-center fallback), emits the same events, and toggles `set_ignore_cursor_events`. If `DISPLAY` is missing or X11 connect fails (pure Wayland), log and return.

**Frontend:** `isHovered` was only set by those Tauri events. DOM `onHoverStart` and click now set `isHovered` so expand can stick. `onHoverEnd` does **not** clear hover — the compact→expand resize briefly reports the pointer outside the old box and auto-collapse would fold immediately. Exit is owned by `mouse-exited-notch` from the X11 poll. `windowSize` is seeded on mount. CompactIdle stays empty; no fake expanded widgets.

Base is the Tauri lineage (`0.0.2a` tag/branch), not GPUI `main`.

**Not in this PR:** Wayland compositor protocol, docs/launch-page, macOS/Windows monitoring rewrites.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b9cd5918-2932-4b62-8e01-5a7975c76e7c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b9cd5918-2932-4b62-8e01-5a7975c76e7c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

