### PR TITLE
Fix Linux island WM chrome with Client decorations

### DIFF
--- a/crates/nook/src/island/render.rs
+++ b/crates/nook/src/island/render.rs
@@ -8,8 +8,8 @@ use crate::theme;
 use gpui::{
     div, point, prelude::*, px, rgba, size, AnyElement, App, Bounds, Context, CursorStyle,
     ExternalPaths, FontFallbacks, FontWeight, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, ScrollWheelEvent, Window, WindowBackgroundAppearance, WindowBounds, WindowKind,
-    WindowOptions,
+    MouseUpEvent, ScrollWheelEvent, Window, WindowBackgroundAppearance, WindowBounds,
+    WindowDecorations, WindowKind, WindowOptions,
 };
 use nook_core::notch;
 use std::any::Any;
@@ -400,7 +400,7 @@ pub fn open_island(cx: &mut App) {
             is_resizable: false,
             is_minimizable: false,
             window_background: WindowBackgroundAppearance::Transparent,
-            window_decorations: None,
+            window_decorations: Some(WindowDecorations::Client),
             app_id: Some("com.jonasvogel.opennook-gpui".into()),
             ..Default::default()
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
NOOK-75: Linux GPUI island still shows window-manager chrome (XFCE title bar + min/max/close) on the 0.3.0 compact island from #53. Mac has none.

Stacks on #53 (`cursor/linux-compact-island-e691`). Does not merge #48. Does not rewrite the release workflow. Does not touch the settings window.

## Cause

`open_island` already sets `titlebar: None`, `kind: WindowKind::PopUp`, and `is_movable` / `is_resizable` / `is_minimizable` false. `window_decorations` was `None`.

gpui 0.2.2 `Window::new` does `request_decorations(window_decorations.unwrap_or(WindowDecorations::Server))`. On X11, Server writes `_MOTIF_WM_HINTS decorations=1`, so XFCE/xfwm draws the title bar.

This box already logs `x11: compositor present: true, gtk_frame_extents_supported: true`, so Client will not fall back to Server.

## Change

In `crates/nook/src/island/render.rs::open_island`, set `window_decorations: Some(WindowDecorations::Client)`. Client writes `_MOTIF_WM_HINTS decorations=0` and strips WM chrome.

Settings (`island/mod.rs`) stays a normal decorated window.

No Linux-only x11rb Motif path. No Mac-path changes. No screenshots or docs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a20c579-69bc-4f08-bb9b-6fe48405381a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a20c579-69bc-4f08-bb9b-6fe48405381a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

