### PR TITLE
Add a real GPUI 0.3.0 Linux release

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,3 +13,14 @@ jobs:
       - run: cargo test --workspace --offline || cargo test --workspace
         env:
           CARGO_TERM_COLOR: always
+
+  linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install Linux GPUI build deps
+        run: ./scripts/linux-deps.sh
+      - run: cargo test --workspace
+        env:
+          CARGO_TERM_COLOR: always

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -64,7 +64,7 @@ jobs:
 
             This is `cargo build --release -p nook` of the current GPUI product (`crates/nook`). It is not a republish of `openNook_0.1.0` AppImage/deb from tag `0.0.2a`, and it is not a Linux dmg. This release does not attach to or rewrite macOS `v0.3.0`.
 
-            Compact has no app title and is top-center (Idle housing wrap). Screen size is X11 `DisplayWidth` / `DisplayHeight`. Settings, expanded island, and the file tray have been proven on Linux.
+            Compact has no app title, is top-center (Idle housing wrap), and has no window-manager decorations (no title bar / min / max / close). Screen size is X11 `DisplayWidth` / `DisplayHeight`. Settings, expanded island, and the file tray have been proven on Linux.
 
             **Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit, hide-when-maximized, `installer.dmg`. Hover polling is still stubbed — click or scroll the painted island. Use Ctrl+, for Settings and Ctrl+Q to quit.
 

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -1,0 +1,68 @@
+# GPUI 0.3.x Linux binary. Not the Tauri 0.0.2a AppImage / deb line.
+# Does not attach assets to v0.3.0 (macOS dmg). Publishes v<version>-linux.
+name: linux-release
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*-linux"
+
+permissions:
+  contents: write
+
+jobs:
+  linux:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install Linux GPUI build deps
+        run: ./scripts/linux-deps.sh
+
+      - name: Build release binary
+        run: cargo build --release -p nook
+        env:
+          CARGO_TERM_COLOR: always
+
+      - name: Package tarball
+        id: pack
+        run: |
+          set -euo pipefail
+          version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' Cargo.toml | head -n1)"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          dest="openNook-${version}-x86_64-unknown-linux-gnu"
+          mkdir -p "target/${dest}"
+          install -m 0755 target/release/nook "target/${dest}/nook"
+          sed "s/0\\.3\\.0/${version}/g" resources/LINUX.txt > "target/${dest}/LINUX.txt"
+          tar -C target -czf "target/${dest}.tar.gz" "${dest}"
+          echo "tarball=target/${dest}.tar.gz" >> "$GITHUB_OUTPUT"
+          echo "asset=${dest}.tar.gz" >> "$GITHUB_OUTPUT"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.pack.outputs.asset }}
+          path: ${{ steps.pack.outputs.tarball }}
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_type == 'tag' && github.ref_name || format('v{0}-linux', steps.pack.outputs.version) }}
+          name: openNook ${{ steps.pack.outputs.version }} Linux (GPUI)
+          make_latest: false
+          body: |
+            GPUI ${{ steps.pack.outputs.version }} Linux build; macOS notch/Metal features unavailable; not the old Tauri 0.0.2a line.
+
+            Artifact: `openNook-${{ steps.pack.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz` (`nook` binary).
+
+            This is `cargo build --release -p nook` of the current GPUI product (`crates/nook`). It is not a republish of `openNook_0.1.0` AppImage/deb from tag `0.0.2a`, and it is not a Linux dmg.
+
+            **Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit, hide-when-maximized, `installer.dmg`. Hover polling is stubbed. Use Ctrl+, for Settings and Ctrl+Q to quit.
+
+            Runtime: Vulkan driver, libxkbcommon, Wayland or X11.
+          files: ${{ steps.pack.outputs.tarball }}
+          fail_on_unmatched_files: true
+          target_commitish: ${{ github.sha }}

--- a/.github/workflows/linux-release.yml
+++ b/.github/workflows/linux-release.yml
@@ -37,6 +37,10 @@ jobs:
           mkdir -p "target/${dest}"
           install -m 0755 target/release/nook "target/${dest}/nook"
           sed "s/0\\.3\\.0/${version}/g" resources/LINUX.txt > "target/${dest}/LINUX.txt"
+          shopt -s nullglob
+          for shot in docs/linux-72-*.png; do
+            cp "$shot" "target/${dest}/"
+          done
           tar -C target -czf "target/${dest}.tar.gz" "${dest}"
           echo "tarball=target/${dest}.tar.gz" >> "$GITHUB_OUTPUT"
           echo "asset=${dest}.tar.gz" >> "$GITHUB_OUTPUT"
@@ -58,9 +62,11 @@ jobs:
 
             Artifact: `openNook-${{ steps.pack.outputs.version }}-x86_64-unknown-linux-gnu.tar.gz` (`nook` binary).
 
-            This is `cargo build --release -p nook` of the current GPUI product (`crates/nook`). It is not a republish of `openNook_0.1.0` AppImage/deb from tag `0.0.2a`, and it is not a Linux dmg.
+            This is `cargo build --release -p nook` of the current GPUI product (`crates/nook`). It is not a republish of `openNook_0.1.0` AppImage/deb from tag `0.0.2a`, and it is not a Linux dmg. This release does not attach to or rewrite macOS `v0.3.0`.
 
-            **Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit, hide-when-maximized, `installer.dmg`. Hover polling is stubbed. Use Ctrl+, for Settings and Ctrl+Q to quit.
+            Compact has no app title and is top-center (Idle housing wrap). Screen size is X11 `DisplayWidth` / `DisplayHeight`. Settings, expanded island, and the file tray have been proven on Linux.
+
+            **Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit, hide-when-maximized, `installer.dmg`. Hover polling is still stubbed — click or scroll the painted island. Use Ctrl+, for Settings and Ctrl+Q to quit.
 
             Runtime: Vulkan driver, libxkbcommon, Wayland or X11.
           files: ${{ steps.pack.outputs.tarball }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Packaging
+
+- Linux GPUI artifact: `cargo build --release -p nook` on Ubuntu, uploaded as
+  `openNook-0.3.0-x86_64-unknown-linux-gnu.tar.gz` from `.github/workflows/linux-release.yml`
+  (`workflow_dispatch` or a `v*-linux` tag). Publishes `v0.3.0-linux`; does not
+  retag or rewrite the macOS `v0.3.0` notes.
+- This is the current GPUI product. It is not the Tauri `0.0.2a` AppImage.
+
+Linux does not get Metal, camera-housing notch metrics, MediaRemote, Liquid
+Glass, the menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out,
+EventKit, hide-when-maximized occupancy, or `installer.dmg`. Hover polling is
+stubbed. Settings / Quit: Ctrl+, and Ctrl+Q.
+
 ## [0.3.0] - 2026-08-23
 
 Settings rebuilt as a native sidebar window, a compact island that hugs the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   retag or rewrite the macOS `v0.3.0` notes.
 - This is the current GPUI product. It is not the Tauri `0.0.2a` AppImage.
 
+Linux compact is the Idle housing wrap (no “openNook” title), top-center on
+the real X11 `DisplayWidth` / `DisplayHeight`. Hover polling is still
+stubbed — click or scroll the painted island.
+
 Linux does not get Metal, camera-housing notch metrics, MediaRemote, Liquid
 Glass, the menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out,
-EventKit, hide-when-maximized occupancy, or `installer.dmg`. Hover polling is
-stubbed. Settings / Quit: Ctrl+, and Ctrl+Q.
+EventKit, hide-when-maximized occupancy, or `installer.dmg`. Settings / Quit:
+Ctrl+, and Ctrl+Q.
 
 ## [0.3.0] - 2026-08-23
 

--- a/README.md
+++ b/README.md
@@ -38,12 +38,26 @@ Release installer (DMG with an Applications drop):
 
 ```bash
 ./scripts/with-metal.sh ./scripts/installer.sh
-open target/openNook-0.2.0.dmg
+open target/openNook-0.3.0.dmg
 ```
 
-See [CHANGELOG.md](CHANGELOG.md) for what landed in 0.2.0.
+See [CHANGELOG.md](CHANGELOG.md) for what landed in 0.3.0.
 
 On macOS the process is an accessory (`LSUIElement` / `NSApplicationActivationPolicyAccessory`): no dock icon. Hover the notch to take mouse events; click or scroll up to expand. Quit and Settings live on the **Nook** menu-bar extra.
+
+## Linux (GPUI)
+
+This is the current GPUI client (`crates/nook`), not the old Tauri `0.0.2a` AppImage.
+
+```bash
+./scripts/linux-deps.sh
+cargo run -p nook
+# or: cargo build --release -p nook
+```
+
+CI job `linux-release` uploads `openNook-0.3.0-x86_64-unknown-linux-gnu.tar.gz` (the `nook` binary). Trigger via **Actions → linux-release → Run workflow**, or push a `v*-linux` tag. That publishes GitHub Release `v0.3.0-linux` and does not rewrite the macOS `v0.3.0` dmg notes.
+
+**Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit Calendar/Reminders, hide-when-maximized, `installer.dmg`. Global hover polling is stubbed (cursor reports 0,0). Click or scroll the island; Ctrl+, opens Settings; Ctrl+Q quits. Needs a Vulkan driver at runtime.
 
 ## Features (v1)
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ cargo run -p nook
 
 CI job `linux-release` uploads `openNook-0.3.0-x86_64-unknown-linux-gnu.tar.gz` (the `nook` binary). Trigger via **Actions → linux-release → Run workflow**, or push a `v*-linux` tag. That publishes GitHub Release `v0.3.0-linux` and does not rewrite the macOS `v0.3.0` dmg notes.
 
-**Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit Calendar/Reminders, hide-when-maximized, `installer.dmg`. Global hover polling is stubbed (cursor reports 0,0). Click or scroll the island; Ctrl+, opens Settings; Ctrl+Q quits. Needs a Vulkan driver at runtime.
+Compact has no app title and is top-center (Idle housing wrap). Screen size comes from X11 `DisplayWidth` / `DisplayHeight`. Settings, expanded island, and the file tray work on Linux.
+
+**Unavailable on Linux:** Metal / `scripts/with-metal.sh`, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, camera Mirror, AirDrop, AppKit file drag-out, EventKit Calendar/Reminders, hide-when-maximized, `installer.dmg`. Global hover polling is still stubbed (cursor reports 0,0). Click or scroll the painted island; Ctrl+, opens Settings; Ctrl+Q quits. Needs a Vulkan driver at runtime.
 
 ## Features (v1)
 

--- a/crates/nook-core/src/notch.rs
+++ b/crates/nook-core/src/notch.rs
@@ -149,8 +149,41 @@ fn read_screen_info() -> (f64, f64, f64, f64) {
 
     #[cfg(target_os = "linux")]
     {
-        let notch_width = calculate_dynamic_notch_width(1920.0);
-        (1920.0, 1080.0, 0.0, notch_width)
+        let (width, height) = linux_root_display_size().unwrap_or((1920.0, 1080.0));
+        let notch_width = calculate_dynamic_notch_width(width);
+        (width, height, 0.0, notch_width)
+    }
+}
+
+/// Primary display in logical pixels. `has_notch` stays false — this only
+/// sizes the overlay so `island_origin` can centre the stub housing wrap.
+#[cfg(target_os = "linux")]
+fn linux_root_display_size() -> Option<(f64, f64)> {
+    use std::os::raw::{c_char, c_int, c_void};
+
+    #[link(name = "X11")]
+    unsafe extern "C" {
+        fn XOpenDisplay(display: *const c_char) -> *mut c_void;
+        fn XCloseDisplay(display: *mut c_void) -> c_int;
+        fn XDefaultScreen(display: *mut c_void) -> c_int;
+        fn XDisplayWidth(display: *mut c_void, screen_number: c_int) -> c_int;
+        fn XDisplayHeight(display: *mut c_void, screen_number: c_int) -> c_int;
+    }
+
+    unsafe {
+        let dpy = XOpenDisplay(std::ptr::null());
+        if dpy.is_null() {
+            return None;
+        }
+        let screen = XDefaultScreen(dpy);
+        let width = XDisplayWidth(dpy, screen);
+        let height = XDisplayHeight(dpy, screen);
+        XCloseDisplay(dpy);
+        if width > 0 && height > 0 {
+            Some((width as f64, height as f64))
+        } else {
+            None
+        }
     }
 }
 
@@ -182,4 +215,36 @@ pub fn overlay_window_size() -> (f64, f64) {
 
 pub fn overlay_window_origin() -> (f64, f64) {
     (0.0, 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_notch_width_follows_the_real_screen() {
+        assert_eq!(calculate_dynamic_notch_width(1280.0), 200.0);
+        assert_eq!(calculate_dynamic_notch_width(1920.0), 200.0);
+        assert_eq!(calculate_dynamic_notch_width(3000.0), 260.0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_screen_has_no_notch_and_overlay_matches_root() {
+        let info = get_notch_info();
+        assert!(!info.has_notch, "Linux must not invent a camera notch");
+        assert_eq!(info.notch_height, 0.0);
+        assert_eq!(
+            info.notch_width,
+            calculate_dynamic_notch_width(info.screen_width)
+        );
+        assert_eq!(
+            overlay_window_size(),
+            (info.screen_width, info.screen_height)
+        );
+        if let Some((w, h)) = linux_root_display_size() {
+            assert_eq!(info.screen_width, w);
+            assert_eq!(info.screen_height, h);
+        }
+    }
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -635,7 +635,11 @@ mod tests {
         let (x, y) = settings.island_origin(screen_w, screen_h, wrap_w, wrap_h);
         assert_eq!(y, 0.0);
         assert!((x - (screen_w - wrap_w) / 2.0).abs() < 0.01);
-        assert!(x < 400.0, "must not sit on the right of a 1280 display, got {x}");
+        let parked_on_1920 = (1920.0 - wrap_w) / 2.0;
+        assert!(
+            (x - parked_on_1920).abs() > 100.0,
+            "a 1920-wide canvas parks the pill at {parked_on_1920}, which is the right of 1280; got {x}"
+        );
         assert!(settings.island_attached(screen_h));
     }
 

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -619,6 +619,27 @@ mod tests {
     }
 
     #[test]
+    fn linux_stub_notch_origin_is_top_center() {
+        // Linux reports has_notch=false and a stub width from
+        // calculate_dynamic_notch_width(real_width). Default island_x=0.5
+        // then centres that wrap on the *reported* screen — a leftover
+        // 1920-wide canvas parked the same pill at x≈860 on a 1280 display.
+        let settings = AppSettings::default();
+        assert!((settings.island_x - 0.5).abs() < f32::EPSILON);
+        assert_eq!(settings.island_y, 0.0);
+        let screen_w = 1280.0;
+        let screen_h = 800.0;
+        let notch_w = (screen_w as f64 * 0.1).clamp(200.0, 260.0) as f32;
+        let wrap_w = notch_w + 1.0;
+        let wrap_h = 32.0 + 1.0 + 1.0;
+        let (x, y) = settings.island_origin(screen_w, screen_h, wrap_w, wrap_h);
+        assert_eq!(y, 0.0);
+        assert!((x - (screen_w - wrap_w) / 2.0).abs() < 0.01);
+        assert!(x < 400.0, "must not sit on the right of a 1280 display, got {x}");
+        assert!(settings.island_attached(screen_h));
+    }
+
+    #[test]
     fn island_origin_tracks_a_drag_and_clamps() {
         let mut settings = AppSettings::default();
         settings.set_island_origin(0.0, 120.0, 1512.0, 982.0, 180.0);

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -63,16 +63,18 @@ impl Island {
             CompactMode::Observe => {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
-            CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
-            CompactMode::Idle => div().into_any_element(),
+            // Onboard is not a titled compact face (Mac 0.3.0 has no app-name
+            // pill). Keep the arm empty so a leftover preferred mode cannot
+            // paint "openNook" / clip to "openNc".
+            CompactMode::Onboard | CompactMode::Idle => div().into_any_element(),
         }
     }
 
     fn compact_right(
         &self,
         mode: CompactMode,
-        hovered: bool,
-        cx: &mut Context<Self>,
+        _hovered: bool,
+        _cx: &mut Context<Self>,
     ) -> AnyElement {
         match mode {
             CompactMode::Media => visualizer(
@@ -105,20 +107,6 @@ impl Island {
                 };
                 label(text, theme::BODY, true).into_any_element()
             }
-            CompactMode::Onboard if hovered => div()
-                .id("github")
-                .cursor(CursorStyle::PointingHand)
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|_, _: &MouseDownEvent, _, cx| {
-                        cx.stop_propagation();
-                        let _ = std::process::Command::new("/usr/bin/open")
-                            .arg("https://github.com/prodBirdy/openNook-gpui")
-                            .spawn();
-                    }),
-                )
-                .child(lucide("github", theme::COMPACT_FACE))
-                .into_any_element(),
             _ => div().into_any_element(),
         }
     }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -797,9 +797,8 @@ impl Island {
         if self.settings.show_files && !self.files.is_empty() {
             modes.push(CompactMode::Files);
         }
-        if self.first_run {
-            modes.push(CompactMode::Onboard);
-        }
+        // First-run still calls mark_onboarded() on first expand. Do not
+        // expose Onboard as a compact face — Mac 0.3.0 has no titled pill.
         modes.push(CompactMode::Idle);
         modes
     }
@@ -821,7 +820,7 @@ impl Island {
         if self.hovered {
             return (base_w + 125.0, base_h + 15.0);
         }
-        if self.mode() == CompactMode::Idle {
+        if matches!(self.mode(), CompactMode::Idle | CompactMode::Onboard) {
             let h = if self.settings.non_notch_mode {
                 1.0
             } else {
@@ -1538,6 +1537,37 @@ mod tests {
         let (w, h) = island.target_size();
         assert_eq!(w, 185.0 + theme::IDLE_NOTCH_OVERFLOW);
         assert_eq!(h, 1.0);
+    }
+
+    #[test]
+    fn first_run_compact_is_idle_housing_wrap() {
+        let mut island = test_island();
+        island.first_run = true;
+        island.notch_width = 185.0;
+        island.notch_height = 38.0;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+        assert_eq!(island.mode(), CompactMode::Idle);
+        let idle = island.target_size();
+        assert_eq!(idle.0, 185.0 + theme::IDLE_NOTCH_OVERFLOW);
+        assert_eq!(
+            idle.1,
+            38.0 + theme::IDLE_NOTCH_OVERFLOW + theme::COMPACT_HEIGHT_OVERFLOW
+        );
+
+        // If Onboard is still selected, it must use the same wrap — not the
+        // live-activity capsule that painted a clipped "openNook" title.
+        island.preferred = Some(CompactMode::Onboard);
+        assert!(
+            !island.available_modes().contains(&CompactMode::Onboard),
+            "Onboard is not a compact face and does not imply a title"
+        );
+        assert_eq!(island.mode(), CompactMode::Idle);
+        assert_eq!(island.target_size(), idle);
+        let capsule = (
+            island.notch_width.max(180.0) + 120.0,
+            island.notch_height.max(32.0) + theme::COMPACT_HEIGHT_OVERFLOW,
+        );
+        assert_ne!(idle, capsule);
     }
 
     #[test]

--- a/crates/nook/src/island/render.rs
+++ b/crates/nook/src/island/render.rs
@@ -8,8 +8,8 @@ use crate::theme;
 use gpui::{
     div, point, prelude::*, px, rgba, size, AnyElement, App, Bounds, Context, CursorStyle,
     ExternalPaths, FontFallbacks, FontWeight, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, ScrollWheelEvent, Window, WindowBackgroundAppearance, WindowBounds, WindowKind,
-    WindowOptions,
+    MouseUpEvent, ScrollWheelEvent, Window, WindowBackgroundAppearance, WindowBounds,
+    WindowDecorations, WindowKind, WindowOptions,
 };
 use nook_core::notch;
 use std::any::Any;
@@ -400,7 +400,7 @@ pub fn open_island(cx: &mut App) {
             is_resizable: false,
             is_minimizable: false,
             window_background: WindowBackgroundAppearance::Transparent,
-            window_decorations: None,
+            window_decorations: Some(WindowDecorations::Client),
             app_id: Some("com.jonasvogel.opennook-gpui".into()),
             ..Default::default()
         },

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -568,7 +568,11 @@ impl SettingsView {
                         )
                         .into_any_element(),
                     ]),
-                    Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
+                    Some(if cfg!(target_os = "macos") {
+                        "Hover the island to expand. Settings and Quit are in the menu bar extra."
+                    } else {
+                        "Click or scroll the island to expand. Ctrl+, opens Settings; Ctrl+Q quits."
+                    }),
                 )),
         )
     }

--- a/crates/nook/src/main.rs
+++ b/crates/nook/src/main.rs
@@ -9,7 +9,7 @@ mod widgets;
 use gpui::{actions, App, Application, KeyBinding};
 use island::open_island;
 
-actions!(nook, [Quit]);
+actions!(nook, [Quit, OpenSettings]);
 
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -22,7 +22,14 @@ fn main() {
             platform::install();
             platform::install_status_item();
             cx.on_action(|_: &Quit, cx| cx.quit());
-            cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+            cx.on_action(|_: &OpenSettings, _cx| platform::request_open_settings());
+            // cmd-* is the Mac extra; ctrl-* is what Linux/Windows keyboards send.
+            cx.bind_keys([
+                KeyBinding::new("cmd-q", Quit, None),
+                KeyBinding::new("ctrl-q", Quit, None),
+                KeyBinding::new("cmd-,", OpenSettings, None),
+                KeyBinding::new("ctrl-,", OpenSettings, None),
+            ]);
             open_island(cx);
             cx.activate(false);
         });

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -12,12 +12,12 @@
 //!      (not `visibleFrame`), without touching GPUI's `Window` (that RefCell-panics).
 
 use gpui::Window;
+#[cfg(target_os = "macos")]
 use raw_window_handle::{HasWindowHandle, RawWindowHandle};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 #[cfg(target_os = "macos")]
 use nook_core::notch::{CGPoint, CGRect, CGSize};
-#[cfg(target_os = "macos")]
-use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::Once;
 
@@ -25,7 +25,6 @@ use std::sync::Once;
 static INSTALL: Once = Once::new();
 #[cfg(target_os = "macos")]
 static LOGGED_PIN: AtomicBool = AtomicBool::new(false);
-#[cfg(target_os = "macos")]
 static OPEN_SETTINGS: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static STATUS_ITEM: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
@@ -639,6 +638,8 @@ unsafe fn begin_file_drag(ns_win: *mut objc2::runtime::AnyObject, path: &str) {
 }
 
 pub fn set_accessory(accessory: bool) {
+    #[cfg(not(target_os = "macos"))]
+    let _ = accessory;
     #[cfg(target_os = "macos")]
     unsafe {
         use objc2::runtime::AnyObject;
@@ -668,14 +669,14 @@ fn ns_window(window: &Window) -> Option<*mut objc2::runtime::AnyObject> {
     }
 }
 
-/// True once if the status item asked to open Settings.
+/// True once if Settings was requested (menu-bar extra or a keybinding).
 pub fn take_open_settings() -> bool {
-    #[cfg(target_os = "macos")]
-    {
-        OPEN_SETTINGS.swap(false, Ordering::SeqCst)
-    }
-    #[cfg(not(target_os = "macos"))]
-    false
+    OPEN_SETTINGS.swap(false, Ordering::SeqCst)
+}
+
+/// Ask the island poll loop to open Settings. Works without a status item.
+pub fn request_open_settings() {
+    OPEN_SETTINGS.store(true, Ordering::SeqCst);
 }
 
 /// Menu-bar extra with Settings and Quit. Accessory apps have no Dock/menu otherwise.

--- a/resources/LINUX.txt
+++ b/resources/LINUX.txt
@@ -1,21 +1,27 @@
 GPUI 0.3.0 Linux build.
 macOS notch/Metal features unavailable.
 Not the old Tauri 0.0.2a line.
+Does not rewrite the macOS v0.3.0 dmg notes.
 
 Run: ./nook
 Needs a Vulkan-capable GPU driver, plus libxkbcommon and
 libwayland or X11 libraries at runtime.
+
+Compact island: Idle housing wrap, no app title, top-center.
+Screen size comes from X11 DisplayWidth / DisplayHeight (not a
+hardcoded 1920×1080 canvas). Settings, expanded island, and the
+file tray have been proven on Linux.
+
+Hover-to-expand uses global mouse polling, which is still stubbed
+on Linux (cursor reports 0,0). Click or scroll the painted island.
+Ctrl+, opens Settings; Ctrl+Q quits.
 
 Unavailable on this build:
 - Metal shaders / scripts/with-metal.sh
 - camera-housing notch metrics (no hardware notch)
 - MediaRemote Now Playing (Linux uses MPRIS when a player is running)
 - NSGlassEffectView / Liquid Glass
-- NSStatusItem menu-bar extra (use Ctrl+, and Ctrl+Q)
+- NSStatusItem menu-bar extra
 - camera Mirror, AirDrop, AppKit file drag-out
 - EventKit Calendar/Reminders, hide-when-maximized occupancy
 - installer.dmg
-
-Hover-to-expand uses global mouse polling, which is stubbed on
-Linux (cursor reports 0,0). Click or scroll the painted island.
-Screen size is a 1920x1080 stub until a display backend is added.

--- a/resources/LINUX.txt
+++ b/resources/LINUX.txt
@@ -7,7 +7,8 @@ Run: ./nook
 Needs a Vulkan-capable GPU driver, plus libxkbcommon and
 libwayland or X11 libraries at runtime.
 
-Compact island: Idle housing wrap, no app title, top-center.
+Compact island: Idle housing wrap, no app title, top-center,
+no window-manager decorations (no title bar / min / max / close).
 Screen size comes from X11 DisplayWidth / DisplayHeight (not a
 hardcoded 1920×1080 canvas). Settings, expanded island, and the
 file tray have been proven on Linux.

--- a/resources/LINUX.txt
+++ b/resources/LINUX.txt
@@ -1,0 +1,21 @@
+GPUI 0.3.0 Linux build.
+macOS notch/Metal features unavailable.
+Not the old Tauri 0.0.2a line.
+
+Run: ./nook
+Needs a Vulkan-capable GPU driver, plus libxkbcommon and
+libwayland or X11 libraries at runtime.
+
+Unavailable on this build:
+- Metal shaders / scripts/with-metal.sh
+- camera-housing notch metrics (no hardware notch)
+- MediaRemote Now Playing (Linux uses MPRIS when a player is running)
+- NSGlassEffectView / Liquid Glass
+- NSStatusItem menu-bar extra (use Ctrl+, and Ctrl+Q)
+- camera Mirror, AirDrop, AppKit file drag-out
+- EventKit Calendar/Reminders, hide-when-maximized occupancy
+- installer.dmg
+
+Hover-to-expand uses global mouse polling, which is stubbed on
+Linux (cursor reports 0,0). Click or scroll the painted island.
+Screen size is a 1920x1080 stub until a display backend is added.

--- a/scripts/linux-deps.sh
+++ b/scripts/linux-deps.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# System packages needed to compile crates/nook (GPUI 0.2.2) on Debian/Ubuntu.
+# Metal / with-metal.sh is macOS-only. Linux uses Vulkan (blade) + X11/Wayland.
+set -euo pipefail
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+  build-essential g++ pkg-config libssl-dev \
+  libxkbcommon-dev libxkbcommon-x11-dev \
+  libwayland-dev libvulkan-dev \
+  libx11-dev libxrandr-dev libxi-dev libxcursor-dev libxinerama-dev \
+  libxcb1-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev

--- a/scripts/linux-deps.sh
+++ b/scripts/linux-deps.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # System packages needed to compile crates/nook (GPUI 0.2.2) on Debian/Ubuntu.
 # Metal / with-metal.sh is macOS-only. Linux uses Vulkan (blade) + X11/Wayland.
+# libx11 is also used at runtime for DisplayWidth / DisplayHeight centering.
 set -euo pipefail
 sudo apt-get update
 sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`cargo build --release -p nook` of the current GPUI product (`crates/nook` / workspace 0.3.0) produces an installable Linux binary. This PR adds CI that builds that binary and publishes it. It does **not** restore Tauri, retag `0.0.2a` / `openNook_0.1.0` AppImage, merge Linux-hover #50, or touch launch-page #48.

## Stacked

- **#53** (`d09e9a6` / `ee3dc58`): compact Idle housing wrap, no “openNook” title, X11 `DisplayWidth` / `DisplayHeight` centering
- **#54** (`aceba44`): `window_decorations: Some(WindowDecorations::Client)` so XFCE does not draw a title bar / min / max / close

## Artifact / CI

- **Check job:** `check.yml` → `linux` on `ubuntu-22.04`
- **Release job:** `.github/workflows/linux-release.yml` on `workflow_dispatch` or tag `v*-linux`
- Artifact: `openNook-0.3.0-x86_64-unknown-linux-gnu.tar.gz`
- Publishes **`v0.3.0-linux`** (`make_latest: false`). Does not attach to or rewrite `v0.3.0`.

Compact has no app title, is top-center, and has no window-manager decorations.

## Leftovers

Hover polling is still stubbed. Metal, camera-housing notch, MediaRemote, Liquid Glass, menu-bar extra, Mirror, AirDrop, AppKit drag-out, EventKit, hide-when-maximized, and `installer.dmg` stay macOS-only. Settings stays a normal decorated window.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5314befb-0c0d-407f-a019-8287b6282557?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5314befb-0c0d-407f-a019-8287b6282557&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

