### PR TITLE
WP05: Battery alerts + one-tap Low Power Mode

### DIFF
--- a/crates/nook-core/src/assets/Toggle Low Power Mode.shortcut
+++ b/crates/nook-core/src/assets/Toggle Low Power Mode.shortcut
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>WFWorkflowMinimumClientVersion</key>
+	<integer>900</integer>
+	<key>WFWorkflowMinimumClientVersionString</key>
+	<string>900</string>
+	<key>WFWorkflowHasOutputFallback</key>
+	<false/>
+	<key>WFWorkflowActions</key>
+	<array>
+		<dict>
+			<key>WFWorkflowActionIdentifier</key>
+			<string>is.workflow.actions.lowpowermode.set</string>
+			<key>WFWorkflowActionParameters</key>
+			<dict>
+				<key>OnValue</key>
+				<integer>2</integer>
+			</dict>
+		</dict>
+	</array>
+	<key>WFWorkflowClientRelease</key>
+	<string>18.0</string>
+	<key>WFWorkflowClientVersion</key>
+	<string>1300.0.5</string>
+	<key>WFWorkflowIcon</key>
+	<dict>
+		<key>WFWorkflowIconStartColor</key>
+		<integer>431817727</integer>
+		<key>WFWorkflowIconGlyphNumber</key>
+		<integer>59458</integer>
+	</dict>
+	<key>WFWorkflowImportQuestions</key>
+	<array/>
+	<key>WFWorkflowInputContentItemClasses</key>
+	<array/>
+	<key>WFWorkflowName</key>
+	<string>Toggle Low Power Mode</string>
+	<key>WFWorkflowTypes</key>
+	<array/>
+</dict>
+</plist>

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod notch;
 pub mod notes;
 pub mod observe;
 pub mod occupancy;
+pub mod power;
 pub mod settings;
 pub mod utils;
 pub mod widgets;
@@ -63,5 +64,6 @@ pub fn init() {
         audio::init_audio_state();
         audio::setup_audio_monitoring();
         mouse::start_polling();
+        power::start();
     });
 }

--- a/crates/nook-core/src/power.rs
+++ b/crates/nook-core/src/power.rs
@@ -1,0 +1,815 @@
+//! Battery state and Low Power Mode.
+//!
+//! Event-driven on macOS: Darwin `notify_register_dispatch` for IOKit power
+//! sources plus `NSProcessInfoPowerStateDidChangeNotification` for LPM. No
+//! polling loop. Desktop Macs (empty power-source list) hide the gauge and
+//! still expose the LPM toggle.
+
+use std::sync::OnceLock;
+use tokio::sync::watch;
+
+/// IOKit / `IOPSGetBatteryWarningLevel` values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum BatteryWarning {
+    #[default]
+    None,
+    Early,
+    Final,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PowerSnapshot {
+    pub percent: Option<u8>,
+    pub is_charging: bool,
+    pub on_ac: bool,
+    pub time_to_empty_min: Option<u32>,
+    pub warning_level: BatteryWarning,
+    pub low_power_mode: bool,
+    pub has_battery: bool,
+}
+
+impl Default for PowerSnapshot {
+    fn default() -> Self {
+        Self {
+            percent: None,
+            is_charging: false,
+            on_ac: true,
+            time_to_empty_min: None,
+            warning_level: BatteryWarning::None,
+            low_power_mode: false,
+            has_battery: false,
+        }
+    }
+}
+
+impl PowerSnapshot {
+    /// Compact-face takeover: discharging at or below the user threshold, or
+    /// the OS early/final low-battery warning. Charging (or AC with no
+    /// internal battery) clears the alert. Desktop Macs never alert.
+    pub fn is_alerting(self, threshold: u8) -> bool {
+        if !self.has_battery {
+            return false;
+        }
+        if self.is_charging || self.on_ac {
+            return false;
+        }
+        let below = self
+            .percent
+            .map(|percent| percent <= threshold)
+            .unwrap_or(false);
+        below || self.warning_level != BatteryWarning::None
+    }
+
+    /// `kIOPSNotifyTimeRemaining` is chatty. Subscribe only on the expanded
+    /// battery card or while discharging below ~30%.
+    pub fn should_watch_time_remaining(self, detail: bool) -> bool {
+        if detail {
+            return true;
+        }
+        self.has_battery
+            && !self.is_charging
+            && !self.on_ac
+            && self.percent.map(|percent| percent <= 30).unwrap_or(false)
+    }
+
+    pub fn compact_icon(self) -> &'static str {
+        if self.is_charging {
+            "battery-charging"
+        } else {
+            "battery-low"
+        }
+    }
+}
+
+/// How the next LPM write will be issued.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LpmRoute {
+    Shortcut(String),
+    OsascriptAdmin,
+}
+
+/// Prefer a named Shortcuts action when `shortcuts list` contains it.
+pub fn lpm_route(shortcut_name: Option<&str>, listed: &[String]) -> LpmRoute {
+    if let Some(name) = shortcut_name.map(str::trim).filter(|name| !name.is_empty()) {
+        if listed.iter().any(|entry| entry == name) {
+            return LpmRoute::Shortcut(name.to_string());
+        }
+    }
+    LpmRoute::OsascriptAdmin
+}
+
+pub fn default_lpm_shortcut_name() -> &'static str {
+    "Toggle Low Power Mode"
+}
+
+pub fn clamp_alert_threshold(value: u8) -> u8 {
+    value.clamp(5, 80)
+}
+
+pub fn format_time_remaining(minutes: Option<u32>) -> String {
+    match minutes {
+        None => "—".into(),
+        Some(0) => "Calculating…".into(),
+        Some(m) if m < 60 => format!("{m}m left"),
+        Some(m) => format!("{}h {:02}m left", m / 60, m % 60),
+    }
+}
+
+pub fn format_percent(percent: Option<u8>) -> String {
+    match percent {
+        Some(value) => format!("{value}%"),
+        None => "—".into(),
+    }
+}
+
+fn channel() -> &'static watch::Sender<PowerSnapshot> {
+    static TX: OnceLock<watch::Sender<PowerSnapshot>> = OnceLock::new();
+    TX.get_or_init(|| {
+        let (tx, _rx) = watch::channel(PowerSnapshot::default());
+        tx
+    })
+}
+
+/// Latest snapshot. Cheap; the island tick should not poll this.
+pub fn current() -> PowerSnapshot {
+    *channel().borrow()
+}
+
+pub fn subscribe() -> watch::Receiver<PowerSnapshot> {
+    channel().subscribe()
+}
+
+/// Register Darwin / NSProcessInfo observers. Idempotent, no-op off macOS.
+pub fn start() {
+    #[cfg(target_os = "macos")]
+    macos::start();
+}
+
+/// Keep per-percent `timeremaining` notifications only while the battery card
+/// is on screen (or while [`PowerSnapshot::should_watch_time_remaining`]
+/// decides we are critically discharging).
+pub fn set_detail_watch(on: bool) {
+    #[cfg(target_os = "macos")]
+    macos::set_detail_watch(on);
+    #[cfg(not(target_os = "macos"))]
+    let _ = on;
+}
+
+/// Shortcuts, then osascript-admin. Success is the NSProcessInfo LPM flag
+/// flipping within ~3 s, not the command exit code.
+pub async fn toggle_low_power_mode() -> Result<bool, String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::toggle_low_power_mode().await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Low Power Mode is only available on macOS".into())
+    }
+}
+
+/// Write the bundled shortcut to a temp file and `/usr/bin/open` it so the
+/// user can confirm the import in Shortcuts.app (cannot be silent).
+pub fn install_lpm_shortcut() -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::install_lpm_shortcut()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Err("Shortcuts are only available on macOS".into())
+    }
+}
+
+pub async fn list_shortcuts() -> Vec<String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::list_shortcuts().await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Vec::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use std::ffi::CStr;
+    use std::os::raw::{c_char, c_int, c_void};
+    use std::ptr;
+    use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering};
+    use std::sync::Once;
+    use std::time::Duration;
+
+    const NOTIFY_STATUS_OK: u32 = 0;
+    const K_CFSTRING_ENCODING_UTF8: u32 = 0x0800_0100;
+    const K_CF_NUMBER_SINT32_TYPE: i32 = 3;
+    const K_CF_NUMBER_DOUBLE_TYPE: i32 = 13;
+    const K_IOPS_TIME_REMAINING_UNKNOWN: f64 = -1.0;
+    const K_IOPS_TIME_REMAINING_UNLIMITED: f64 = -2.0;
+    const K_IOPS_WARNING_NONE: i32 = 1;
+    const K_IOPS_WARNING_EARLY: i32 = 2;
+    const K_IOPS_WARNING_FINAL: i32 = 3;
+    const DEBOUNCE_MS: u64 = 250;
+    const LPM_CONFIRM_SECS: u64 = 3;
+
+    const NOTIFY_SOURCE: &CStr = c"com.apple.system.powersources.source";
+    const NOTIFY_LOW: &CStr = c"com.apple.system.powersources.lowbattery";
+    const NOTIFY_TIME: &CStr = c"com.apple.system.powersources.timeremaining";
+
+    type CfTypeRef = *const c_void;
+    type CfStringRef = *const c_void;
+    type CfArrayRef = *const c_void;
+    type CfDictionaryRef = *const c_void;
+    type CfNumberRef = *const c_void;
+    type CfBooleanRef = *const c_void;
+    type CfAllocatorRef = *const c_void;
+    type DispatchQueue = *mut c_void;
+
+    #[link(name = "IOKit", kind = "framework")]
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn IOPSCopyPowerSourcesInfo() -> CfTypeRef;
+        fn IOPSCopyPowerSourcesList(blob: CfTypeRef) -> CfArrayRef;
+        fn IOPSGetPowerSourceDescription(blob: CfTypeRef, ps: CfTypeRef) -> CfDictionaryRef;
+        fn IOPSGetBatteryWarningLevel() -> i32;
+        fn IOPSGetTimeRemainingEstimate() -> f64;
+
+        fn CFRelease(cf: CfTypeRef);
+        fn CFGetTypeID(cf: CfTypeRef) -> usize;
+        fn CFArrayGetCount(array: CfArrayRef) -> isize;
+        fn CFArrayGetValueAtIndex(array: CfArrayRef, idx: isize) -> CfTypeRef;
+        fn CFDictionaryGetValue(dict: CfDictionaryRef, key: CfTypeRef) -> CfTypeRef;
+        fn CFStringCreateWithCString(
+            alloc: CfAllocatorRef,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CfStringRef;
+        fn CFStringGetTypeID() -> usize;
+        fn CFStringGetCString(
+            string: CfStringRef,
+            buffer: *mut c_char,
+            buffer_size: isize,
+            encoding: u32,
+        ) -> u8;
+        fn CFNumberGetTypeID() -> usize;
+        fn CFNumberGetValue(number: CfNumberRef, the_type: i32, value_ptr: *mut c_void) -> u8;
+        fn CFBooleanGetTypeID() -> usize;
+        fn CFBooleanGetValue(boolean: CfBooleanRef) -> u8;
+
+        fn notify_register_dispatch(
+            name: *const c_char,
+            out_token: *mut c_int,
+            queue: DispatchQueue,
+            handler: *mut block2::Block<dyn Fn(c_int)>,
+        ) -> u32;
+        fn notify_cancel(token: c_int) -> u32;
+        fn dispatch_get_global_queue(identifier: isize, flags: usize) -> DispatchQueue;
+    }
+
+    static STARTED: Once = Once::new();
+    static DEBOUNCE_GEN: AtomicU64 = AtomicU64::new(0);
+    static DETAIL_WATCH: AtomicBool = AtomicBool::new(false);
+    static TIME_TOKEN: AtomicI32 = AtomicI32::new(-1);
+
+    pub fn start() {
+        STARTED.call_once(|| {
+            register_notify(NOTIFY_SOURCE);
+            register_notify(NOTIFY_LOW);
+            install_lpm_observer();
+            publish_now();
+        });
+    }
+
+    pub fn set_detail_watch(on: bool) {
+        DETAIL_WATCH.store(on, Ordering::Relaxed);
+        let snap = super::current();
+        set_time_remaining_subscription(snap.should_watch_time_remaining(on));
+    }
+
+    fn register_notify(name: &CStr) {
+        unsafe {
+            let queue = dispatch_get_global_queue(0, 0);
+            if queue.is_null() {
+                log::warn!("power: dispatch_get_global_queue failed");
+                return;
+            }
+            let block = block2::RcBlock::new(move |_token: c_int| {
+                schedule_publish();
+            });
+            let mut token: c_int = 0;
+            let status = notify_register_dispatch(
+                name.as_ptr(),
+                &mut token,
+                queue,
+                &*block as *const block2::Block<_> as *mut block2::Block<_>,
+            );
+            std::mem::forget(block);
+            if status != NOTIFY_STATUS_OK {
+                log::warn!("power: notify_register_dispatch({name:?}) = {status}");
+            }
+        }
+    }
+
+    fn set_time_remaining_subscription(on: bool) {
+        if on {
+            if TIME_TOKEN.load(Ordering::Relaxed) >= 0 {
+                return;
+            }
+            unsafe {
+                let queue = dispatch_get_global_queue(0, 0);
+                if queue.is_null() {
+                    return;
+                }
+                let block = block2::RcBlock::new(move |_token: c_int| {
+                    schedule_publish();
+                });
+                let mut token: c_int = 0;
+                let status = notify_register_dispatch(
+                    NOTIFY_TIME.as_ptr(),
+                    &mut token,
+                    queue,
+                    &*block as *const block2::Block<_> as *mut block2::Block<_>,
+                );
+                std::mem::forget(block);
+                if status == NOTIFY_STATUS_OK {
+                    TIME_TOKEN.store(token, Ordering::Relaxed);
+                }
+            }
+        } else {
+            let token = TIME_TOKEN.swap(-1, Ordering::Relaxed);
+            if token >= 0 {
+                unsafe {
+                    notify_cancel(token);
+                }
+            }
+        }
+    }
+
+    fn schedule_publish() {
+        let gen = DEBOUNCE_GEN.fetch_add(1, Ordering::Relaxed) + 1;
+        crate::runtime().spawn(async move {
+            tokio::time::sleep(Duration::from_millis(DEBOUNCE_MS)).await;
+            if DEBOUNCE_GEN.load(Ordering::Relaxed) == gen {
+                publish_now();
+            }
+        });
+    }
+
+    fn publish_now() {
+        let snap = read_snapshot();
+        set_time_remaining_subscription(
+            snap.should_watch_time_remaining(DETAIL_WATCH.load(Ordering::Relaxed)),
+        );
+        let _ = super::channel().send(snap);
+    }
+
+    fn install_lpm_observer() {
+        unsafe {
+            use objc2::runtime::AnyObject;
+            use objc2::*;
+
+            let center: *mut AnyObject = msg_send![class!(NSNotificationCenter), defaultCenter];
+            if center.is_null() {
+                return;
+            }
+            let name: *mut AnyObject = msg_send![
+                class!(NSString),
+                stringWithUTF8String: c"NSProcessInfoPowerStateDidChangeNotification".as_ptr()
+            ];
+            let block = block2::RcBlock::new(move |_note: *mut AnyObject| {
+                schedule_publish();
+            });
+            let _token: *mut AnyObject = msg_send![
+                center,
+                addObserverForName: name,
+                object: ptr::null_mut::<AnyObject>(),
+                queue: ptr::null_mut::<AnyObject>(),
+                usingBlock: &*block
+            ];
+            std::mem::forget(block);
+        }
+    }
+
+    fn read_lpm() -> bool {
+        unsafe {
+            use objc2::runtime::AnyObject;
+            use objc2::*;
+            let info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+            if info.is_null() {
+                return false;
+            }
+            let enabled: bool = msg_send![info, isLowPowerModeEnabled];
+            enabled
+        }
+    }
+
+    fn read_snapshot() -> PowerSnapshot {
+        let mut snap = PowerSnapshot {
+            low_power_mode: read_lpm(),
+            ..PowerSnapshot::default()
+        };
+        snap.warning_level = match unsafe { IOPSGetBatteryWarningLevel() } {
+            K_IOPS_WARNING_EARLY => BatteryWarning::Early,
+            K_IOPS_WARNING_FINAL => BatteryWarning::Final,
+            K_IOPS_WARNING_NONE | _ => BatteryWarning::None,
+        };
+
+        unsafe {
+            let blob = IOPSCopyPowerSourcesInfo();
+            if blob.is_null() {
+                return snap;
+            }
+            let list = IOPSCopyPowerSourcesList(blob);
+            if list.is_null() {
+                CFRelease(blob);
+                return snap;
+            }
+            let count = CFArrayGetCount(list);
+            for i in 0..count {
+                let ps = CFArrayGetValueAtIndex(list, i);
+                if ps.is_null() {
+                    continue;
+                }
+                let desc = IOPSGetPowerSourceDescription(blob, ps);
+                if desc.is_null() {
+                    continue;
+                }
+                let kind = cf_dict_string(desc, c"Type");
+                if kind.as_deref() != Some("InternalBattery") {
+                    continue;
+                }
+                if cf_dict_bool(desc, c"Is Present") == Some(false) {
+                    continue;
+                }
+                snap.has_battery = true;
+                let current = cf_dict_i32(desc, c"Current Capacity");
+                let max = cf_dict_i32(desc, c"Max Capacity").filter(|value| *value > 0);
+                snap.percent = match (current, max) {
+                    (Some(cur), Some(max)) => Some(((cur.clamp(0, max) * 100) / max) as u8),
+                    (Some(cur), None) if (0..=100).contains(&cur) => Some(cur as u8),
+                    _ => None,
+                };
+                snap.is_charging = cf_dict_bool(desc, c"Is Charging").unwrap_or(false);
+                let state = cf_dict_string(desc, c"Power Source State");
+                snap.on_ac = state.as_deref() == Some("AC Power");
+                if let Some(minutes) = cf_dict_i32(desc, c"Time to Empty").filter(|m| *m > 0) {
+                    snap.time_to_empty_min = Some(minutes as u32);
+                }
+                break;
+            }
+            CFRelease(list);
+            CFRelease(blob);
+        }
+
+        if snap.has_battery && !snap.on_ac {
+            let estimate = unsafe { IOPSGetTimeRemainingEstimate() };
+            if estimate > 0.0
+                && estimate != K_IOPS_TIME_REMAINING_UNKNOWN
+                && estimate != K_IOPS_TIME_REMAINING_UNLIMITED
+            {
+                snap.time_to_empty_min = Some((estimate / 60.0).round().max(0.0) as u32);
+            }
+        }
+
+        snap
+    }
+
+    fn cf_key(name: &CStr) -> CfStringRef {
+        unsafe { CFStringCreateWithCString(ptr::null(), name.as_ptr(), K_CFSTRING_ENCODING_UTF8) }
+    }
+
+    fn cf_dict_get(dict: CfDictionaryRef, key: &CStr) -> CfTypeRef {
+        let key_ref = cf_key(key);
+        if key_ref.is_null() {
+            return ptr::null();
+        }
+        let value = unsafe { CFDictionaryGetValue(dict, key_ref) };
+        unsafe { CFRelease(key_ref) };
+        value
+    }
+
+    fn cf_dict_bool(dict: CfDictionaryRef, key: &CStr) -> Option<bool> {
+        let value = cf_dict_get(dict, key);
+        if value.is_null() {
+            return None;
+        }
+        unsafe {
+            let ty = CFGetTypeID(value);
+            if ty == CFBooleanGetTypeID() {
+                return Some(CFBooleanGetValue(value as CfBooleanRef) != 0);
+            }
+            if ty == CFNumberGetTypeID() {
+                let mut n: i32 = 0;
+                if CFNumberGetValue(
+                    value as CfNumberRef,
+                    K_CF_NUMBER_SINT32_TYPE,
+                    &mut n as *mut i32 as *mut c_void,
+                ) != 0
+                {
+                    return Some(n != 0);
+                }
+            }
+        }
+        None
+    }
+
+    fn cf_dict_i32(dict: CfDictionaryRef, key: &CStr) -> Option<i32> {
+        let value = cf_dict_get(dict, key);
+        if value.is_null() {
+            return None;
+        }
+        unsafe {
+            if CFGetTypeID(value) != CFNumberGetTypeID() {
+                return None;
+            }
+            let mut n: i32 = 0;
+            if CFNumberGetValue(
+                value as CfNumberRef,
+                K_CF_NUMBER_SINT32_TYPE,
+                &mut n as *mut i32 as *mut c_void,
+            ) != 0
+            {
+                return Some(n);
+            }
+            let mut d: f64 = 0.0;
+            if CFNumberGetValue(
+                value as CfNumberRef,
+                K_CF_NUMBER_DOUBLE_TYPE,
+                &mut d as *mut f64 as *mut c_void,
+            ) != 0
+            {
+                return Some(d as i32);
+            }
+        }
+        None
+    }
+
+    fn cf_dict_string(dict: CfDictionaryRef, key: &CStr) -> Option<String> {
+        let value = cf_dict_get(dict, key);
+        if value.is_null() {
+            return None;
+        }
+        unsafe {
+            if CFGetTypeID(value) != CFStringGetTypeID() {
+                return None;
+            }
+            let mut buf = [0i8; 128];
+            if CFStringGetCString(
+                value as CfStringRef,
+                buf.as_mut_ptr(),
+                buf.len() as isize,
+                K_CFSTRING_ENCODING_UTF8,
+            ) == 0
+            {
+                return None;
+            }
+            CStr::from_ptr(buf.as_ptr()).to_str().ok().map(str::to_string)
+        }
+    }
+
+    pub async fn list_shortcuts() -> Vec<String> {
+        let output = tokio::process::Command::new("/usr/bin/shortcuts")
+            .arg("list")
+            .output()
+            .await;
+        match output {
+            Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect(),
+            Ok(output) => {
+                log::debug!(
+                    "shortcuts list failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                Vec::new()
+            }
+            Err(err) => {
+                log::debug!("shortcuts list: {err}");
+                Vec::new()
+            }
+        }
+    }
+
+    async fn run_shortcut(name: &str) -> Result<(), String> {
+        let output = tokio::process::Command::new("/usr/bin/shortcuts")
+            .arg("run")
+            .arg(name)
+            .output()
+            .await
+            .map_err(|err| err.to_string())?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        }
+    }
+
+    async fn run_osascript_admin(on: bool) -> Result<(), String> {
+        let flag = if on { "1" } else { "0" };
+        let script =
+            format!(r#"do shell script "pmset -a lowpowermode {flag}" with administrator privileges"#);
+        let output = tokio::process::Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(script)
+            .output()
+            .await
+            .map_err(|err| err.to_string())?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            let err = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(if err.is_empty() {
+                "Administrator approval was cancelled".into()
+            } else {
+                err
+            })
+        }
+    }
+
+    pub async fn toggle_low_power_mode() -> Result<bool, String> {
+        let before = super::current().low_power_mode;
+        let settings = crate::settings::get_app_settings();
+        let name = settings
+            .lpm_shortcut_name
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty())
+            .map(str::to_string);
+        let listed = list_shortcuts().await;
+        match super::lpm_route(name.as_deref(), &listed) {
+            LpmRoute::Shortcut(name) => {
+                if let Err(err) = run_shortcut(&name).await {
+                    log::warn!("shortcuts run '{name}' failed ({err}); falling back to admin prompt");
+                    run_osascript_admin(!before).await?;
+                }
+            }
+            LpmRoute::OsascriptAdmin => {
+                run_osascript_admin(!before).await?;
+            }
+        }
+
+        let mut rx = super::subscribe();
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(LPM_CONFIRM_SECS);
+        loop {
+            if super::current().low_power_mode != before {
+                return Ok(super::current().low_power_mode);
+            }
+            match tokio::time::timeout_at(deadline, rx.changed()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(_)) | Err(_) => break,
+            }
+        }
+        publish_now();
+        if super::current().low_power_mode != before {
+            return Ok(super::current().low_power_mode);
+        }
+        Err("Low Power Mode did not change. Import the shortcut or approve the admin prompt.".into())
+    }
+
+    pub fn install_lpm_shortcut() -> Result<(), String> {
+        const SHORTCUT: &[u8] = include_bytes!("assets/Toggle Low Power Mode.shortcut");
+        let name = crate::settings::get_app_settings()
+            .lpm_shortcut_name
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| super::default_lpm_shortcut_name().into());
+        let safe: String = name
+            .chars()
+            .map(|ch| if ch.is_ascii_alphanumeric() || ch == ' ' { ch } else { '_' })
+            .collect();
+        let path = std::env::temp_dir().join(format!("{safe}.shortcut"));
+        std::fs::write(&path, SHORTCUT).map_err(|err| err.to_string())?;
+        std::process::Command::new("/usr/bin/open")
+            .arg(&path)
+            .spawn()
+            .map_err(|err| err.to_string())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn battery(percent: u8) -> PowerSnapshot {
+        PowerSnapshot {
+            percent: Some(percent),
+            is_charging: false,
+            on_ac: false,
+            time_to_empty_min: Some(40),
+            warning_level: BatteryWarning::None,
+            low_power_mode: false,
+            has_battery: true,
+        }
+    }
+
+    #[test]
+    fn desktop_macs_never_alert() {
+        let snap = PowerSnapshot::default();
+        assert!(!snap.has_battery);
+        assert!(!snap.is_alerting(20));
+        assert!(!snap.is_alerting(100));
+        assert!(!snap.should_watch_time_remaining(false));
+        assert!(snap.should_watch_time_remaining(true));
+    }
+
+    #[test]
+    fn discharging_below_threshold_alerts() {
+        assert!(battery(20).is_alerting(20));
+        assert!(battery(5).is_alerting(20));
+        assert!(!battery(21).is_alerting(20));
+        assert!(!battery(50).is_alerting(20));
+    }
+
+    #[test]
+    fn charging_or_ac_clears_the_alert() {
+        let mut snap = battery(8);
+        snap.is_charging = true;
+        snap.on_ac = true;
+        assert!(!snap.is_alerting(20));
+        snap.is_charging = false;
+        assert!(!snap.is_alerting(20), "AC without charge still clears");
+    }
+
+    #[test]
+    fn os_warning_alerts_even_above_threshold() {
+        let mut snap = battery(40);
+        snap.warning_level = BatteryWarning::Early;
+        assert!(snap.is_alerting(20));
+        snap.warning_level = BatteryWarning::Final;
+        assert!(snap.is_alerting(5));
+    }
+
+    #[test]
+    fn time_remaining_watch_is_gated() {
+        assert!(!battery(55).should_watch_time_remaining(false));
+        assert!(battery(30).should_watch_time_remaining(false));
+        assert!(battery(10).should_watch_time_remaining(false));
+        assert!(battery(90).should_watch_time_remaining(true));
+        let mut ac = battery(10);
+        ac.on_ac = true;
+        ac.is_charging = true;
+        assert!(!ac.should_watch_time_remaining(false));
+    }
+
+    #[test]
+    fn compact_icon_follows_charge_state() {
+        assert_eq!(battery(12).compact_icon(), "battery-low");
+        let mut charging = battery(12);
+        charging.is_charging = true;
+        assert_eq!(charging.compact_icon(), "battery-charging");
+    }
+
+    #[test]
+    fn lpm_prefers_an_installed_shortcut() {
+        let listed = vec!["Focus".into(), "Toggle Low Power Mode".into()];
+        assert_eq!(
+            lpm_route(Some("Toggle Low Power Mode"), &listed),
+            LpmRoute::Shortcut("Toggle Low Power Mode".into())
+        );
+        assert_eq!(
+            lpm_route(Some("Missing"), &listed),
+            LpmRoute::OsascriptAdmin
+        );
+        assert_eq!(lpm_route(Some("  "), &listed), LpmRoute::OsascriptAdmin);
+        assert_eq!(lpm_route(None, &listed), LpmRoute::OsascriptAdmin);
+    }
+
+    #[test]
+    fn threshold_clamps_to_a_usable_range() {
+        assert_eq!(clamp_alert_threshold(0), 5);
+        assert_eq!(clamp_alert_threshold(20), 20);
+        assert_eq!(clamp_alert_threshold(80), 80);
+        assert_eq!(clamp_alert_threshold(99), 80);
+    }
+
+    #[test]
+    fn time_remaining_and_percent_labels() {
+        assert_eq!(format_time_remaining(None), "—");
+        assert_eq!(format_time_remaining(Some(0)), "Calculating…");
+        assert_eq!(format_time_remaining(Some(12)), "12m left");
+        assert_eq!(format_time_remaining(Some(75)), "1h 15m left");
+        assert_eq!(format_percent(Some(47)), "47%");
+        assert_eq!(format_percent(None), "—");
+    }
+
+    #[test]
+    fn watch_channel_starts_as_desktop() {
+        assert_eq!(current(), PowerSnapshot::default());
+        let rx = subscribe();
+        assert_eq!(*rx.borrow(), PowerSnapshot::default());
+    }
+
+    #[test]
+    fn bundled_shortcut_is_a_plist() {
+        let bytes = include_bytes!("assets/Toggle Low Power Mode.shortcut");
+        let text = std::str::from_utf8(bytes).expect("shortcut is UTF-8 plist");
+        assert!(text.contains("WFWorkflowActions"));
+        assert!(text.contains("lowpowermode"));
+        assert!(text.contains("Toggle Low Power Mode"));
+    }
+}

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -17,10 +17,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    Battery = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +32,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::Battery,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -45,7 +47,7 @@ impl WidgetModule {
         match self {
             Self::Calendar | Self::Music => 5,
             Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
-            Self::Timers | Self::Speed | Self::Mirror => 3,
+            Self::Timers | Self::Speed | Self::Mirror | Self::Battery => 3,
         }
     }
 
@@ -53,13 +55,13 @@ impl WidgetModule {
         match self {
             Self::Calendar => 4,
             Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
-            Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
+            Self::Notes | Self::Timers | Self::Speed | Self::Agents | Self::Battery => 2,
         }
     }
 
     pub fn max_cells(self) -> u8 {
         match self {
-            Self::Timers | Self::Speed | Self::Agents | Self::Mirror => 6,
+            Self::Timers | Self::Speed | Self::Agents | Self::Mirror | Self::Battery => 6,
             _ => 8,
         }
     }
@@ -82,6 +84,7 @@ fn default_widget_order() -> Vec<WidgetModule> {
         WidgetModule::Timers,
         WidgetModule::Notes,
         WidgetModule::Speed,
+        WidgetModule::Battery,
     ]
 }
 
@@ -142,6 +145,15 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default = "default_true")]
+    pub show_battery: bool,
+    /// Percent at or below which the compact face takes over while discharging.
+    #[serde(default = "default_battery_alert_threshold")]
+    pub battery_alert_threshold: u8,
+    /// Shortcuts.app name for the one-tap LPM toggle. `None` or a missing
+    /// shortcut falls back to the osascript-admin prompt.
+    #[serde(default = "default_lpm_shortcut_name")]
+    pub lpm_shortcut_name: Option<String>,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -217,6 +229,14 @@ fn default_true() -> bool {
     true
 }
 
+fn default_battery_alert_threshold() -> u8 {
+    20
+}
+
+fn default_lpm_shortcut_name() -> Option<String> {
+    Some(crate::power::default_lpm_shortcut_name().into())
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -231,6 +251,9 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            show_battery: true,
+            battery_alert_threshold: default_battery_alert_threshold(),
+            lpm_shortcut_name: default_lpm_shortcut_name(),
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +299,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::Battery => self.show_battery,
         }
     }
 
@@ -291,6 +315,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::Battery => self.show_battery = !self.show_battery,
         }
     }
 
@@ -611,6 +636,12 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.show_battery);
+        assert_eq!(parsed.battery_alert_threshold, 20);
+        assert_eq!(
+            parsed.lpm_shortcut_name.as_deref(),
+            Some(crate::power::default_lpm_shortcut_name())
+        );
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +727,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.show_battery = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook/src/assets/icons/battery-charging.svg
+++ b/crates/nook/src/assets/icons/battery-charging.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M15 7h1a2 2 0 0 1 2 2v6a2 2 0 0 1-2 2h-2"/><path d="M6 7H4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h1"/><path d="m11 7-3 5h4l-3 5"/><line x1="22" x2="22" y1="11" y2="13"/>
+</svg>

--- a/crates/nook/src/assets/icons/battery-low.svg
+++ b/crates/nook/src/assets/icons/battery-low.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<rect width="16" height="10" x="2" y="7" rx="2" ry="2"/><line x1="22" x2="22" y1="11" y2="13"/><line x1="6" x2="6" y1="11" y2="13"/>
+</svg>

--- a/crates/nook/src/assets/icons/battery.svg
+++ b/crates/nook/src/assets/icons/battery.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<rect width="16" height="10" x="2" y="7" rx="2" ry="2"/><line x1="22" x2="22" y1="11" y2="13"/>
+</svg>

--- a/crates/nook/src/assets/icons/zap.svg
+++ b/crates/nook/src/assets/icons/zap.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -3,7 +3,7 @@
 use super::media::{album_chip, visualizer};
 use super::ui::{label, timer_text};
 use super::{CompactMode, Island};
-use crate::icons::lucide;
+use crate::icons::{lucide, lucide_color};
 use crate::theme;
 use crate::widgets;
 use gpui::{
@@ -63,6 +63,17 @@ impl Island {
             CompactMode::Observe => {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
+            CompactMode::Battery => {
+                let critical = self.power.percent.map(|p| p <= 10).unwrap_or(false)
+                    || self.power.warning_level == nook_core::power::BatteryWarning::Final;
+                let color = if critical {
+                    theme::DESTRUCTIVE
+                } else {
+                    theme::SYSTEM_ORANGE
+                };
+                lucide_color(self.power.compact_icon(), theme::COMPACT_FACE, color)
+                    .into_any_element()
+            }
             CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
             CompactMode::Idle => div().into_any_element(),
         }
@@ -104,6 +115,10 @@ impl Island {
                     _ => self.observe.firing_count().to_string(),
                 };
                 label(text, theme::BODY, true).into_any_element()
+            }
+            CompactMode::Battery => {
+                label(nook_core::power::format_percent(self.power.percent), theme::BODY, true)
+                    .into_any_element()
             }
             CompactMode::Onboard if hovered => div()
                 .id("github")
@@ -147,6 +162,7 @@ impl Island {
                 CompactMode::Files => "files",
                 CompactMode::Timer => "timer",
                 CompactMode::Observe => "observe",
+                CompactMode::Battery => "battery",
                 CompactMode::Onboard => "onboard",
             };
             row = row.child(

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, battery_card, calendar_card, notes_card, observe_card, reminders_card, speed_card,
+    timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -156,6 +157,10 @@ impl Island {
                         self.settings.cells_for(module),
                         speed_card(self.speed_mbps, self.speed_progress, self.speed_running, cx),
                     ),
+                ),
+                WidgetModule::Battery if self.settings.show_battery => add(
+                    &mut kids,
+                    cell_pane(self.settings.cells_for(module), battery_card(self, cx)),
                 ),
                 _ => {}
             }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -26,6 +26,7 @@ use nook_core::files::FileTrayItem;
 use nook_core::models::NowPlayingData;
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
+use nook_core::power::PowerSnapshot;
 use nook_core::settings::AppSettings;
 use settings::SettingsView;
 use std::time::{Duration, Instant};
@@ -38,6 +39,7 @@ pub enum CompactMode {
     Files,
     Timer,
     Observe,
+    Battery,
     Onboard,
 }
 
@@ -86,6 +88,9 @@ pub struct Island {
     pub observe: ObserveSnapshot,
     observe_history: MetricHistory,
     pub(crate) observe_hover: Option<crate::widgets::ObserveHover>,
+    pub power: PowerSnapshot,
+    pub(crate) lpm_pending: bool,
+    pub(crate) lpm_error: Option<String>,
     pub settings: AppSettings,
     pub first_run: bool,
     pub speed_mbps: Option<f64>,
@@ -213,6 +218,9 @@ impl Island {
             observe: ObserveSnapshot::default(),
             observe_history: nook_core::observe::load_history(),
             observe_hover: None,
+            power: nook_core::power::current(),
+            lpm_pending: false,
+            lpm_error: None,
             settings,
             first_run,
             speed_mbps: None,
@@ -690,6 +698,81 @@ impl Island {
                 .await;
         })
         .detach();
+
+        // Power is push-based: the watch fires on IOKit / LPM notifications.
+        cx.spawn(async move |this, cx| {
+            let mut rx = nook_core::power::subscribe();
+            loop {
+                let snap = *rx.borrow();
+                if this
+                    .update(cx, |this, cx| {
+                        this.apply_power_snapshot(snap, cx);
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+                let (alive, next_rx) = cx
+                    .background_executor()
+                    .spawn(async move {
+                        let ok = nook_core::runtime().block_on(rx.changed()).is_ok();
+                        (ok, rx)
+                    })
+                    .await;
+                rx = next_rx;
+                if !alive {
+                    break;
+                }
+            }
+        })
+        .detach();
+    }
+
+    fn apply_power_snapshot(&mut self, snap: PowerSnapshot, cx: &mut Context<Self>) {
+        let was_alert = self.has_battery_alert();
+        self.power = snap;
+        let now_alert = self.has_battery_alert();
+        if !was_alert && now_alert {
+            self.preferred = Some(CompactMode::Battery);
+            nook_core::haptics::trigger(None);
+        } else if was_alert && !now_alert && self.preferred == Some(CompactMode::Battery) {
+            self.preferred = None;
+        }
+        nook_core::power::set_detail_watch(self.expanded && self.settings.show_battery);
+        cx.notify();
+    }
+
+    pub(crate) fn has_battery_alert(&self) -> bool {
+        self.settings.show_battery
+            && self.power.is_alerting(nook_core::power::clamp_alert_threshold(
+                self.settings.battery_alert_threshold,
+            ))
+    }
+
+    pub(crate) fn toggle_low_power_mode(&mut self, cx: &mut Context<Self>) {
+        if self.lpm_pending {
+            return;
+        }
+        self.lpm_pending = true;
+        self.lpm_error = None;
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async { nook_core::runtime().block_on(nook_core::power::toggle_low_power_mode()) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.lpm_pending = false;
+                match result {
+                    Ok(_) => this.lpm_error = None,
+                    Err(err) => this.lpm_error = Some(err),
+                }
+                this.power = nook_core::power::current();
+                nook_core::power::set_detail_watch(this.expanded && this.settings.show_battery);
+                cx.notify();
+            });
+        })
+        .detach();
     }
 
     /// Merge a fresh poll into the island: extend the local sample history and
@@ -862,6 +945,9 @@ impl Island {
 
     fn available_modes(&self) -> Vec<CompactMode> {
         let mut modes = Vec::new();
+        if self.has_battery_alert() {
+            modes.push(CompactMode::Battery);
+        }
         if self.has_observe_outage() {
             modes.push(CompactMode::Observe);
         }
@@ -1082,6 +1168,7 @@ impl Island {
             self.close_notes_editor(cx);
             self.stop_mirror(cx);
         }
+        nook_core::power::set_detail_watch(self.expanded && self.settings.show_battery);
         nook_core::haptics::trigger(None);
         cx.notify();
     }
@@ -1155,10 +1242,12 @@ impl Island {
         } else if !self.expanded && ay > 0.0 {
             // AppKit scrollingDeltaY: two-finger swipe *down* is positive.
             self.expanded = true;
+            nook_core::power::set_detail_watch(self.settings.show_battery);
             nook_core::haptics::trigger(None);
             true
         } else if self.expanded && ay < 0.0 {
             self.expanded = false;
+            nook_core::power::set_detail_watch(false);
             nook_core::haptics::trigger(None);
             true
         } else {
@@ -1452,6 +1541,9 @@ mod tests {
             observe: ObserveSnapshot::default(),
             observe_history: HashMap::new(),
             observe_hover: None,
+            power: PowerSnapshot::default(),
+            lpm_pending: false,
+            lpm_error: None,
             settings: AppSettings::default(),
             first_run: false,
             speed_mbps: None,
@@ -1758,6 +1850,42 @@ mod tests {
         );
         assert_eq!(island.mode(), CompactMode::Observe);
         island.settings.show_observe = false;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn available_modes_battery_only_while_alerting() {
+        let mut island = test_island();
+        island.settings.show_battery = true;
+        island.settings.battery_alert_threshold = 20;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+        island.power = PowerSnapshot {
+            percent: Some(12),
+            is_charging: false,
+            on_ac: false,
+            time_to_empty_min: Some(40),
+            warning_level: nook_core::power::BatteryWarning::None,
+            low_power_mode: false,
+            has_battery: true,
+        };
+        assert_eq!(
+            island.available_modes(),
+            vec![CompactMode::Battery, CompactMode::Idle]
+        );
+        assert_eq!(island.mode(), CompactMode::Battery);
+        island.power.is_charging = true;
+        island.power.on_ac = true;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+        island.power.is_charging = false;
+        island.power.on_ac = false;
+        island.power.has_battery = false;
+        assert_eq!(
+            island.available_modes(),
+            vec![CompactMode::Idle],
+            "desktop Macs hide the compact battery face"
+        );
+        island.power.has_battery = true;
+        island.settings.show_battery = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
     }
 

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -131,6 +131,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Battery => "Battery",
         }
     }
 
@@ -146,6 +147,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::Battery => "battery",
         }
     }
 
@@ -161,6 +163,11 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::Battery => format!(
+                "Alert at {}%",
+                nook_core::power::clamp_alert_threshold(settings.battery_alert_threshold)
+            )
+            .into(),
         }
     }
 
@@ -184,6 +191,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Battery => "Battery",
         }
     }
 }
@@ -998,6 +1006,23 @@ impl SettingsView {
                     .into_any_element(),
                 );
             }
+            WidgetModule::Battery => {
+                rows.push(threshold_row(settings.battery_alert_threshold, cx).into_any_element());
+                rows.push(
+                    action_row(
+                        "lpm-shortcut",
+                        "Low Power Mode",
+                        "Install shortcut",
+                        cx,
+                        |_, _, _| {
+                            if let Err(err) = nook_core::power::install_lpm_shortcut() {
+                                log::warn!("install LPM shortcut: {err}");
+                            }
+                        },
+                    )
+                    .into_any_element(),
+                );
+            }
             _ => {}
         }
 
@@ -1356,6 +1381,9 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::Battery => {
+            "Low-battery takeover on the compact face. Low Power Mode uses a one-time Shortcuts import, then falls back to an admin prompt.".into()
+        }
     }
 }
 
@@ -1435,6 +1463,70 @@ fn action_row(
             cx,
             on_click,
         ))
+}
+
+fn threshold_row(value: u8, cx: &mut Context<SettingsView>) -> impl IntoElement {
+    let value = nook_core::power::clamp_alert_threshold(value);
+    settings_row("battery-threshold")
+        .child(label("Alert below", theme::BODY, true))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(8.))
+                .child(stepper_btn("thr-dec", "−", cx, move |_, _, cx| {
+                    nook_core::settings::tweak_app_settings(|s| {
+                        s.battery_alert_threshold =
+                            nook_core::power::clamp_alert_threshold(
+                                s.battery_alert_threshold.saturating_sub(5),
+                            );
+                    });
+                    cx.notify();
+                }))
+                .child(
+                    div()
+                        .w(px(44.))
+                        .flex()
+                        .justify_center()
+                        .child(label(format!("{value}%"), theme::BODY, true)),
+                )
+                .child(stepper_btn("thr-inc", "+", cx, move |_, _, cx| {
+                    nook_core::settings::tweak_app_settings(|s| {
+                        s.battery_alert_threshold =
+                            nook_core::power::clamp_alert_threshold(
+                                s.battery_alert_threshold.saturating_add(5),
+                            );
+                    });
+                    cx.notify();
+                })),
+        )
+}
+
+fn stepper_btn(
+    id: &'static str,
+    caption: &'static str,
+    cx: &mut Context<SettingsView>,
+    on_click: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .size(px(theme::HIT_MIN))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded(px(6.))
+        .bg(theme::FILL)
+        .hover(|s| s.bg(theme::FILL_SECONDARY))
+        .active(|s| s.opacity(0.85))
+        .cursor(CursorStyle::PointingHand)
+        .child(label(caption, theme::BODY, true))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, window, cx| {
+                cx.stop_propagation();
+                on_click(this, window, cx);
+            }),
+        )
 }
 
 fn toggle_row(
@@ -1705,6 +1797,20 @@ mod tests {
     }
 
     #[test]
+    fn battery_subtitle_shows_the_alert_threshold() {
+        let mut settings = AppSettings::default();
+        assert_eq!(
+            WidgetModule::Battery.subtitle(&settings).as_ref(),
+            "Alert at 20%"
+        );
+        settings.battery_alert_threshold = 5;
+        assert_eq!(
+            WidgetModule::Battery.subtitle(&settings).as_ref(),
+            "Alert at 5%"
+        );
+    }
+
+    #[test]
     fn observe_subtitle_counts_pinned_metrics() {
         assert_eq!(observe_subtitle(0).as_ref(), "Prometheus");
         assert_eq!(observe_subtitle(1).as_ref(), "1 metric");
@@ -1727,6 +1833,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "Battery",
             ]
         );
         assert!(!names

--- a/crates/nook/src/theme.rs
+++ b/crates/nook/src/theme.rs
@@ -122,7 +122,13 @@ pub const DESTRUCTIVE: Rgba = Rgba {
     b: 0.227,
     a: 1.0,
 };
-#[allow(dead_code)]
+/// Dark-mode systemOrange for low-battery (not yet critical) compact faces.
+pub const SYSTEM_ORANGE: Rgba = Rgba {
+    r: 1.0,
+    g: 0.584,
+    b: 0.0,
+    a: 1.0,
+};
 pub const SUCCESS: Rgba = Rgba {
     r: 0.188,
     g: 0.820,

--- a/crates/nook/src/widgets/battery.rs
+++ b/crates/nook/src/widgets/battery.rs
@@ -1,0 +1,168 @@
+//! Battery Nook pane: percent, time remaining, charging state, LPM toggle.
+
+use crate::icons::lucide_color;
+use crate::island::ui::{nook_display, nook_pane};
+use crate::island::Island;
+use crate::theme;
+use gpui::{div, prelude::*, px, rgba, Context, CursorStyle, FontWeight, MouseButton, MouseDownEvent};
+use nook_core::power::{self, PowerSnapshot};
+
+pub(crate) fn battery_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let snap = island.power;
+    let pending = island.lpm_pending;
+    let error = island.lpm_error.clone();
+
+    nook_pane("nook-battery")
+        .w_full()
+        .child(
+            div()
+                .flex_1()
+                .min_h(px(0.))
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(px(10.))
+                .child(gauge(snap))
+                .child(lpm_btn(snap.low_power_mode, pending, cx)),
+        )
+        .child(status_line(snap, error.as_deref()))
+}
+
+fn gauge(snap: PowerSnapshot) -> impl IntoElement {
+    if !snap.has_battery {
+        return div()
+            .flex()
+            .flex_col()
+            .gap(px(2.))
+            .child(nook_display("AC"))
+            .child(
+                div()
+                    .text_size(px(11.))
+                    .line_height(px(14.))
+                    .font_weight(FontWeight::MEDIUM)
+                    .text_color(theme::SECONDARY_LABEL)
+                    .child("No battery"),
+            );
+    }
+
+    let tint = if snap.is_alerting(20) {
+        theme::DESTRUCTIVE
+    } else if snap.is_charging {
+        theme::SUCCESS
+    } else {
+        theme::LABEL
+    };
+
+    div()
+        .flex()
+        .items_end()
+        .gap(px(8.))
+        .child(
+            nook_display(power::format_percent(snap.percent)).text_color(tint),
+        )
+        .child(
+            div()
+                .pb(px(4.))
+                .flex()
+                .flex_col()
+                .child(
+                    div()
+                        .text_size(px(11.))
+                        .line_height(px(14.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme::SECONDARY_LABEL)
+                        .child(if snap.is_charging {
+                            "Charging"
+                        } else if snap.on_ac {
+                            "On AC"
+                        } else {
+                            "On battery"
+                        }),
+                )
+                .child(
+                    div()
+                        .text_size(px(11.))
+                        .line_height(px(14.))
+                        .text_color(theme::TERTIARY_LABEL)
+                        .child(power::format_time_remaining(snap.time_to_empty_min)),
+                ),
+        )
+}
+
+fn status_line(snap: PowerSnapshot, error: Option<&str>) -> impl IntoElement {
+    let text = if let Some(err) = error {
+        err.to_string()
+    } else if snap.low_power_mode {
+        "Low Power Mode on".into()
+    } else if !snap.has_battery {
+        "Low Power Mode still works on this Mac.".into()
+    } else {
+        String::new()
+    };
+    div()
+        .w_full()
+        .text_size(px(11.))
+        .line_height(px(14.))
+        .font_weight(FontWeight::MEDIUM)
+        .text_color(if error.is_some() {
+            theme::DESTRUCTIVE
+        } else {
+            theme::TERTIARY_LABEL
+        })
+        .child(text)
+}
+
+fn lpm_btn(on: bool, pending: bool, cx: &mut Context<Island>) -> impl IntoElement {
+    let label = if pending {
+        "…"
+    } else if on {
+        "LPM on"
+    } else {
+        "LPM"
+    };
+    div()
+        .id("battery-lpm")
+        .h(px(theme::HIT_MIN))
+        .px(px(10.))
+        .rounded(px(8.))
+        .flex()
+        .items_center()
+        .gap(px(6.))
+        .bg(if on {
+            rgba(0xf59e0b33)
+        } else {
+            rgba(0xffffff14)
+        })
+        .opacity(if pending { 0.7 } else { 1.0 })
+        .hover(|s| if pending { s } else { s.bg(rgba(0xffffff22)) })
+        .active(|s| s.opacity(0.85))
+        .cursor(CursorStyle::PointingHand)
+        .child(lucide_color(
+            "zap",
+            14.0,
+            if on {
+                theme::SYSTEM_ORANGE
+            } else {
+                theme::LABEL
+            },
+        ))
+        .child(
+            div()
+                .text_size(px(12.))
+                .line_height(px(16.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(if on {
+                    theme::SYSTEM_ORANGE
+                } else {
+                    theme::LABEL
+                })
+                .child(label),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                this.toggle_low_power_mode(cx);
+            }),
+        )
+}

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -1,6 +1,7 @@
 //! Expanded widget cards. One file per widget so each can be edited on its own.
 
 mod agents;
+mod battery;
 mod calendar;
 mod notes;
 mod notes_editor;
@@ -12,6 +13,7 @@ mod timers;
 pub(crate) use agents::{
     agents_card, compact_left as agents_compact_left, compact_right as agents_compact_right,
 };
+pub(crate) use battery::battery_card;
 pub(crate) use calendar::calendar_card;
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};


### PR DESCRIPTION
## Summary

Implements openNook WP05 only: event-driven battery alerts and a one-tap Low Power Mode toggle.

- New `nook-core` `power` module: IOKit `IOPSCopyPowerSources*` plus `notify_register_dispatch` for `powersources.source` / `lowbattery`, with `timeremaining` subscribed only on the expanded battery card or while discharging ≤30%. 250 ms debounce before publishing a `tokio::sync::watch` snapshot. LPM state via `NSProcessInfo` + `NSProcessInfoPowerStateDidChangeNotification`.
- `CompactMode::Battery` takes over the compact face (red/orange icon + percent) when discharging at or below the Settings threshold (default 20%) or when the OS posts a low-battery warning. Auto-clears when charging resumes. Haptic on rising edge, same pattern as Observe.
- Expanded battery card: percent, time remaining, charging/AC state, and an LPM button. Desktop Macs (empty IOKit list) hide the gauge and keep the toggle.
- LPM write path: `/usr/bin/shortcuts run` when the configured shortcut exists, otherwise `osascript` + `pmset -a lowpowermode` with administrator privileges. Success is confirmed by the NSProcessInfo flag, not the command exit code.
- Settings: enable toggle (default on), alert threshold stepper, and “Install shortcut” which opens the bundled `.shortcut` for a one-time Shortcuts.app confirm.

No new polling loops. Off-macOS stubs degrade to a desktop snapshot so Linux CI stays green.

## Test plan

- [x] `cargo test -p nook -p nook-core` (83 + 87 tests, all green on Linux)
- [ ] On a MacBook: unplug and drop below the threshold — compact face takes over, haptic fires, charging clears it
- [ ] Settings → Battery: change threshold, toggle the widget off, Install shortcut then tap LPM
- [ ] Desktop Mac / no battery: card shows AC + LPM only, no compact takeover
- [ ] Missing shortcut: LPM button falls back to the admin password dialog
