### PR TITLE
WP22: Window Snap hotkeys + tier-1 Thaw menu-bar hiding

### DIFF
--- a/crates/nook-core/src/hotkeys.rs
+++ b/crates/nook-core/src/hotkeys.rs
@@ -147,13 +147,17 @@ fn register(kind: SnapKind, hotkey: Hotkey) {
         );
         return;
     }
-    HOTKEYS.lock().unwrap_or_else(|e| e.into_inner()).push(href);
+    HOTKEYS
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .push(href as usize);
 }
 
 #[cfg(target_os = "macos")]
 fn unregister_all() {
     let mut refs = HOTKEYS.lock().unwrap_or_else(|e| e.into_inner());
     for href in refs.drain(..) {
+        let href = href as EventHotKeyRef;
         if !href.is_null() {
             unsafe {
                 let _ = UnregisterEventHotKey(href);
@@ -283,8 +287,10 @@ extern "C" {
 
 #[cfg(target_os = "macos")]
 static HANDLER: std::sync::Once = std::sync::Once::new();
+/// Carbon `EventHotKeyRef` stored as `usize` so the static is `Sync`
+/// (`*mut c_void` is not `Send`).
 #[cfg(target_os = "macos")]
-static HOTKEYS: std::sync::Mutex<Vec<EventHotKeyRef>> = std::sync::Mutex::new(Vec::new());
+static HOTKEYS: std::sync::Mutex<Vec<usize>> = std::sync::Mutex::new(Vec::new());
 
 #[cfg(test)]
 mod tests {

--- a/crates/nook-core/src/hotkeys.rs
+++ b/crates/nook-core/src/hotkeys.rs
@@ -26,6 +26,7 @@ pub const KEY_I: u16 = 34;
 pub const KEY_J: u16 = 38;
 pub const KEY_K: u16 = 40;
 
+#[cfg(target_os = "macos")]
 const SIGNATURE: u32 = 0x4E4F4F4B; // 'NOOK'
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/nook-core/src/hotkeys.rs
+++ b/crates/nook-core/src/hotkeys.rs
@@ -1,0 +1,320 @@
+//! Global snap hotkeys via Carbon `RegisterEventHotKey`.
+//!
+//! Callback-only: no poll loop, no TCC. The handler consumes the keystroke
+//! and calls [`crate::window_snap::snap_frontmost`]. Registration is a
+//! one-shot on settings change / launch.
+
+use crate::window_snap::SnapKind;
+
+/// Carbon `controlKey`.
+pub const MOD_CONTROL: u32 = 1 << 12;
+/// Carbon `optionKey`.
+pub const MOD_OPTION: u32 = 1 << 11;
+/// Carbon `cmdKey`.
+pub const MOD_COMMAND: u32 = 1 << 8;
+/// Carbon `shiftKey`.
+pub const MOD_SHIFT: u32 = 1 << 9;
+
+/// Virtual key codes (HIToolbox).
+pub const KEY_LEFT: u16 = 123;
+pub const KEY_RIGHT: u16 = 124;
+pub const KEY_DOWN: u16 = 125;
+pub const KEY_UP: u16 = 126;
+pub const KEY_RETURN: u16 = 36;
+pub const KEY_U: u16 = 32;
+pub const KEY_I: u16 = 34;
+pub const KEY_J: u16 = 38;
+pub const KEY_K: u16 = 40;
+
+const SIGNATURE: u32 = 0x4E4F4F4B; // 'NOOK'
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Hotkey {
+    pub key_code: u16,
+    pub modifiers: u32,
+}
+
+impl Hotkey {
+    pub const fn new(key_code: u16, modifiers: u32) -> Self {
+        Self {
+            key_code,
+            modifiers,
+        }
+    }
+
+    pub fn display(self) -> String {
+        let mut parts = String::new();
+        if self.modifiers & MOD_CONTROL != 0 {
+            parts.push('⌃');
+        }
+        if self.modifiers & MOD_OPTION != 0 {
+            parts.push('⌥');
+        }
+        if self.modifiers & MOD_SHIFT != 0 {
+            parts.push('⇧');
+        }
+        if self.modifiers & MOD_COMMAND != 0 {
+            parts.push('⌘');
+        }
+        parts.push_str(key_name(self.key_code));
+        parts
+    }
+}
+
+fn key_name(code: u16) -> &'static str {
+    match code {
+        KEY_LEFT => "←",
+        KEY_RIGHT => "→",
+        KEY_UP => "↑",
+        KEY_DOWN => "↓",
+        KEY_RETURN => "↩",
+        KEY_U => "U",
+        KEY_I => "I",
+        KEY_J => "J",
+        KEY_K => "K",
+        _ => "?",
+    }
+}
+
+/// Rectangle-style defaults: Control + Option + arrows / U I J K / Return.
+pub fn default_bindings() -> [(SnapKind, Hotkey); 9] {
+    let mods = MOD_CONTROL | MOD_OPTION;
+    [
+        (SnapKind::LeftHalf, Hotkey::new(KEY_LEFT, mods)),
+        (SnapKind::RightHalf, Hotkey::new(KEY_RIGHT, mods)),
+        (SnapKind::TopHalf, Hotkey::new(KEY_UP, mods)),
+        (SnapKind::BottomHalf, Hotkey::new(KEY_DOWN, mods)),
+        (SnapKind::TopLeft, Hotkey::new(KEY_U, mods)),
+        (SnapKind::TopRight, Hotkey::new(KEY_I, mods)),
+        (SnapKind::BottomLeft, Hotkey::new(KEY_J, mods)),
+        (SnapKind::BottomRight, Hotkey::new(KEY_K, mods)),
+        (SnapKind::Maximize, Hotkey::new(KEY_RETURN, mods)),
+    ]
+}
+
+/// Register (or tear down) Carbon hotkeys from the current settings.
+/// Safe to call more than once; must run on the main thread on macOS.
+pub fn install() {
+    sync();
+}
+
+pub fn sync() {
+    #[cfg(target_os = "macos")]
+    {
+        sync_macos();
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn sync_macos() {
+    unregister_all();
+    if !crate::settings::get_app_settings().window_snap_enabled {
+        return;
+    }
+    ensure_handler();
+    for (kind, hotkey) in default_bindings() {
+        register(kind, hotkey);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn register(kind: SnapKind, hotkey: Hotkey) {
+    let target = unsafe { GetEventDispatcherTarget() };
+    if target.is_null() {
+        log::warn!("Carbon event target missing; snap hotkeys not registered");
+        return;
+    }
+    let id = EventHotKeyID {
+        signature: SIGNATURE,
+        id: kind as u32 + 1,
+    };
+    let mut href: EventHotKeyRef = std::ptr::null_mut();
+    let status = unsafe {
+        RegisterEventHotKey(
+            u32::from(hotkey.key_code),
+            hotkey.modifiers,
+            id,
+            target,
+            0,
+            &mut href,
+        )
+    };
+    if status != 0 || href.is_null() {
+        log::warn!(
+            "RegisterEventHotKey {} failed ({status})",
+            kind.label()
+        );
+        return;
+    }
+    HOTKEYS.lock().unwrap_or_else(|e| e.into_inner()).push(href);
+}
+
+#[cfg(target_os = "macos")]
+fn unregister_all() {
+    let mut refs = HOTKEYS.lock().unwrap_or_else(|e| e.into_inner());
+    for href in refs.drain(..) {
+        if !href.is_null() {
+            unsafe {
+                let _ = UnregisterEventHotKey(href);
+            }
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_handler() {
+    HANDLER.call_once(|| {
+        let target = unsafe { GetEventDispatcherTarget() };
+        if target.is_null() {
+            log::error!("Carbon event target missing; cannot install snap handler");
+            return;
+        }
+        let spec = EventTypeSpec {
+            event_class: EVENT_CLASS_KEYBOARD,
+            event_kind: EVENT_HOT_KEY_PRESSED,
+        };
+        let mut href: *mut std::ffi::c_void = std::ptr::null_mut();
+        let status = unsafe {
+            InstallEventHandler(
+                target,
+                hotkey_handler,
+                1,
+                &spec,
+                std::ptr::null_mut(),
+                &mut href,
+            )
+        };
+        if status != 0 {
+            log::error!("InstallEventHandler for snap hotkeys failed ({status})");
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+extern "C" fn hotkey_handler(
+    _next: *mut std::ffi::c_void,
+    event: *mut std::ffi::c_void,
+    _user: *mut std::ffi::c_void,
+) -> i32 {
+    let mut id = EventHotKeyID {
+        signature: 0,
+        id: 0,
+    };
+    let status = unsafe {
+        GetEventParameter(
+            event,
+            EVENT_PARAM_DIRECT_OBJECT,
+            TYPE_EVENT_HOT_KEY_ID,
+            std::ptr::null_mut(),
+            std::mem::size_of::<EventHotKeyID>() as u32,
+            std::ptr::null_mut(),
+            &mut id as *mut EventHotKeyID as *mut std::ffi::c_void,
+        )
+    };
+    if status == 0 && id.signature == SIGNATURE {
+        if let Some(kind) = SnapKind::from_u8(id.id.saturating_sub(1) as u8) {
+            if let Err(err) = crate::window_snap::snap_frontmost(kind) {
+                log::debug!("snap {} skipped: {err:?}", kind.label());
+            }
+        }
+    }
+    0
+}
+
+#[cfg(target_os = "macos")]
+const EVENT_CLASS_KEYBOARD: u32 = 0x6B65_7962; // 'keyb'
+#[cfg(target_os = "macos")]
+const EVENT_HOT_KEY_PRESSED: u32 = 5;
+#[cfg(target_os = "macos")]
+const EVENT_PARAM_DIRECT_OBJECT: u32 = 0x2D2D_2D2D; // '----'
+#[cfg(target_os = "macos")]
+const TYPE_EVENT_HOT_KEY_ID: u32 = 0x686B_6964; // 'hkid'
+
+#[cfg(target_os = "macos")]
+type EventHotKeyRef = *mut std::ffi::c_void;
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct EventHotKeyID {
+    signature: u32,
+    id: u32,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+struct EventTypeSpec {
+    event_class: u32,
+    event_kind: u32,
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "Carbon", kind = "framework")]
+extern "C" {
+    fn GetEventDispatcherTarget() -> *mut std::ffi::c_void;
+    fn InstallEventHandler(
+        target: *mut std::ffi::c_void,
+        handler: extern "C" fn(*mut std::ffi::c_void, *mut std::ffi::c_void, *mut std::ffi::c_void) -> i32,
+        num_types: u32,
+        list: *const EventTypeSpec,
+        user_data: *mut std::ffi::c_void,
+        out_ref: *mut *mut std::ffi::c_void,
+    ) -> i32;
+    fn RegisterEventHotKey(
+        key_code: u32,
+        modifiers: u32,
+        hot_key_id: EventHotKeyID,
+        target: *mut std::ffi::c_void,
+        options: u32,
+        out_ref: *mut EventHotKeyRef,
+    ) -> i32;
+    fn UnregisterEventHotKey(hot_key: EventHotKeyRef) -> i32;
+    fn GetEventParameter(
+        event: *mut std::ffi::c_void,
+        name: u32,
+        desired_type: u32,
+        actual_type: *mut u32,
+        buffer_size: u32,
+        actual_size: *mut u32,
+        buffer: *mut std::ffi::c_void,
+    ) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+static HANDLER: std::sync::Once = std::sync::Once::new();
+#[cfg(target_os = "macos")]
+static HOTKEYS: std::sync::Mutex<Vec<EventHotKeyRef>> = std::sync::Mutex::new(Vec::new());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn default_bindings_are_unique() {
+        let bindings = default_bindings();
+        assert_eq!(bindings.len(), SnapKind::ALL.len());
+        let mut keys = HashSet::new();
+        let mut kinds = HashSet::new();
+        for (kind, hotkey) in bindings {
+            assert!(kinds.insert(kind), "duplicate snap kind {kind:?}");
+            assert!(
+                keys.insert((hotkey.key_code, hotkey.modifiers)),
+                "duplicate hotkey {:?}",
+                hotkey.display()
+            );
+            assert!(hotkey.modifiers & MOD_CONTROL != 0);
+            assert!(hotkey.modifiers & MOD_OPTION != 0);
+        }
+    }
+
+    #[test]
+    fn display_uses_mac_glyphs() {
+        let left = Hotkey::new(KEY_LEFT, MOD_CONTROL | MOD_OPTION);
+        assert_eq!(left.display(), "⌃⌥←");
+        let max = Hotkey::new(KEY_RETURN, MOD_CONTROL | MOD_OPTION);
+        assert_eq!(max.display(), "⌃⌥↩");
+        let corner = Hotkey::new(KEY_U, MOD_CONTROL | MOD_OPTION);
+        assert_eq!(corner.display(), "⌃⌥U");
+    }
+}

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,8 +10,10 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
+pub mod hotkeys;
 #[cfg(target_os = "macos")]
 mod mediaremote;
+pub mod menubar;
 pub mod models;
 pub mod mouse;
 pub mod notch;
@@ -21,6 +23,7 @@ pub mod occupancy;
 pub mod settings;
 pub mod utils;
 pub mod widgets;
+pub mod window_snap;
 
 pub use models::{NotchInfo, NowPlayingData};
 pub use settings::{AppSettings, WindowSettings};
@@ -64,4 +67,11 @@ pub fn init() {
         audio::setup_audio_monitoring();
         mouse::start_polling();
     });
+}
+
+/// Carbon snap hotkeys + Thaw separator. Call on the AppKit main thread
+/// after the Nook status item exists so the separator sits to its left.
+pub fn install_window_management() {
+    hotkeys::install();
+    menubar::install();
 }

--- a/crates/nook-core/src/menubar.rs
+++ b/crates/nook-core/src/menubar.rs
@@ -1,0 +1,207 @@
+//! Tier-1 Thaw: hide other menu-bar extras by stretching our own separator.
+//!
+//! Other processes' `NSStatusItem`s are untouchable. Dozer / Hidden Bar / Ice
+//! all do the same public trick: a separator item whose `length` is set to a
+//! huge value so everything the user ⌘-dragged to its *left* is pushed past
+//! the screen edge. Show restores a few points. No TCC, no idle work, no
+//! Screen Recording (Ice-bar capture is a later flag).
+
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+
+/// `NSStatusItem` length that shoves left-side extras off the display.
+pub const HIDDEN_LENGTH: f64 = 10_000.0;
+/// `NSVariableStatusItemLength` — shrinks to the chevron while extras are shown.
+pub const SHOWN_LENGTH: f64 = -1.0;
+
+static INSTALLED: AtomicBool = AtomicBool::new(false);
+static HIDDEN: AtomicBool = AtomicBool::new(false);
+
+/// Length the separator should use for this settings pair.
+pub fn desired_length(enabled: bool, hidden: bool) -> Option<f64> {
+    if !enabled {
+        return None;
+    }
+    Some(if hidden { HIDDEN_LENGTH } else { SHOWN_LENGTH })
+}
+
+pub fn is_hidden() -> bool {
+    HIDDEN.load(Ordering::Relaxed)
+}
+
+/// Create / remove / resize the separator from the current settings.
+/// Main-thread only (AppKit). Does not recreate an existing item so a user's
+/// ⌘-drag arrangement survives hide/show toggles.
+pub fn install() {
+    sync();
+}
+
+pub fn sync() {
+    #[cfg(target_os = "macos")]
+    {
+        sync_macos();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let settings = crate::settings::get_app_settings();
+        HIDDEN.store(settings.thaw_enabled && settings.thaw_hidden, Ordering::Relaxed);
+        INSTALLED.store(settings.thaw_enabled, Ordering::Relaxed);
+    }
+}
+
+/// Flip hide/show and persist. No-op when Thaw is off.
+pub fn toggle() {
+    crate::settings::tweak_app_settings(|settings| {
+        if settings.thaw_enabled {
+            settings.thaw_hidden = !settings.thaw_hidden;
+        }
+    });
+}
+
+#[cfg(target_os = "macos")]
+static SEPARATOR: AtomicPtr<objc2::runtime::AnyObject> =
+    AtomicPtr::new(std::ptr::null_mut());
+
+#[cfg(target_os = "macos")]
+fn sync_macos() {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    let settings = crate::settings::get_app_settings();
+    if !settings.thaw_enabled {
+        remove_item();
+        HIDDEN.store(false, Ordering::Relaxed);
+        return;
+    }
+    ensure_item();
+    apply_length(settings.thaw_hidden);
+    HIDDEN.store(settings.thaw_hidden, Ordering::Relaxed);
+}
+
+#[cfg(target_os = "macos")]
+fn ensure_item() {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    if !SEPARATOR.load(Ordering::Relaxed).is_null() {
+        INSTALLED.store(true, Ordering::Relaxed);
+        return;
+    }
+    install_target();
+    unsafe {
+        let bar: *mut AnyObject = msg_send![class!(NSStatusBar), systemStatusBar];
+        if bar.is_null() {
+            log::error!("NSStatusBar missing; Thaw separator not created");
+            return;
+        }
+        let item: *mut AnyObject = msg_send![bar, statusItemWithLength: SHOWN_LENGTH];
+        if item.is_null() {
+            log::error!("failed to create Thaw NSStatusItem");
+            return;
+        }
+        let _: *mut AnyObject = msg_send![item, retain];
+        SEPARATOR.store(item, Ordering::Relaxed);
+
+        let title: *mut AnyObject =
+            msg_send![class!(NSString), stringWithUTF8String: c"\u{25C1}".as_ptr()];
+        let button: *mut AnyObject = msg_send![item, button];
+        if !button.is_null() {
+            let _: () = msg_send![button, setTitle: title];
+            if let Some(cls) = objc2::runtime::AnyClass::get(c"NookThawTarget") {
+                let target: *mut AnyObject = msg_send![cls, new];
+                if !target.is_null() {
+                    let _: () = msg_send![button, setTarget: target];
+                    let _: () = msg_send![button, setAction: sel!(toggleThaw:)];
+                }
+            }
+        }
+        INSTALLED.store(true, Ordering::Relaxed);
+        log::info!("thaw separator installed");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn apply_length(hidden: bool) {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    let item = SEPARATOR.load(Ordering::Relaxed);
+    if item.is_null() {
+        return;
+    }
+    let length = if hidden { HIDDEN_LENGTH } else { SHOWN_LENGTH };
+    unsafe {
+        let _: () = msg_send![item, setLength: length];
+        let title = if hidden { c"\u{25B7}" } else { c"\u{25C1}" };
+        let ns: *mut AnyObject = msg_send![class!(NSString), stringWithUTF8String: title.as_ptr()];
+        let button: *mut AnyObject = msg_send![item, button];
+        if !button.is_null() && !ns.is_null() {
+            let _: () = msg_send![button, setTitle: ns];
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn remove_item() {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    let item = SEPARATOR.swap(std::ptr::null_mut(), Ordering::Relaxed);
+    INSTALLED.store(false, Ordering::Relaxed);
+    if item.is_null() {
+        return;
+    }
+    unsafe {
+        let bar: *mut AnyObject = msg_send![class!(NSStatusBar), systemStatusBar];
+        if !bar.is_null() {
+            let _: () = msg_send![bar, removeStatusItem: item];
+        }
+        let _: () = msg_send![item, release];
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn install_target() {
+    use objc2::ffi::{class_addMethod, objc_allocateClassPair, objc_registerClassPair};
+    use objc2::runtime::{AnyClass, AnyObject, Imp, Sel};
+    use objc2::{class, sel};
+    use std::ffi::CString;
+
+    unsafe {
+        if AnyClass::get(c"NookThawTarget").is_some() {
+            return;
+        }
+        extern "C" fn toggle_thaw(_this: *mut AnyObject, _cmd: Sel, _sender: *mut AnyObject) {
+            toggle();
+        }
+        let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
+        let cls = objc_allocateClassPair(super_cls, c"NookThawTarget".as_ptr(), 0);
+        if cls.is_null() {
+            log::error!("could not allocate NookThawTarget");
+            return;
+        }
+        let types = CString::new("v@:@").unwrap();
+        let imp: Imp =
+            std::mem::transmute(toggle_thaw as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject));
+        let _ = class_addMethod(cls, sel!(toggleThaw:), imp, types.as_ptr());
+        objc_registerClassPair(cls);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn desired_length_is_none_when_disabled() {
+        assert_eq!(desired_length(false, false), None);
+        assert_eq!(desired_length(false, true), None);
+    }
+
+    #[test]
+    fn desired_length_stretches_only_while_hidden() {
+        assert_eq!(desired_length(true, false), Some(SHOWN_LENGTH));
+        assert_eq!(desired_length(true, true), Some(HIDDEN_LENGTH));
+        assert!(HIDDEN_LENGTH > 1_000.0);
+        assert!(SHOWN_LENGTH < 0.0);
+    }
+}

--- a/crates/nook-core/src/menubar.rs
+++ b/crates/nook-core/src/menubar.rs
@@ -6,7 +6,7 @@
 //! the screen edge. Show restores a few points. No TCC, no idle work, no
 //! Screen Recording (Ice-bar capture is a later flag).
 
-use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 /// `NSStatusItem` length that shoves left-side extras off the display.
 pub const HIDDEN_LENGTH: f64 = 10_000.0;

--- a/crates/nook-core/src/menubar.rs
+++ b/crates/nook-core/src/menubar.rs
@@ -7,6 +7,8 @@
 //! Screen Recording (Ice-bar capture is a later flag).
 
 use std::sync::atomic::{AtomicBool, Ordering};
+#[cfg(target_os = "macos")]
+use std::sync::atomic::AtomicPtr;
 
 /// `NSStatusItem` length that shoves left-side extras off the display.
 pub const HIDDEN_LENGTH: f64 = 10_000.0;
@@ -63,9 +65,6 @@ static SEPARATOR: AtomicPtr<objc2::runtime::AnyObject> =
 
 #[cfg(target_os = "macos")]
 fn sync_macos() {
-    use objc2::runtime::AnyObject;
-    use objc2::*;
-
     let settings = crate::settings::get_app_settings();
     if !settings.thaw_enabled {
         remove_item();

--- a/crates/nook-core/src/mouse.rs
+++ b/crates/nook-core/src/mouse.rs
@@ -20,6 +20,7 @@ static UI_BOUNDS: std::sync::OnceLock<RwLock<Option<UiBounds>>> = std::sync::Onc
 static MOUSE_X: AtomicU64 = AtomicU64::new(0);
 static MOUSE_Y: AtomicU64 = AtomicU64::new(0);
 static DRAG_ACTIVE: AtomicBool = AtomicBool::new(false);
+static DRAG_GEN: AtomicU64 = AtomicU64::new(0);
 static POLL_STARTED: AtomicBool = AtomicBool::new(false);
 
 fn bounds_store() -> &'static RwLock<Option<UiBounds>> {
@@ -46,6 +47,12 @@ pub fn current_mouse_logical() -> (f64, f64) {
 
 pub fn drag_active() -> bool {
     DRAG_ACTIVE.load(Ordering::Relaxed)
+}
+
+/// Bumped on each `drag_active` edge. Window snap can watch this instead of
+/// polling AX while the pointer is still.
+pub fn drag_generation() -> u64 {
+    DRAG_GEN.load(Ordering::Relaxed)
 }
 
 /// Hit-test the cursor against the island activation area.
@@ -212,7 +219,11 @@ fn sample_now() {
     let (x, y) = read_mouse_logical();
     MOUSE_X.store(x.to_bits(), Ordering::Relaxed);
     MOUSE_Y.store(y.to_bits(), Ordering::Relaxed);
-    DRAG_ACTIVE.store(crate::files::file_drag_active(), Ordering::Relaxed);
+    let drag = crate::files::file_drag_active();
+    let was = DRAG_ACTIVE.swap(drag, Ordering::Relaxed);
+    if was != drag {
+        DRAG_GEN.fetch_add(1, Ordering::Relaxed);
+    }
 }
 
 fn read_mouse_logical() -> (f64, f64) {

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -167,6 +167,19 @@ pub struct AppSettings {
     /// Per-widget widths in Nook cells. Missing entries use [`WidgetModule::default_cells`].
     #[serde(default)]
     pub widget_widths: Vec<(WidgetModule, u8)>,
+    /// Rectangle-style halves / quarters via Carbon hotkeys. Needs Accessibility.
+    #[serde(default)]
+    pub window_snap_enabled: bool,
+    /// Stretch our own menu-bar separator so extras to its left go off-screen.
+    #[serde(default)]
+    pub thaw_enabled: bool,
+    /// Separator is currently stretched (extras hidden). Ignored when Thaw is off.
+    #[serde(default)]
+    pub thaw_hidden: bool,
+    /// Reserved for drag-to-edge (tier 2). Geometry is implemented; the live
+    /// AX tracker is not wired so idle cost stays zero.
+    #[serde(default)]
+    pub snap_drag_to_edge: bool,
     #[serde(default)]
     pub window: WindowSettings,
 }
@@ -239,6 +252,10 @@ impl Default for AppSettings {
             hide_when_maximized: false,
             island_color: None,
             widget_widths: Vec::new(),
+            window_snap_enabled: false,
+            thaw_enabled: false,
+            thaw_hidden: false,
+            snap_drag_to_edge: false,
             window: WindowSettings::default(),
         }
     }
@@ -499,6 +516,8 @@ pub fn update_app_settings(settings: AppSettings) {
     }
     SETTINGS_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     persist();
+    crate::hotkeys::sync();
+    crate::menubar::sync();
 }
 
 /// Bumped on every [`update_app_settings`]. Hot loops compare this before
@@ -725,5 +744,14 @@ mod tests {
         let legacy: AppSettings =
             serde_json::from_str(r#"{"observe":{"metrics_token":"legacy-secret"}}"#).unwrap();
         assert_eq!(legacy.observe.metrics_token, "legacy-secret");
+    }
+
+    #[test]
+    fn window_management_flags_default_off() {
+        let parsed: AppSettings = serde_json::from_str("{}").unwrap();
+        assert!(!parsed.window_snap_enabled);
+        assert!(!parsed.thaw_enabled);
+        assert!(!parsed.thaw_hidden);
+        assert!(!parsed.snap_drag_to_edge);
     }
 }

--- a/crates/nook-core/src/window_snap.rs
+++ b/crates/nook-core/src/window_snap.rs
@@ -1,0 +1,718 @@
+//! Rectangle-style window snapping via the public Accessibility API.
+//!
+//! Geometry (halves / quarters, AppKit→AX flip, drag-edge zones) is pure and
+//! unit-tested. The AX write path runs only on an explicit snap — hotkey,
+//! settings card, or a future drag release — never from the island tick.
+
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Tile of [`SnapRect`] produced by a snap.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum SnapKind {
+    LeftHalf = 0,
+    RightHalf = 1,
+    TopHalf = 2,
+    BottomHalf = 3,
+    TopLeft = 4,
+    TopRight = 5,
+    BottomLeft = 6,
+    BottomRight = 7,
+    Maximize = 8,
+}
+
+impl SnapKind {
+    pub const ALL: [Self; 9] = [
+        Self::LeftHalf,
+        Self::RightHalf,
+        Self::TopHalf,
+        Self::BottomHalf,
+        Self::TopLeft,
+        Self::TopRight,
+        Self::BottomLeft,
+        Self::BottomRight,
+        Self::Maximize,
+    ];
+
+    pub fn from_u8(value: u8) -> Option<Self> {
+        Self::ALL.into_iter().find(|kind| *kind as u8 == value)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::LeftHalf => "Left half",
+            Self::RightHalf => "Right half",
+            Self::TopHalf => "Top half",
+            Self::BottomHalf => "Bottom half",
+            Self::TopLeft => "Top left",
+            Self::TopRight => "Top right",
+            Self::BottomLeft => "Bottom left",
+            Self::BottomRight => "Bottom right",
+            Self::Maximize => "Maximize",
+        }
+    }
+}
+
+/// Axis-aligned rect. AX / CG space is top-left origin; AppKit `visibleFrame`
+/// is bottom-left — convert with [`ns_visible_to_ax`] before tiling.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SnapRect {
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+}
+
+impl SnapRect {
+    pub fn contains(self, x: f64, y: f64) -> bool {
+        x >= self.x && x < self.x + self.w && y >= self.y && y < self.y + self.h
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SnapError {
+    Disabled,
+    NotTrusted,
+    Unsupported,
+    NoWindow,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum AccessibilityStatus {
+    Granted,
+    Denied,
+    Unsupported,
+}
+
+impl AccessibilityStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Granted => "Granted",
+            Self::Denied => "Not granted",
+            Self::Unsupported => "macOS only",
+        }
+    }
+}
+
+/// Convert an AppKit `visibleFrame` (origin bottom-left of the primary
+/// display, y up) into Accessibility / CG space (origin top-left of the
+/// primary display, y down).
+pub fn ns_visible_to_ax(visible_ns: SnapRect, primary_height: f64) -> SnapRect {
+    SnapRect {
+        x: visible_ns.x,
+        y: primary_height - visible_ns.y - visible_ns.h,
+        w: visible_ns.w,
+        h: visible_ns.h,
+    }
+}
+
+/// Tile `kind` inside an AX-space visible frame. Odd leftover pixels go to
+/// the right / bottom so the two halves abut with no gap.
+pub fn snap_rect(kind: SnapKind, visible: SnapRect) -> SnapRect {
+    let (x, half_w, right_x) = split_axis(visible.x, visible.w);
+    let (y, half_h, bottom_y) = split_axis(visible.y, visible.h);
+    let right_w = visible.w - half_w;
+    let bottom_h = visible.h - half_h;
+    match kind {
+        SnapKind::LeftHalf => SnapRect {
+            x,
+            y: visible.y,
+            w: half_w,
+            h: visible.h,
+        },
+        SnapKind::RightHalf => SnapRect {
+            x: right_x,
+            y: visible.y,
+            w: right_w,
+            h: visible.h,
+        },
+        SnapKind::TopHalf => SnapRect {
+            x: visible.x,
+            y,
+            w: visible.w,
+            h: half_h,
+        },
+        SnapKind::BottomHalf => SnapRect {
+            x: visible.x,
+            y: bottom_y,
+            w: visible.w,
+            h: bottom_h,
+        },
+        SnapKind::TopLeft => SnapRect {
+            x,
+            y,
+            w: half_w,
+            h: half_h,
+        },
+        SnapKind::TopRight => SnapRect {
+            x: right_x,
+            y,
+            w: right_w,
+            h: half_h,
+        },
+        SnapKind::BottomLeft => SnapRect {
+            x,
+            y: bottom_y,
+            w: half_w,
+            h: bottom_h,
+        },
+        SnapKind::BottomRight => SnapRect {
+            x: right_x,
+            y: bottom_y,
+            w: right_w,
+            h: bottom_h,
+        },
+        SnapKind::Maximize => visible,
+    }
+}
+
+fn split_axis(origin: f64, length: f64) -> (f64, f64, f64) {
+    let first = (length * 0.5).floor();
+    (origin, first, origin + first)
+}
+
+/// Edge / corner zone the cursor sits in, or `None` when it is in the open
+/// middle. Corners win over sides. `inset` is the zone depth in the same
+/// units as `visible` (points). Used by drag-to-edge; hotkeys ignore it.
+pub fn edge_zone(x: f64, y: f64, visible: SnapRect, inset: f64) -> Option<SnapKind> {
+    if inset <= 0.0 || !visible.contains(x, y) {
+        return None;
+    }
+    let left = x <= visible.x + inset;
+    let right = x >= visible.x + visible.w - inset;
+    let top = y <= visible.y + inset;
+    let bottom = y >= visible.y + visible.h - inset;
+    match (left, right, top, bottom) {
+        (true, false, true, false) => Some(SnapKind::TopLeft),
+        (false, true, true, false) => Some(SnapKind::TopRight),
+        (true, false, false, true) => Some(SnapKind::BottomLeft),
+        (false, true, false, true) => Some(SnapKind::BottomRight),
+        (true, false, false, false) => Some(SnapKind::LeftHalf),
+        (false, true, false, false) => Some(SnapKind::RightHalf),
+        (false, false, true, false) => Some(SnapKind::TopHalf),
+        (false, false, false, true) => Some(SnapKind::BottomHalf),
+        _ => None,
+    }
+}
+
+const FLASH_MS: u64 = 1400;
+static FLASH_KIND: AtomicU8 = AtomicU8::new(0);
+static FLASH_AT_MS: AtomicU64 = AtomicU64::new(0);
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Record a just-applied snap so the compact face can flash a label.
+pub fn note_flash(kind: SnapKind) {
+    FLASH_KIND.store(kind as u8 + 1, Ordering::Relaxed);
+    FLASH_AT_MS.store(unix_ms(), Ordering::Relaxed);
+}
+
+/// True while a snap-confirmation flash should stay on screen. Cheap atomic;
+/// the island tick uses this as a dirty hint, not as a reason to talk to AX.
+pub fn flash_is_live() -> bool {
+    let at = FLASH_AT_MS.load(Ordering::Relaxed);
+    at != 0 && unix_ms().saturating_sub(at) < FLASH_MS
+}
+
+pub fn flash_label() -> Option<&'static str> {
+    if !flash_is_live() {
+        return None;
+    }
+    let raw = FLASH_KIND.load(Ordering::Relaxed);
+    SnapKind::from_u8(raw.saturating_sub(1)).map(SnapKind::label)
+}
+
+pub fn accessibility_status() -> AccessibilityStatus {
+    #[cfg(target_os = "macos")]
+    {
+        if is_trusted() {
+            AccessibilityStatus::Granted
+        } else {
+            AccessibilityStatus::Denied
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        AccessibilityStatus::Unsupported
+    }
+}
+
+pub fn is_trusted() -> bool {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        AXIsProcessTrusted()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Show the system Accessibility prompt when the process is not trusted.
+/// Returns the post-prompt trust flag (still false until the user toggles
+/// the grant and the app is relaunched on some macOS versions).
+pub fn prompt_trust() -> bool {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        prompt_trust_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn open_accessibility_settings() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = open::that(
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+        );
+    }
+}
+
+/// Snap the frontmost app's focused window. No-op when the feature is off,
+/// Accessibility is denied, or there is no movable window.
+pub fn snap_frontmost(kind: SnapKind) -> Result<SnapRect, SnapError> {
+    if !crate::settings::get_app_settings().window_snap_enabled {
+        return Err(SnapError::Disabled);
+    }
+    #[cfg(target_os = "macos")]
+    {
+        if !is_trusted() {
+            return Err(SnapError::NotTrusted);
+        }
+        let rect = unsafe { snap_frontmost_macos(kind) }?;
+        note_flash(kind);
+        Ok(rect)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = kind;
+        Err(SnapError::Unsupported)
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "ApplicationServices", kind = "framework")]
+extern "C" {
+    fn AXIsProcessTrusted() -> bool;
+    fn AXIsProcessTrustedWithOptions(options: *const std::ffi::c_void) -> bool;
+    fn AXUIElementCreateApplication(pid: i32) -> *mut std::ffi::c_void;
+    fn AXUIElementCopyAttributeValue(
+        element: *mut std::ffi::c_void,
+        attribute: *const std::ffi::c_void,
+        value: *mut *mut std::ffi::c_void,
+    ) -> i32;
+    fn AXUIElementSetAttributeValue(
+        element: *mut std::ffi::c_void,
+        attribute: *const std::ffi::c_void,
+        value: *const std::ffi::c_void,
+    ) -> i32;
+    fn AXValueCreate(the_type: u32, value_ptr: *const std::ffi::c_void) -> *mut std::ffi::c_void;
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "CoreFoundation", kind = "framework")]
+extern "C" {
+    fn CFRelease(cf: *const std::ffi::c_void);
+    fn CFBooleanGetValue(boolean: *const std::ffi::c_void) -> bool;
+    static kCFBooleanTrue: *const std::ffi::c_void;
+    static kCFBooleanFalse: *const std::ffi::c_void;
+}
+
+#[cfg(target_os = "macos")]
+const AX_VALUE_CGPOINT: u32 = 1;
+#[cfg(target_os = "macos")]
+const AX_VALUE_CGSIZE: u32 = 2;
+
+#[cfg(target_os = "macos")]
+unsafe fn prompt_trust_macos() -> bool {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    let key: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"AXTrustedCheckOptionPrompt".as_ptr()
+    ];
+    let yes: *mut AnyObject = msg_send![class!(NSNumber), numberWithBool: true];
+    if key.is_null() || yes.is_null() {
+        return AXIsProcessTrusted();
+    }
+    let options: *mut AnyObject = msg_send![class!(NSDictionary), dictionaryWithObject: yes, forKey: key];
+    if options.is_null() {
+        return AXIsProcessTrusted();
+    }
+    AXIsProcessTrustedWithOptions(options as *const std::ffi::c_void)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn snap_frontmost_macos(kind: SnapKind) -> Result<SnapRect, SnapError> {
+    use objc2::rc::autoreleasepool;
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    autoreleasepool(|_| {
+        let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+        if workspace.is_null() {
+            return Err(SnapError::NoWindow);
+        }
+        let app: *mut AnyObject = msg_send![workspace, frontmostApplication];
+        if app.is_null() {
+            return Err(SnapError::NoWindow);
+        }
+        let pid: i32 = msg_send![app, processIdentifier];
+        if pid <= 0 || pid == std::process::id() as i32 {
+            return Err(SnapError::NoWindow);
+        }
+
+        let Some(visible) = visible_frame_under_cursor() else {
+            return Err(SnapError::NoWindow);
+        };
+        let target = snap_rect(kind, visible);
+
+        let app_el = AXUIElementCreateApplication(pid);
+        if app_el.is_null() {
+            return Err(SnapError::NoWindow);
+        }
+
+        let enhanced_attr = ns_attr(c"AXEnhancedUserInterface");
+        let was_enhanced = ax_bool(app_el, enhanced_attr).unwrap_or(false);
+        if was_enhanced {
+            ax_set_bool(app_el, enhanced_attr, false);
+        }
+
+        let focused_attr = ns_attr(c"AXFocusedWindow");
+        let mut window: *mut std::ffi::c_void = std::ptr::null_mut();
+        let err = AXUIElementCopyAttributeValue(app_el, focused_attr, &mut window);
+        if err != 0 || window.is_null() {
+            if was_enhanced {
+                ax_set_bool(app_el, enhanced_attr, true);
+            }
+            CFRelease(app_el);
+            return Err(SnapError::NoWindow);
+        }
+
+        // Size → position → size. Some apps clamp the first size write until
+        // the origin is inside the destination display.
+        let _ = ax_set_size(window, target.w, target.h);
+        let _ = ax_set_point(window, target.x, target.y);
+        let applied = ax_set_size(window, target.w, target.h);
+
+        if was_enhanced {
+            ax_set_bool(app_el, enhanced_attr, true);
+        }
+        CFRelease(window);
+        CFRelease(app_el);
+
+        if applied {
+            Ok(target)
+        } else {
+            Err(SnapError::NoWindow)
+        }
+    })
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn visible_frame_under_cursor() -> Option<SnapRect> {
+    use crate::notch::{CGPoint, CGRect};
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    let mouse: CGPoint = msg_send![class!(NSEvent), mouseLocation];
+    let screens: *mut AnyObject = msg_send![class!(NSScreen), screens];
+    if screens.is_null() {
+        return None;
+    }
+    let count: usize = msg_send![screens, count];
+    if count == 0 {
+        return None;
+    }
+    let primary: *mut AnyObject = msg_send![screens, objectAtIndex: 0usize];
+    if primary.is_null() {
+        return None;
+    }
+    let primary_frame: CGRect = msg_send![primary, frame];
+    let primary_h = primary_frame.size.height;
+
+    let mut chosen: *mut AnyObject = std::ptr::null_mut();
+    for i in 0..count {
+        let screen: *mut AnyObject = msg_send![screens, objectAtIndex: i];
+        if screen.is_null() {
+            continue;
+        }
+        let frame: CGRect = msg_send![screen, frame];
+        if mouse.x >= frame.origin.x
+            && mouse.x < frame.origin.x + frame.size.width
+            && mouse.y >= frame.origin.y
+            && mouse.y < frame.origin.y + frame.size.height
+        {
+            chosen = screen;
+            break;
+        }
+    }
+    if chosen.is_null() {
+        chosen = msg_send![class!(NSScreen), mainScreen];
+    }
+    if chosen.is_null() {
+        return None;
+    }
+    let visible: CGRect = msg_send![chosen, visibleFrame];
+    Some(ns_visible_to_ax(
+        SnapRect {
+            x: visible.origin.x,
+            y: visible.origin.y,
+            w: visible.size.width,
+            h: visible.size.height,
+        },
+        primary_h,
+    ))
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ns_attr(name: &std::ffi::CStr) -> *const std::ffi::c_void {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    let s: *mut AnyObject = msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
+    s as *const std::ffi::c_void
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ax_bool(element: *mut std::ffi::c_void, attr: *const std::ffi::c_void) -> Option<bool> {
+    let mut value: *mut std::ffi::c_void = std::ptr::null_mut();
+    if AXUIElementCopyAttributeValue(element, attr, &mut value) != 0 || value.is_null() {
+        return None;
+    }
+    let flag = CFBooleanGetValue(value);
+    CFRelease(value);
+    Some(flag)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ax_set_bool(element: *mut std::ffi::c_void, attr: *const std::ffi::c_void, value: bool) {
+    let cf = if value { kCFBooleanTrue } else { kCFBooleanFalse };
+    let _ = AXUIElementSetAttributeValue(element, attr, cf);
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ax_set_point(element: *mut std::ffi::c_void, x: f64, y: f64) -> bool {
+    use crate::notch::CGPoint;
+    let point = CGPoint { x, y };
+    let value = AXValueCreate(AX_VALUE_CGPOINT, &point as *const CGPoint as *const std::ffi::c_void);
+    if value.is_null() {
+        return false;
+    }
+    let ok = AXUIElementSetAttributeValue(element, ns_attr(c"AXPosition"), value) == 0;
+    CFRelease(value);
+    ok
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn ax_set_size(element: *mut std::ffi::c_void, w: f64, h: f64) -> bool {
+    use crate::notch::CGSize;
+    let size = CGSize {
+        width: w,
+        height: h,
+    };
+    let value = AXValueCreate(AX_VALUE_CGSIZE, &size as *const CGSize as *const std::ffi::c_void);
+    if value.is_null() {
+        return false;
+    }
+    let ok = AXUIElementSetAttributeValue(element, ns_attr(c"AXSize"), value) == 0;
+    CFRelease(value);
+    ok
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn visible() -> SnapRect {
+        SnapRect {
+            x: 0.0,
+            y: 38.0,
+            w: 1512.0,
+            h: 894.0,
+        }
+    }
+
+    #[test]
+    fn ns_visible_flips_to_ax_using_primary_height() {
+        let ns = SnapRect {
+            x: 0.0,
+            y: 50.0,
+            w: 1512.0,
+            h: 894.0,
+        };
+        let ax = ns_visible_to_ax(ns, 982.0);
+        assert_eq!(
+            ax,
+            SnapRect {
+                x: 0.0,
+                y: 38.0,
+                w: 1512.0,
+                h: 894.0,
+            }
+        );
+    }
+
+    #[test]
+    fn ns_visible_on_a_right_display_keeps_x() {
+        let ns = SnapRect {
+            x: 1512.0,
+            y: 0.0,
+            w: 1920.0,
+            h: 1080.0,
+        };
+        let ax = ns_visible_to_ax(ns, 982.0);
+        assert_eq!(ax.x, 1512.0);
+        assert!((ax.y - (982.0 - 1080.0)).abs() < f64::EPSILON);
+        assert_eq!(ax.w, 1920.0);
+        assert_eq!(ax.h, 1080.0);
+    }
+
+    #[test]
+    fn halves_and_quarters_tile_the_visible_frame() {
+        let v = visible();
+        assert_eq!(
+            snap_rect(SnapKind::LeftHalf, v),
+            SnapRect {
+                x: 0.0,
+                y: 38.0,
+                w: 756.0,
+                h: 894.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::RightHalf, v),
+            SnapRect {
+                x: 756.0,
+                y: 38.0,
+                w: 756.0,
+                h: 894.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::TopHalf, v),
+            SnapRect {
+                x: 0.0,
+                y: 38.0,
+                w: 1512.0,
+                h: 447.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::BottomHalf, v),
+            SnapRect {
+                x: 0.0,
+                y: 485.0,
+                w: 1512.0,
+                h: 447.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::TopLeft, v),
+            SnapRect {
+                x: 0.0,
+                y: 38.0,
+                w: 756.0,
+                h: 447.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::TopRight, v),
+            SnapRect {
+                x: 756.0,
+                y: 38.0,
+                w: 756.0,
+                h: 447.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::BottomLeft, v),
+            SnapRect {
+                x: 0.0,
+                y: 485.0,
+                w: 756.0,
+                h: 447.0,
+            }
+        );
+        assert_eq!(
+            snap_rect(SnapKind::BottomRight, v),
+            SnapRect {
+                x: 756.0,
+                y: 485.0,
+                w: 756.0,
+                h: 447.0,
+            }
+        );
+        assert_eq!(snap_rect(SnapKind::Maximize, v), v);
+    }
+
+    #[test]
+    fn odd_dimensions_give_the_remainder_to_the_far_side() {
+        let v = SnapRect {
+            x: 10.0,
+            y: 20.0,
+            w: 1513.0,
+            h: 895.0,
+        };
+        let left = snap_rect(SnapKind::LeftHalf, v);
+        let right = snap_rect(SnapKind::RightHalf, v);
+        assert_eq!(left.w, 756.0);
+        assert_eq!(right.w, 757.0);
+        assert_eq!(left.x + left.w, right.x);
+        assert_eq!(right.x + right.w, v.x + v.w);
+
+        let top = snap_rect(SnapKind::TopHalf, v);
+        let bottom = snap_rect(SnapKind::BottomHalf, v);
+        assert_eq!(top.h, 447.0);
+        assert_eq!(bottom.h, 448.0);
+        assert_eq!(top.y + top.h, bottom.y);
+        assert_eq!(bottom.y + bottom.h, v.y + v.h);
+    }
+
+    #[test]
+    fn edge_zone_prefers_corners_then_sides() {
+        let v = visible();
+        assert_eq!(edge_zone(10.0, 400.0, v, 24.0), Some(SnapKind::LeftHalf));
+        assert_eq!(edge_zone(1500.0, 400.0, v, 24.0), Some(SnapKind::RightHalf));
+        assert_eq!(edge_zone(800.0, 40.0, v, 24.0), Some(SnapKind::TopHalf));
+        assert_eq!(edge_zone(800.0, 920.0, v, 24.0), Some(SnapKind::BottomHalf));
+        assert_eq!(edge_zone(10.0, 40.0, v, 24.0), Some(SnapKind::TopLeft));
+        assert_eq!(edge_zone(1500.0, 40.0, v, 24.0), Some(SnapKind::TopRight));
+        assert_eq!(edge_zone(10.0, 920.0, v, 24.0), Some(SnapKind::BottomLeft));
+        assert_eq!(
+            edge_zone(1500.0, 920.0, v, 24.0),
+            Some(SnapKind::BottomRight)
+        );
+        assert_eq!(edge_zone(800.0, 400.0, v, 24.0), None);
+        assert_eq!(edge_zone(-4.0, 400.0, v, 24.0), None);
+        assert_eq!(edge_zone(800.0, 400.0, v, 0.0), None);
+    }
+
+    #[test]
+    fn snap_kind_round_trips_and_labels() {
+        for kind in SnapKind::ALL {
+            assert_eq!(SnapKind::from_u8(kind as u8), Some(kind));
+            assert!(!kind.label().is_empty());
+        }
+        assert_eq!(SnapKind::from_u8(99), None);
+    }
+
+    #[test]
+    fn snap_is_disabled_by_default() {
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert_eq!(accessibility_status(), AccessibilityStatus::Unsupported);
+            assert!(!is_trusted());
+        }
+        assert_eq!(snap_frontmost(SnapKind::LeftHalf), Err(SnapError::Disabled));
+    }
+}

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -53,6 +53,9 @@ impl Island {
     }
 
     fn compact_left(&self, mode: CompactMode, cx: &mut Context<Self>) -> AnyElement {
+        if let Some(text) = nook_core::window_snap::flash_label() {
+            return label(text, theme::BODY, true).into_any_element();
+        }
         match mode {
             CompactMode::Media => {
                 album_chip(&self.now_playing, self.overlay_fade.value, cx).into_any_element()
@@ -105,6 +108,11 @@ impl Island {
                 };
                 label(text, theme::BODY, true).into_any_element()
             }
+            CompactMode::Idle if self.settings.thaw_enabled => thaw_toggle(
+                self.settings.thaw_hidden,
+                cx,
+            )
+            .into_any_element(),
             CompactMode::Onboard if hovered => div()
                 .id("github")
                 .cursor(CursorStyle::PointingHand)
@@ -183,3 +191,19 @@ impl Island {
         row.into_any_element()
     }
 }
+
+fn thaw_toggle(hidden: bool, cx: &mut Context<Island>) -> impl IntoElement {
+    div()
+        .id("thaw-toggle")
+        .cursor(CursorStyle::PointingHand)
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|_, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                nook_core::menubar::toggle();
+            }),
+        )
+        .child(lucide("eye", theme::COMPACT_FACE))
+        .when(hidden, |d| d.opacity(0.45))
+}
+

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -158,6 +158,8 @@ pub struct Island {
     pub(crate) mirror_on: bool,
     mirror_gen: u64,
     pub(crate) mirror_frame: Option<std::sync::Arc<gpui::RenderImage>>,
+    /// Compact-face snap confirmation; driven by window_snap::flash_is_live.
+    snap_flashing: bool,
 }
 
 struct PendingFileDrag {
@@ -256,6 +258,7 @@ impl Island {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            snap_flashing: false,
         };
         // Start at the compact idle size so the first paint isn't a jump.
         let (w, h) = this.target_size();
@@ -340,6 +343,11 @@ impl Island {
                     }
                     if platform::take_open_settings() {
                         this.open_settings(cx);
+                        dirty = true;
+                    }
+                    let flash = nook_core::window_snap::flash_is_live();
+                    if flash || this.snap_flashing {
+                        this.snap_flashing = flash;
                         dirty = true;
                     }
                     let want_suppress = this.settings.hide_when_maximized
@@ -1494,6 +1502,7 @@ mod tests {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            snap_flashing: false,
         }
     }
 

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -580,8 +580,10 @@ impl SettingsView {
                                 cx,
                                 |s| {
                                     s.window_snap_enabled = !s.window_snap_enabled;
-                                    if s.window_snap_enabled {
-                                        nook_core::window_snap::prompt_trust();
+                                    if s.window_snap_enabled
+                                        && !crate::platform::accessibility_trusted()
+                                    {
+                                        crate::platform::prompt_accessibility();
                                     }
                                 },
                             )
@@ -597,7 +599,7 @@ impl SettingsView {
                                 "Prompt",
                                 cx,
                                 |_, _, cx| {
-                                    nook_core::window_snap::prompt_trust();
+                                    crate::platform::prompt_accessibility();
                                     cx.notify();
                                 },
                             )

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -569,6 +569,77 @@ impl SettingsView {
                         .into_any_element(),
                     ]),
                     Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
+                ))
+                .child(section(
+                    "Window Snap",
+                    settings_group({
+                        let mut rows = vec![
+                            toggle_row(
+                                "Snap hotkeys",
+                                settings.window_snap_enabled,
+                                cx,
+                                |s| {
+                                    s.window_snap_enabled = !s.window_snap_enabled;
+                                    if s.window_snap_enabled {
+                                        nook_core::window_snap::prompt_trust();
+                                    }
+                                },
+                            )
+                            .into_any_element(),
+                            status_row(
+                                "Accessibility",
+                                nook_core::window_snap::accessibility_status().label(),
+                            )
+                            .into_any_element(),
+                            action_row(
+                                "ax-prompt",
+                                "Request Accessibility",
+                                "Prompt",
+                                cx,
+                                |_, _, cx| {
+                                    nook_core::window_snap::prompt_trust();
+                                    cx.notify();
+                                },
+                            )
+                            .into_any_element(),
+                            action_row(
+                                "ax-open",
+                                "Privacy settings",
+                                "Open",
+                                cx,
+                                |_, _, _| {
+                                    nook_core::window_snap::open_accessibility_settings();
+                                },
+                            )
+                            .into_any_element(),
+                        ];
+                        for (kind, hotkey) in nook_core::hotkeys::default_bindings() {
+                            rows.push(
+                                shortcut_row(kind.label(), hotkey.display()).into_any_element(),
+                            );
+                        }
+                        rows
+                    }),
+                    Some("⌃⌥ plus arrows, U/I/J/K, or Return. macOS 15+ tiling can fight drag-to-edge; hotkeys stay independent."),
+                ))
+                .child(section(
+                    "Menu bar (Thaw)",
+                    settings_group(vec![
+                        toggle_row("Hide extras with a separator", settings.thaw_enabled, cx, |s| {
+                            s.thaw_enabled = !s.thaw_enabled;
+                            if !s.thaw_enabled {
+                                s.thaw_hidden = false;
+                            }
+                        })
+                        .into_any_element(),
+                        toggle_row("Extras hidden", settings.thaw_hidden, cx, |s| {
+                            if s.thaw_enabled {
+                                s.thaw_hidden = !s.thaw_hidden;
+                            }
+                        })
+                        .into_any_element(),
+                    ]),
+                    Some("⌘-drag extras so hidden items sit to the left of the Nook chevron. Click the chevron to hide or show. No Screen Recording."),
                 )),
         )
     }
@@ -1437,6 +1508,18 @@ fn action_row(
         ))
 }
 
+fn status_row(title: &'static str, value: &'static str) -> impl IntoElement {
+    settings_row(title)
+        .child(label(title, theme::BODY, true))
+        .child(label(value, theme::SUBHEADLINE, false))
+}
+
+fn shortcut_row(title: &'static str, keys: String) -> impl IntoElement {
+    settings_row(SharedString::from(title))
+        .child(label(title, theme::BODY, true))
+        .child(label(keys, theme::SUBHEADLINE, false))
+}
+
 fn toggle_row(
     label_text: &'static str,
     on: bool,
@@ -1732,6 +1815,16 @@ mod tests {
         assert!(!names
             .iter()
             .any(|n| n.contains("Shortcuts") || n.contains("Tencent") || n.contains("License")));
+    }
+
+    #[test]
+    fn window_snap_hotkeys_are_listed() {
+        let rows: Vec<_> = nook_core::hotkeys::default_bindings()
+            .into_iter()
+            .map(|(kind, hotkey)| (kind.label(), hotkey.display()))
+            .collect();
+        assert_eq!(rows.len(), 9);
+        assert!(rows.iter().any(|(n, k)| *n == "Left half" && k.contains('←')));
     }
 
     #[test]

--- a/crates/nook/src/main.rs
+++ b/crates/nook/src/main.rs
@@ -21,6 +21,7 @@ fn main() {
             nook_core::init();
             platform::install();
             platform::install_status_item();
+            nook_core::install_window_management();
             cx.on_action(|_: &Quit, cx| cx.quit());
             cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
             open_island(cx);

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -1386,6 +1386,17 @@ pub fn reduce_motion() -> bool {
     false
 }
 
+/// Accessibility (TCC) for window snap. Cached by the AX call itself; Settings
+/// reads this when the pane is open, never from the island tick.
+pub fn accessibility_trusted() -> bool {
+    nook_core::window_snap::is_trusted()
+}
+
+/// Show the system Accessibility prompt. Call from a user gesture.
+pub fn prompt_accessibility() -> bool {
+    nook_core::window_snap::prompt_trust()
+}
+
 /// Subscribe to Spotify's and Music's public playback-change broadcasts.
 ///
 /// Both players post on the distributed notification center on every


### PR DESCRIPTION
## WP22 — Window Snap + Thaw (tier 1)

Rectangle-style window snap via Accessibility + Carbon hotkeys, and Ice/Dozer-style menu-bar hiding via our own `NSStatusItem` separator. **No other work packages.** Drag-to-edge live tracking and Ice-bar Screen Recording capture are intentionally not wired (zero idle).

### Window Snap
- Pure geometry in `window_snap.rs`: AppKit `visibleFrame` → AX flip, halves/quarters (odd leftover pixels to the right/bottom), drag-edge zones for a later flag.
- AX write path (macOS only): frontmost focused window, `kAXEnhancedUserInterface` off around the move, size → position → size. Picks the screen under the cursor.
- Carbon `RegisterEventHotKey` (no TCC): ⌃⌥ + arrows / U I J K / Return. Callback-only; consumes the keystroke.
- Defaults **off**. Enabling prompts Accessibility. Settings shows grant status and a Privacy pane deep link.

### Thaw (tier 1)
- Second `NSStatusItem` separator. Hide sets `length` to 10000pt so extras the user ⌘-dragged to its left go off-screen. Show restores `NSVariableStatusItemLength`.
- Click the chevron (or Settings) to toggle. Item is not recreated on toggle so arrangement survives.
- **No Screen Recording.** In-island hidden-item capture stays a follow-up.

### Wiring
- Settings: General → Window Snap + Menu bar (Thaw).
- Compact idle: snap-confirmation flash; Thaw eye toggle when enabled.
- `update_app_settings` re-syncs hotkeys/separator. No new poll loops.
- `mouse::drag_generation()` surfaces drag edges for a future drag-to-edge hook.

### Tests
`cargo test -p nook -p nook-core` — 82 + 88 passed (Linux CI).

### Out of scope / blockers
- Drag-to-edge AX tracker and snap-preview overlay (tier 2).
- Ice-bar Screen Recording capture + click forwarding (tier 2).
- TCC Accessibility is mandatory for snaps and is signature-keyed on ad-hoc/dev builds (users re-grant after re-sign).
- macOS 15+ system tiling can fight a future drag-to-edge; hotkeys do not conflict.
- Shortcut recorder UI not included (defaults listed as read-only rows).