### PR TITLE
Fix Linux compact island: no title, Idle wrap, top-center

### DIFF
--- a/crates/nook-core/src/notch.rs
+++ b/crates/nook-core/src/notch.rs
@@ -149,8 +149,41 @@ fn read_screen_info() -> (f64, f64, f64, f64) {
 
     #[cfg(target_os = "linux")]
     {
-        let notch_width = calculate_dynamic_notch_width(1920.0);
-        (1920.0, 1080.0, 0.0, notch_width)
+        let (width, height) = linux_root_display_size().unwrap_or((1920.0, 1080.0));
+        let notch_width = calculate_dynamic_notch_width(width);
+        (width, height, 0.0, notch_width)
+    }
+}
+
+/// Primary display in logical pixels. `has_notch` stays false — this only
+/// sizes the overlay so `island_origin` can centre the stub housing wrap.
+#[cfg(target_os = "linux")]
+fn linux_root_display_size() -> Option<(f64, f64)> {
+    use std::os::raw::{c_char, c_int, c_void};
+
+    #[link(name = "X11")]
+    unsafe extern "C" {
+        fn XOpenDisplay(display: *const c_char) -> *mut c_void;
+        fn XCloseDisplay(display: *mut c_void) -> c_int;
+        fn XDefaultScreen(display: *mut c_void) -> c_int;
+        fn XDisplayWidth(display: *mut c_void, screen_number: c_int) -> c_int;
+        fn XDisplayHeight(display: *mut c_void, screen_number: c_int) -> c_int;
+    }
+
+    unsafe {
+        let dpy = XOpenDisplay(std::ptr::null());
+        if dpy.is_null() {
+            return None;
+        }
+        let screen = XDefaultScreen(dpy);
+        let width = XDisplayWidth(dpy, screen);
+        let height = XDisplayHeight(dpy, screen);
+        XCloseDisplay(dpy);
+        if width > 0 && height > 0 {
+            Some((width as f64, height as f64))
+        } else {
+            None
+        }
     }
 }
 
@@ -182,4 +215,36 @@ pub fn overlay_window_size() -> (f64, f64) {
 
 pub fn overlay_window_origin() -> (f64, f64) {
     (0.0, 0.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stub_notch_width_follows_the_real_screen() {
+        assert_eq!(calculate_dynamic_notch_width(1280.0), 200.0);
+        assert_eq!(calculate_dynamic_notch_width(1920.0), 200.0);
+        assert_eq!(calculate_dynamic_notch_width(3000.0), 260.0);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_screen_has_no_notch_and_overlay_matches_root() {
+        let info = get_notch_info();
+        assert!(!info.has_notch, "Linux must not invent a camera notch");
+        assert_eq!(info.notch_height, 0.0);
+        assert_eq!(
+            info.notch_width,
+            calculate_dynamic_notch_width(info.screen_width)
+        );
+        assert_eq!(
+            overlay_window_size(),
+            (info.screen_width, info.screen_height)
+        );
+        if let Some((w, h)) = linux_root_display_size() {
+            assert_eq!(info.screen_width, w);
+            assert_eq!(info.screen_height, h);
+        }
+    }
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -635,7 +635,11 @@ mod tests {
         let (x, y) = settings.island_origin(screen_w, screen_h, wrap_w, wrap_h);
         assert_eq!(y, 0.0);
         assert!((x - (screen_w - wrap_w) / 2.0).abs() < 0.01);
-        assert!(x < 400.0, "must not sit on the right of a 1280 display, got {x}");
+        let parked_on_1920 = (1920.0 - wrap_w) / 2.0;
+        assert!(
+            (x - parked_on_1920).abs() > 100.0,
+            "a 1920-wide canvas parks the pill at {parked_on_1920}, which is the right of 1280; got {x}"
+        );
         assert!(settings.island_attached(screen_h));
     }
 

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -619,6 +619,27 @@ mod tests {
     }
 
     #[test]
+    fn linux_stub_notch_origin_is_top_center() {
+        // Linux reports has_notch=false and a stub width from
+        // calculate_dynamic_notch_width(real_width). Default island_x=0.5
+        // then centres that wrap on the *reported* screen — a leftover
+        // 1920-wide canvas parked the same pill at x≈860 on a 1280 display.
+        let settings = AppSettings::default();
+        assert!((settings.island_x - 0.5).abs() < f32::EPSILON);
+        assert_eq!(settings.island_y, 0.0);
+        let screen_w = 1280.0;
+        let screen_h = 800.0;
+        let notch_w = (screen_w as f64 * 0.1).clamp(200.0, 260.0) as f32;
+        let wrap_w = notch_w + 1.0;
+        let wrap_h = 32.0 + 1.0 + 1.0;
+        let (x, y) = settings.island_origin(screen_w, screen_h, wrap_w, wrap_h);
+        assert_eq!(y, 0.0);
+        assert!((x - (screen_w - wrap_w) / 2.0).abs() < 0.01);
+        assert!(x < 400.0, "must not sit on the right of a 1280 display, got {x}");
+        assert!(settings.island_attached(screen_h));
+    }
+
+    #[test]
     fn island_origin_tracks_a_drag_and_clamps() {
         let mut settings = AppSettings::default();
         settings.set_island_origin(0.0, 120.0, 1512.0, 982.0, 180.0);

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -63,16 +63,18 @@ impl Island {
             CompactMode::Observe => {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
-            CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
-            CompactMode::Idle => div().into_any_element(),
+            // Onboard is not a titled compact face (Mac 0.3.0 has no app-name
+            // pill). Keep the arm empty so a leftover preferred mode cannot
+            // paint "openNook" / clip to "openNc".
+            CompactMode::Onboard | CompactMode::Idle => div().into_any_element(),
         }
     }
 
     fn compact_right(
         &self,
         mode: CompactMode,
-        hovered: bool,
-        cx: &mut Context<Self>,
+        _hovered: bool,
+        _cx: &mut Context<Self>,
     ) -> AnyElement {
         match mode {
             CompactMode::Media => visualizer(
@@ -105,20 +107,6 @@ impl Island {
                 };
                 label(text, theme::BODY, true).into_any_element()
             }
-            CompactMode::Onboard if hovered => div()
-                .id("github")
-                .cursor(CursorStyle::PointingHand)
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(|_, _: &MouseDownEvent, _, cx| {
-                        cx.stop_propagation();
-                        let _ = std::process::Command::new("/usr/bin/open")
-                            .arg("https://github.com/prodBirdy/openNook-gpui")
-                            .spawn();
-                    }),
-                )
-                .child(lucide("github", theme::COMPACT_FACE))
-                .into_any_element(),
             _ => div().into_any_element(),
         }
     }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -797,9 +797,8 @@ impl Island {
         if self.settings.show_files && !self.files.is_empty() {
             modes.push(CompactMode::Files);
         }
-        if self.first_run {
-            modes.push(CompactMode::Onboard);
-        }
+        // First-run still calls mark_onboarded() on first expand. Do not
+        // expose Onboard as a compact face — Mac 0.3.0 has no titled pill.
         modes.push(CompactMode::Idle);
         modes
     }
@@ -821,7 +820,7 @@ impl Island {
         if self.hovered {
             return (base_w + 125.0, base_h + 15.0);
         }
-        if self.mode() == CompactMode::Idle {
+        if matches!(self.mode(), CompactMode::Idle | CompactMode::Onboard) {
             let h = if self.settings.non_notch_mode {
                 1.0
             } else {
@@ -1538,6 +1537,37 @@ mod tests {
         let (w, h) = island.target_size();
         assert_eq!(w, 185.0 + theme::IDLE_NOTCH_OVERFLOW);
         assert_eq!(h, 1.0);
+    }
+
+    #[test]
+    fn first_run_compact_is_idle_housing_wrap() {
+        let mut island = test_island();
+        island.first_run = true;
+        island.notch_width = 185.0;
+        island.notch_height = 38.0;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+        assert_eq!(island.mode(), CompactMode::Idle);
+        let idle = island.target_size();
+        assert_eq!(idle.0, 185.0 + theme::IDLE_NOTCH_OVERFLOW);
+        assert_eq!(
+            idle.1,
+            38.0 + theme::IDLE_NOTCH_OVERFLOW + theme::COMPACT_HEIGHT_OVERFLOW
+        );
+
+        // If Onboard is still selected, it must use the same wrap — not the
+        // live-activity capsule that painted a clipped "openNook" title.
+        island.preferred = Some(CompactMode::Onboard);
+        assert!(
+            !island.available_modes().contains(&CompactMode::Onboard),
+            "Onboard is not a compact face and does not imply a title"
+        );
+        assert_eq!(island.mode(), CompactMode::Idle);
+        assert_eq!(island.target_size(), idle);
+        let capsule = (
+            island.notch_width.max(180.0) + 120.0,
+            island.notch_height.max(32.0) + theme::COMPACT_HEIGHT_OVERFLOW,
+        );
+        assert_ne!(idle, capsule);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Linux first-run compact was a titled live-activity capsule (clipped “openNc” / “openNook”) parked on the right of a real display. Mac 0.3.0 compact chrome is housing wrap + rounded-rect bottom (`COMPACT_RADIUS` 12) with no app title.

## Cause
- `first_run` pushed `CompactMode::Onboard` ahead of Idle. `compact_left` painted `label("openNook")` and `target_size` used the live-activity capsule.
- Linux `read_screen_info` hardcoded `(1920, 1080, …)`. Overlay / `island_origin` then centered on a 1920-wide canvas (`x ≈ 860`), which reads as top-right on a 1280-wide display.

## Change
- Do not add Onboard to `available_modes`. First-run compact is Idle. `mark_onboarded()` on first expand is unchanged.
- Empty the Onboard compact face (no title, no GitHub / `/usr/bin/open` port). If Onboard is still selected, `target_size` uses the Idle housing wrap.
- Linux screen size comes from X11 root `DisplayWidth` / `DisplayHeight`. Stub notch width is `calculate_dynamic_notch_width(real_width)`. `has_notch` stays false. `overlay_window_size` follows. Default `island_x = 0.5` is not rewritten.

## Tests
- `first_run_compact_is_idle_housing_wrap` — first-run compact is Idle wrap, not a title face. Existing `collapsed_idle_wraps_the_hardware_notch_by_one_pixel` kept.
- `linux_stub_notch_origin_is_top_center` — has_notch=false + stub notch is top-center on the reported screen.
- `linux_screen_has_no_notch_and_overlay_matches_root` — Linux overlay matches the X11 root display.

Does not stack on #51 (Linux CI/release only). Does not touch Tauri / 0.0.2a / #50.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e490225-19f8-4f1a-802e-d5bab43fe691?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e490225-19f8-4f1a-802e-d5bab43fe691&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

