### PR TITLE
WP23: iMessage replies + WhatsApp notify/prefill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3834,10 +3840,12 @@ dependencies = [
  "futures-executor",
  "futures-util",
  "log",
+ "notify",
  "objc2",
  "objc2-event-kit",
  "objc2-foundation",
  "open",
+ "plist",
  "reqwest",
  "rusqlite",
  "security-framework",
@@ -3952,6 +3960,12 @@ dependencies = [
  "bytemuck",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4507,6 +4521,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,6 +4619,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -6380,6 +6413,36 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Info.plist
+++ b/Info.plist
@@ -29,6 +29,6 @@
 	<key>NSCameraUsageDescription</key>
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
+	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork, and to send iMessage replies from the island.</string>
 </dict>
 </plist>

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -17,6 +17,8 @@ reqwest.workspace = true
 futures-util.workspace = true
 open.workspace = true
 sysinfo = "0.37"
+notify = "7"
+plist = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -677,28 +677,7 @@ pub async fn get_now_playing() -> NowPlayingData {
 }
 
 #[cfg(target_os = "macos")]
-fn run_osascript(script: &str) -> Result<String, String> {
-    use std::process::Command;
-    let output = Command::new("/usr/bin/osascript")
-        .arg("-e")
-        .arg(script)
-        .output()
-        .map_err(|e| e.to_string())?;
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    if !output.status.success() {
-        log::warn!("osascript failed ({}): {stderr}", output.status);
-        if stderr.contains("-1743") || stderr.to_lowercase().contains("not allowed") {
-            log::warn!(
-                "Automation permission denied. Grant access in System Settings → Privacy & Security → Automation."
-            );
-        }
-        return Err(format!("osascript failed: {}", output.status));
-    }
-    if !stderr.is_empty() {
-        log::debug!("osascript stderr: {stderr}");
-    }
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
-}
+use crate::utils::run_osascript;
 
 /// Get artwork from Music.app using AppleScript to write under the app data dir.
 #[cfg(target_os = "macos")]

--- a/crates/nook-core/src/database.rs
+++ b/crates/nook-core/src/database.rs
@@ -74,6 +74,14 @@ fn migrate(conn: &Connection) -> Result<()> {
         [],
     )?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS message_watermarks (
+            conversation_id TEXT PRIMARY KEY,
+            last_rowid INTEGER NOT NULL
+        )",
+        [],
+    )?;
+
     Ok(())
 }
 

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod files;
 pub mod haptics;
 #[cfg(target_os = "macos")]
 mod mediaremote;
+pub mod messages;
 pub mod models;
 pub mod mouse;
 pub mod notch;
@@ -63,5 +64,6 @@ pub fn init() {
         audio::init_audio_state();
         audio::setup_audio_monitoring();
         mouse::start_polling();
+        messages::start_watchers();
     });
 }

--- a/crates/nook-core/src/messages.rs
+++ b/crates/nook-core/src/messages.rs
@@ -163,27 +163,23 @@ pub fn e164_digits(handle: &str) -> Option<String> {
         .or_else(|| trimmed.strip_prefix("tel:"))
         .unwrap_or(trimmed);
     let mut digits = String::new();
-    let mut saw_digit = false;
-    let mut prefix = String::new();
+    let mut had_plus = false;
     for c in rest.chars() {
-        if c.is_ascii_digit() {
-            saw_digit = true;
+        if c == '+' && digits.is_empty() && !had_plus {
+            had_plus = true;
+        } else if c.is_ascii_digit() {
             digits.push(c);
-        } else if !saw_digit && (c == '+' || c == '0') && prefix.len() < 3 {
-            prefix.push(c);
-        } else if c == ' ' || c == '-' || c == '(' || c == ')' || c == '.' {
+        } else if matches!(c, ' ' | '-' | '(' | ')' | '.') {
             continue;
         } else if !c.is_ascii_whitespace() {
             return None;
         }
     }
-    if prefix == "00" && digits.len() >= 7 {
-        // already international, keep digits
-    } else if prefix == "+" || prefix.is_empty() || prefix == "0" {
-        // national `0…` is not a usable WhatsApp prefill without a country code
-        if prefix == "0" && !digits.starts_with("00") {
-            return None;
-        }
+    if let Some(stripped) = digits.strip_prefix("00") {
+        digits = stripped.to_string();
+    } else if digits.starts_with('0') && !had_plus {
+        // National trunk prefix without a country code cannot prefill WhatsApp.
+        return None;
     }
     if (7..=15).contains(&digits.len()) {
         Some(digits)
@@ -316,16 +312,11 @@ fn looks_like_message_text(text: &str) -> bool {
     if text.is_empty() || text.len() > 8 * 1024 {
         return false;
     }
-    let classish = matches!(
-        text,
-        "NSString"
-            | "NSMutableString"
-            | "NSAttributedString"
-            | "NSMutableAttributedString"
-            | "NSDictionary"
-            | "NSObject"
-            | "streamtyped"
-    );
+    let classish = text.contains("NSString")
+        || text.contains("NSAttributedString")
+        || text.contains("NSDictionary")
+        || text.contains("NSObject")
+        || text.contains("streamtyped");
     !classish && text.chars().any(|c| !c.is_ascii_control())
 }
 

--- a/crates/nook-core/src/messages.rs
+++ b/crates/nook-core/src/messages.rs
@@ -1,0 +1,1387 @@
+//! iMessage + WhatsApp replies for the island.
+//!
+//! iMessage is complete: read-only `chat.db` (bodies from `text` or the
+//! `attributedBody` typedstream), event-driven WAL watch, send via Messages
+//! AppleScript using the chat GUID. WhatsApp is notify + prefill: the Mac
+//! app has no scripting dictionary, so incoming rows come from the usernoted
+//! store and Reply opens `whatsapp://send?phone=&text=`.
+//!
+//! `imessage-database` is GPL-3.0 and cannot be linked from this MIT crate;
+//! the typedstream helper below follows the public NXTypedStream layout
+//! documented by that ecosystem. Message bodies are never written to
+//! `opennook.db` — only ROWID watermarks.
+
+use crate::database;
+use rusqlite::{Connection, OpenFlags};
+use std::io::Cursor;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, Once, OnceLock};
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// Debounce window after a WAL / usernoted write burst.
+pub const WATCH_DEBOUNCE: Duration = Duration::from_millis(300);
+
+/// System Settings deep link for Full Disk Access (no programmatic prompt).
+pub const FDA_SETTINGS_URL: &str =
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles";
+
+/// System Settings deep link for Accessibility (experimental WhatsApp Enter).
+pub const ACCESSIBILITY_SETTINGS_URL: &str =
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility";
+
+const GLOBAL_WATERMARK: &str = "*";
+const APPLE_EPOCH: i64 = 978_307_200;
+const RECENT_LIMIT: usize = 24;
+const WHATSAPP_BUNDLES: &[&str] = &[
+    "net.whatsapp.WhatsApp",
+    "net.whatsapp.WhatsApp.mac",
+    "net.whatsapp.WhatsAppDesktop",
+    "net.whatsapp.WhatsAppSMBIO",
+];
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FdaStatus {
+    Granted,
+    Denied,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MessageService {
+    IMessage,
+    Sms,
+    WhatsApp,
+}
+
+impl MessageService {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::IMessage => "iMessage",
+            Self::Sms => "SMS",
+            Self::WhatsApp => "WhatsApp",
+        }
+    }
+}
+
+/// Parsed Messages chat GUID (`iMessage;-;+49…`, `SMS;-;+1…`, `iMessage;+;chat…`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChatGuid {
+    pub raw: String,
+    pub service: String,
+    pub is_group: bool,
+    pub identifier: String,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct Conversation {
+    pub id: String,
+    pub service: MessageService,
+    pub title: String,
+    pub handle: Option<String>,
+    pub snippet: String,
+    pub from_me: bool,
+    pub unread: bool,
+    pub last_rowid: i64,
+    pub last_date: f64,
+    pub is_group: bool,
+    /// Present for iMessage / SMS rows that can be sent via AppleScript.
+    pub chat_guid: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct IncomingPeek {
+    pub conversation_id: String,
+    pub sender: String,
+    pub snippet: String,
+    pub service: MessageService,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MessagesSnapshot {
+    pub conversations: Vec<Conversation>,
+    pub incoming: Option<IncomingPeek>,
+    pub fda: FdaStatus,
+    pub last_rowid: i64,
+}
+
+impl Default for MessagesSnapshot {
+    fn default() -> Self {
+        Self {
+            conversations: Vec::new(),
+            incoming: None,
+            fda: FdaStatus::Unavailable,
+            last_rowid: 0,
+        }
+    }
+}
+
+/// `service;+|-;identifier` — rejects quote / newline injection.
+pub fn parse_chat_guid(guid: &str) -> Option<ChatGuid> {
+    let guid = guid.trim();
+    if guid.is_empty() || guid.len() > 256 {
+        return None;
+    }
+    let mut parts = guid.splitn(3, ';');
+    let service = parts.next()?.trim();
+    let kind = parts.next()?.trim();
+    let identifier = parts.next()?.trim();
+    if service.is_empty() || identifier.is_empty() {
+        return None;
+    }
+    if !service.chars().all(|c| c.is_ascii_alphanumeric()) {
+        return None;
+    }
+    let is_group = match kind {
+        "+" => true,
+        "-" => false,
+        _ => return None,
+    };
+    if identifier
+        .chars()
+        .any(|c| c == '"' || c == '\n' || c == '\r' || c == ';' || c == '\\')
+    {
+        return None;
+    }
+    Some(ChatGuid {
+        raw: guid.to_string(),
+        service: service.to_string(),
+        is_group,
+        identifier: identifier.to_string(),
+    })
+}
+
+/// Digits-only E.164 (no leading `+`) for `whatsapp://send?phone=`.
+pub fn e164_digits(handle: &str) -> Option<String> {
+    let trimmed = handle.trim();
+    if trimmed.is_empty() || trimmed.contains('@') {
+        return None;
+    }
+    let rest = trimmed
+        .strip_prefix("whatsapp:")
+        .or_else(|| trimmed.strip_prefix("tel:"))
+        .unwrap_or(trimmed);
+    let mut digits = String::new();
+    let mut saw_digit = false;
+    let mut prefix = String::new();
+    for c in rest.chars() {
+        if c.is_ascii_digit() {
+            saw_digit = true;
+            digits.push(c);
+        } else if !saw_digit && (c == '+' || c == '0') && prefix.len() < 3 {
+            prefix.push(c);
+        } else if c == ' ' || c == '-' || c == '(' || c == ')' || c == '.' {
+            continue;
+        } else if !c.is_ascii_whitespace() {
+            return None;
+        }
+    }
+    if prefix == "00" && digits.len() >= 7 {
+        // already international, keep digits
+    } else if prefix == "+" || prefix.is_empty() || prefix == "0" {
+        // national `0…` is not a usable WhatsApp prefill without a country code
+        if prefix == "0" && !digits.starts_with("00") {
+            return None;
+        }
+    }
+    if (7..=15).contains(&digits.len()) {
+        Some(digits)
+    } else {
+        None
+    }
+}
+
+/// `whatsapp://send?phone=<E164>&text=<prefill>` — prefill only, no auto-send.
+pub fn whatsapp_send_url(phone: &str, text: &str) -> Option<String> {
+    let digits = e164_digits(phone)?;
+    Some(format!(
+        "whatsapp://send?phone={digits}&text={}",
+        url_encode(text)
+    ))
+}
+
+pub fn url_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(b as char);
+            }
+            b' ' => out.push_str("%20"),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// Quote a string for AppleScript (`\` and `"` escaped; newlines become spaces).
+pub fn applescript_literal(s: &str) -> String {
+    let flat = s.replace(['\n', '\r'], " ");
+    format!(
+        "\"{}\"",
+        flat.replace('\\', "\\\\").replace('"', "\\\"")
+    )
+}
+
+/// Extract the first NSString payload from an `attributedBody` typedstream.
+///
+/// NXTypedStream integer encoding: a byte in `0..=127` is the length;
+/// `0x81` / `0x82` / `0x83` introduce 2 / 4 / 8 little-endian bytes.
+pub fn extract_typedstream_text(blob: &[u8]) -> Option<String> {
+    if blob.is_empty() {
+        return None;
+    }
+    for marker in [b"NSString".as_slice(), b"NSMutableString".as_slice()] {
+        let mut search = blob;
+        while let Some(pos) = find_bytes(search, marker) {
+            let after = &search[pos + marker.len()..];
+            if let Some(text) = typedstream_string_after_marker(after) {
+                if looks_like_message_text(&text) {
+                    return Some(text);
+                }
+            }
+            search = &search[pos + marker.len()..];
+        }
+    }
+    longest_printable_run(blob)
+}
+
+fn typedstream_string_after_marker(after: &[u8]) -> Option<String> {
+    // Prefer the `+` (0x2B) C-string type tag that follows the class name.
+    let window = &after[..after.len().min(32)];
+    if let Some(plus) = window.iter().position(|b| *b == 0x2B) {
+        if let Some((len, rest)) = read_nx_int(&after[plus + 1..]) {
+            return utf8_lossy_trim(rest, len);
+        }
+    }
+    // Fallback: first plausible NX int + UTF-8 run in the next few bytes.
+    for skip in 0..after.len().min(16) {
+        if let Some((len, rest)) = read_nx_int(&after[skip..]) {
+            if (1..=8 * 1024).contains(&len) {
+                if let Some(text) = utf8_lossy_trim(rest, len) {
+                    if looks_like_message_text(&text) {
+                        return Some(text);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn read_nx_int(data: &[u8]) -> Option<(usize, &[u8])> {
+    let first = *data.first()?;
+    match first {
+        0x81 => {
+            let (bytes, rest) = data.get(1..3)?.split_at(2);
+            let n = i16::from_le_bytes([bytes[0], bytes[1]]);
+            if n < 0 {
+                return None;
+            }
+            Some((n as usize, rest))
+        }
+        0x82 => {
+            let (bytes, rest) = data.get(1..5)?.split_at(4);
+            let n = i32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            if n < 0 {
+                return None;
+            }
+            Some((n as usize, rest))
+        }
+        0x83 => {
+            let (bytes, rest) = data.get(1..9)?.split_at(8);
+            let n = i64::from_le_bytes(bytes.try_into().ok()?);
+            if n < 0 || n > isize::MAX as i64 {
+                return None;
+            }
+            Some((n as usize, rest))
+        }
+        0x00..=0x7F => Some((first as usize, &data[1..])),
+        _ => None,
+    }
+}
+
+fn utf8_lossy_trim(rest: &[u8], len: usize) -> Option<String> {
+    let bytes = rest.get(..len)?;
+    let text = String::from_utf8_lossy(bytes).trim().to_string();
+    if text.is_empty() {
+        None
+    } else {
+        Some(text)
+    }
+}
+
+fn looks_like_message_text(text: &str) -> bool {
+    if text.is_empty() || text.len() > 8 * 1024 {
+        return false;
+    }
+    let classish = matches!(
+        text,
+        "NSString"
+            | "NSMutableString"
+            | "NSAttributedString"
+            | "NSMutableAttributedString"
+            | "NSDictionary"
+            | "NSObject"
+            | "streamtyped"
+    );
+    !classish && text.chars().any(|c| !c.is_ascii_control())
+}
+
+fn longest_printable_run(blob: &[u8]) -> Option<String> {
+    let mut best: Option<String> = None;
+    let mut start = None;
+    for (i, &b) in blob.iter().enumerate() {
+        let printable = (0x20..=0x7E).contains(&b) || b >= 0xC0;
+        if printable {
+            if start.is_none() {
+                start = Some(i);
+            }
+        } else if let Some(s) = start.take() {
+            consider_run(blob, s, i, &mut best);
+        }
+    }
+    if let Some(s) = start {
+        consider_run(blob, s, blob.len(), &mut best);
+    }
+    best
+}
+
+fn consider_run(blob: &[u8], start: usize, end: usize, best: &mut Option<String>) {
+    if end.saturating_sub(start) < 3 {
+        return;
+    }
+    if let Ok(text) = std::str::from_utf8(&blob[start..end]) {
+        let text = text.trim();
+        if looks_like_message_text(text)
+            && text.len() > best.as_ref().map(|s| s.len()).unwrap_or(0)
+        {
+            *best = Some(text.to_string());
+        }
+    }
+}
+
+fn find_bytes(hay: &[u8], needle: &[u8]) -> Option<usize> {
+    hay.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Title + body from a usernoted `record.data` blob (bplist / NSKeyedArchiver).
+pub fn parse_usernoted_notification(data: &[u8]) -> Option<(String, String)> {
+    if data.starts_with(b"bplist") {
+        if let Ok(value) = plist::Value::from_reader(Cursor::new(data)) {
+            if let Some(found) = walk_plist_notification(&value) {
+                return Some(found);
+            }
+        }
+    }
+    if let Some(text) = extract_typedstream_text(data) {
+        return Some((text, String::new()));
+    }
+    None
+}
+
+fn walk_plist_notification(value: &plist::Value) -> Option<(String, String)> {
+    let mut title = None;
+    let mut subtitle = None;
+    let mut body = None;
+    walk_plist(value, &mut title, &mut subtitle, &mut body);
+    let title = title.or(subtitle)?;
+    Some((title, body.unwrap_or_default()))
+}
+
+fn walk_plist(
+    value: &plist::Value,
+    title: &mut Option<String>,
+    subtitle: &mut Option<String>,
+    body: &mut Option<String>,
+) {
+    match value {
+        plist::Value::Dictionary(dict) => {
+            for (key, child) in dict {
+                let k = key.to_ascii_lowercase();
+                if let Some(s) = child.as_string() {
+                    let s = s.trim();
+                    if s.is_empty() {
+                        continue;
+                    }
+                    match k.as_str() {
+                        "titl" | "title" => *title = Some(s.to_string()),
+                        "subt" | "subtitle" => *subtitle = Some(s.to_string()),
+                        "body" => *body = Some(s.to_string()),
+                        _ => {}
+                    }
+                }
+                walk_plist(child, title, subtitle, body);
+            }
+        }
+        plist::Value::Array(items) => {
+            for child in items {
+                walk_plist(child, title, subtitle, body);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub fn chat_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/"))
+        .join("Library/Messages/chat.db")
+}
+
+pub fn usernoted_db_path() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("/"))
+        .join("Library/Group Containers/group.com.apple.usernoted/db2/db")
+}
+
+pub fn fda_status() -> FdaStatus {
+    fda_status_for(&chat_db_path(), &usernoted_db_path())
+}
+
+pub fn fda_status_for(chat_db: &Path, usernoted: &Path) -> FdaStatus {
+    let chat_exists = chat_db.exists();
+    let note_exists = usernoted.exists();
+    if !chat_exists && !note_exists {
+        return FdaStatus::Unavailable;
+    }
+    let chat_ok = !chat_exists || open_readonly(chat_db).is_ok();
+    let note_ok = !note_exists || open_readonly(usernoted).is_ok();
+    if chat_ok && note_ok {
+        FdaStatus::Granted
+    } else {
+        FdaStatus::Denied
+    }
+}
+
+pub fn open_fda_settings() -> Result<(), String> {
+    open::that(FDA_SETTINGS_URL).map_err(|e| e.to_string())
+}
+
+pub fn open_accessibility_settings() -> Result<(), String> {
+    open::that(ACCESSIBILITY_SETTINGS_URL).map_err(|e| e.to_string())
+}
+
+fn open_readonly(path: &Path) -> Result<Connection, String> {
+    Connection::open_with_flags(
+        path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|e| e.to_string())
+}
+
+pub fn snapshot() -> MessagesSnapshot {
+    snapshot_from(Some(&chat_db_path()), Some(&usernoted_db_path()))
+}
+
+/// Testable snapshot: each path is optional so fixtures can omit a store.
+pub fn snapshot_from(chat_db: Option<&Path>, usernoted: Option<&Path>) -> MessagesSnapshot {
+    let chat_path = chat_db.unwrap_or_else(|| Path::new(""));
+    let note_path = usernoted.unwrap_or_else(|| Path::new(""));
+    let fda = if chat_path.as_os_str().is_empty() && note_path.as_os_str().is_empty() {
+        FdaStatus::Unavailable
+    } else {
+        fda_status_for(chat_path, note_path)
+    };
+
+    let mut conversations = Vec::new();
+    if let Some(path) = chat_db.filter(|p| p.exists()) {
+        match read_imessage_conversations(path) {
+            Ok(rows) => conversations.extend(rows),
+            Err(err) => log::debug!("chat.db read: {err}"),
+        }
+    }
+    if let Some(path) = usernoted.filter(|p| p.exists()) {
+        match read_whatsapp_notifications(path) {
+            Ok(rows) => conversations.extend(rows),
+            Err(err) => log::debug!("usernoted read: {err}"),
+        }
+    }
+
+    conversations.sort_by(|a, b| {
+        b.last_date
+            .partial_cmp(&a.last_date)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    if conversations.len() > RECENT_LIMIT {
+        conversations.truncate(RECENT_LIMIT);
+    }
+
+    let max_rowid = conversations
+        .iter()
+        .filter(|c| c.service != MessageService::WhatsApp)
+        .map(|c| c.last_rowid)
+        .max()
+        .unwrap_or(0);
+    let watermark = seed_global_watermark(max_rowid);
+    for row in &mut conversations {
+        if row.service == MessageService::WhatsApp {
+            let seen = get_watermark(&row.id);
+            row.unread = row.last_rowid > seen && !row.from_me;
+        } else {
+            row.unread = row.last_rowid > watermark && !row.from_me;
+        }
+    }
+
+    let incoming = incoming_peek(&conversations);
+    MessagesSnapshot {
+        conversations,
+        incoming,
+        fda,
+        last_rowid: max_rowid,
+    }
+}
+
+pub fn incoming_peek(conversations: &[Conversation]) -> Option<IncomingPeek> {
+    conversations
+        .iter()
+        .filter(|c| c.unread && !c.from_me && !c.snippet.is_empty())
+        .max_by(|a, b| {
+            a.last_date
+                .partial_cmp(&b.last_date)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.last_rowid.cmp(&b.last_rowid))
+        })
+        .map(|c| IncomingPeek {
+            conversation_id: c.id.clone(),
+            sender: c.title.clone(),
+            snippet: c.snippet.clone(),
+            service: c.service,
+        })
+}
+
+/// First launch seeds the watermark at the current max ROWID so history
+/// does not dump into the compact peek.
+pub fn seed_global_watermark(max_rowid: i64) -> i64 {
+    let existing = get_watermark(GLOBAL_WATERMARK);
+    if existing <= 0 && max_rowid > 0 {
+        set_watermark(GLOBAL_WATERMARK, max_rowid);
+        max_rowid
+    } else {
+        existing
+    }
+}
+
+pub fn mark_conversation_seen(conversation_id: &str, rowid: i64) {
+    if conversation_id.is_empty() || rowid <= 0 {
+        return;
+    }
+    set_watermark(conversation_id, rowid);
+    let global = get_watermark(GLOBAL_WATERMARK);
+    if rowid > global {
+        set_watermark(GLOBAL_WATERMARK, rowid);
+    }
+}
+
+pub fn send_imessage(chat_guid: &str, text: &str) -> Result<(), String> {
+    let guid = parse_chat_guid(chat_guid).ok_or_else(|| "invalid chat GUID".to_string())?;
+    let body = text.trim();
+    if body.is_empty() {
+        return Err("empty message".into());
+    }
+    let script = format!(
+        "tell application \"Messages\" to send {} to chat id {}",
+        applescript_literal(body),
+        applescript_literal(&guid.raw)
+    );
+    crate::utils::run_osascript(&script).map(|_| ())
+}
+
+pub fn reply_whatsapp(phone: &str, text: &str, auto_send: bool) -> Result<(), String> {
+    let url = whatsapp_send_url(phone, text)
+        .ok_or_else(|| "WhatsApp prefill needs an international phone number".to_string())?;
+    open::that(&url).map_err(|e| e.to_string())?;
+    if auto_send {
+        if let Err(err) = press_whatsapp_send() {
+            log::warn!("whatsapp auto-send skipped: {err}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn press_whatsapp_send() -> Result<(), String> {
+    if !accessibility_trusted() {
+        return Err(
+            "Accessibility is off — grant it in System Settings to auto-press Return in WhatsApp"
+                .into(),
+        );
+    }
+    press_return_key();
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn press_whatsapp_send() -> Result<(), String> {
+    Err("WhatsApp auto-send is only available on macOS".into())
+}
+
+#[cfg(target_os = "macos")]
+fn accessibility_trusted() -> bool {
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
+        fn AXIsProcessTrusted() -> bool;
+    }
+    unsafe { AXIsProcessTrusted() }
+}
+
+#[cfg(target_os = "macos")]
+fn press_return_key() {
+    type CgEventRef = *mut std::ffi::c_void;
+    const KEY_RETURN: u16 = 36;
+    #[link(name = "ApplicationServices", kind = "framework")]
+    unsafe extern "C" {
+        fn CGEventCreateKeyboardEvent(
+            source: *const std::ffi::c_void,
+            virtualKey: u16,
+            keyDown: bool,
+        ) -> CgEventRef;
+        fn CGEventPost(tap: u32, event: CgEventRef);
+        fn CFRelease(cf: CgEventRef);
+    }
+    unsafe {
+        let down = CGEventCreateKeyboardEvent(std::ptr::null(), KEY_RETURN, true);
+        let up = CGEventCreateKeyboardEvent(std::ptr::null(), KEY_RETURN, false);
+        if !down.is_null() {
+            CGEventPost(0, down);
+            CFRelease(down);
+        }
+        if !up.is_null() {
+            CGEventPost(0, up);
+            CFRelease(up);
+        }
+    }
+}
+
+fn gen_tx() -> &'static watch::Sender<u64> {
+    static TX: OnceLock<watch::Sender<u64>> = OnceLock::new();
+    TX.get_or_init(|| {
+        let (tx, _rx) = watch::channel(0);
+        tx
+    })
+}
+
+/// Bump the generation so the island re-reads. Used on settings toggle.
+pub fn request_refresh() {
+    let tx = gen_tx();
+    let next = tx.borrow().saturating_add(1);
+    let _ = tx.send(next);
+}
+
+pub fn subscribe() -> watch::Receiver<u64> {
+    start_watchers();
+    gen_tx().subscribe()
+}
+
+/// FSEvents / kqueue (or inotify on Linux) on the Messages and usernoted
+/// directories. Idle cost is two dormant watchers; no poll loop.
+pub fn start_watchers() {
+    static ONCE: Once = Once::new();
+    ONCE.call_once(|| {
+        let tx = gen_tx().clone();
+        let (evt_tx, evt_rx) = std::sync::mpsc::channel::<()>();
+        let mut watchers = Vec::new();
+        for root in watch_roots() {
+            let etx = evt_tx.clone();
+            match notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+                if let Ok(event) = res {
+                    if event_is_message_store(&event) {
+                        let _ = etx.send(());
+                    }
+                }
+            }) {
+                Ok(mut watcher) => {
+                    if let Err(err) = watcher.watch(&root, notify::RecursiveMode::NonRecursive) {
+                        log::debug!("messages watch {root:?}: {err}");
+                    } else {
+                        log::info!("messages watching {root:?}");
+                        watchers.push(watcher);
+                    }
+                }
+                Err(err) => log::debug!("messages watcher: {err}"),
+            }
+        }
+        let _ = evt_tx; // keep a sender only if watchers exist
+        if let Err(err) = std::thread::Builder::new()
+            .name("nook-messages-watch".into())
+            .spawn(move || debounce_loop(evt_rx, tx))
+        {
+            log::warn!("messages watch thread: {err}");
+        }
+        static WATCHERS: OnceLock<Mutex<Vec<notify::RecommendedWatcher>>> = OnceLock::new();
+        let _ = WATCHERS.set(Mutex::new(watchers));
+    });
+}
+
+fn watch_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(dir) = chat_db_path().parent() {
+        if dir.is_dir() {
+            roots.push(dir.to_path_buf());
+        }
+    }
+    if let Some(dir) = usernoted_db_path().parent() {
+        if dir.is_dir() {
+            roots.push(dir.to_path_buf());
+        }
+    }
+    roots
+}
+
+fn event_is_message_store(event: &notify::Event) -> bool {
+    event.paths.iter().any(|path| {
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or_default();
+        name.starts_with("chat.db") || name == "db" || name.starts_with("db-")
+    })
+}
+
+fn debounce_loop(rx: std::sync::mpsc::Receiver<()>, tx: watch::Sender<u64>) {
+    loop {
+        if rx.recv().is_err() {
+            break;
+        }
+        loop {
+            match rx.recv_timeout(WATCH_DEBOUNCE) {
+                Ok(()) => continue,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => return,
+            }
+        }
+        let next = tx.borrow().saturating_add(1);
+        let _ = tx.send(next);
+    }
+}
+
+fn read_imessage_conversations(path: &Path) -> Result<Vec<Conversation>, String> {
+    let conn = open_readonly(path)?;
+    let sql = "
+        SELECT
+            c.guid,
+            c.display_name,
+            c.chat_identifier,
+            c.style,
+            m.ROWID,
+            m.text,
+            m.attributedBody,
+            m.is_from_me,
+            m.date,
+            m.is_read,
+            h.id
+        FROM chat c
+        JOIN (
+            SELECT chat_id, MAX(message_id) AS message_id
+            FROM chat_message_join
+            GROUP BY chat_id
+        ) latest ON latest.chat_id = c.ROWID
+        JOIN message m ON m.ROWID = latest.message_id
+        LEFT JOIN handle h ON h.ROWID = m.handle_id
+        ORDER BY m.date DESC
+        LIMIT 40
+    ";
+    let mut stmt = conn.prepare(sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            let guid: String = row.get(0)?;
+            let display_name: Option<String> = row.get(1)?;
+            let chat_identifier: Option<String> = row.get(2)?;
+            let style: i64 = row.get::<_, Option<i64>>(3)?.unwrap_or(0);
+            let rowid: i64 = row.get(4)?;
+            let text: Option<String> = row.get(5)?;
+            let attributed: Option<Vec<u8>> = row.get(6)?;
+            let from_me: i64 = row.get::<_, Option<i64>>(7)?.unwrap_or(0);
+            let date: i64 = row.get::<_, Option<i64>>(8)?.unwrap_or(0);
+            let handle: Option<String> = row.get(10)?;
+            Ok(imessage_row(
+                guid,
+                display_name,
+                chat_identifier,
+                style,
+                rowid,
+                text,
+                attributed,
+                from_me != 0,
+                date,
+                handle,
+            ))
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        if let Ok(conv) = row {
+            out.push(conv);
+        }
+    }
+    Ok(out)
+}
+
+fn imessage_row(
+    guid: String,
+    display_name: Option<String>,
+    chat_identifier: Option<String>,
+    style: i64,
+    rowid: i64,
+    text: Option<String>,
+    attributed: Option<Vec<u8>>,
+    from_me: bool,
+    date: i64,
+    handle: Option<String>,
+) -> Conversation {
+    let parsed = parse_chat_guid(&guid);
+    let is_group = parsed
+        .as_ref()
+        .map(|g| g.is_group)
+        .unwrap_or(style == 43);
+    let service = match parsed
+        .as_ref()
+        .map(|g| g.service.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("sms") | Some("rcs") => MessageService::Sms,
+        _ => MessageService::IMessage,
+    };
+    let handle = handle
+        .filter(|s| !s.is_empty())
+        .or_else(|| {
+            parsed
+                .as_ref()
+                .filter(|g| !g.is_group)
+                .map(|g| g.identifier.clone())
+        })
+        .or(chat_identifier.clone())
+        .filter(|s| !s.is_empty());
+    let title = display_name
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| handle.clone())
+        .or_else(|| chat_identifier.clone())
+        .unwrap_or_else(|| "Message".into());
+    let snippet = text
+        .and_then(|s| {
+            let t = s.trim().to_string();
+            if t.is_empty() {
+                None
+            } else {
+                Some(t)
+            }
+        })
+        .or_else(|| attributed.as_deref().and_then(extract_typedstream_text))
+        .unwrap_or_default();
+    Conversation {
+        id: guid.clone(),
+        service,
+        title,
+        handle,
+        snippet,
+        from_me,
+        unread: false,
+        last_rowid: rowid,
+        last_date: apple_date_to_unix(date),
+        is_group,
+        chat_guid: parsed.map(|g| g.raw),
+    }
+}
+
+fn apple_date_to_unix(date: i64) -> f64 {
+    if date == 0 {
+        return 0.0;
+    }
+    let seconds = if date.abs() > 1_000_000_000_000 {
+        date as f64 / 1_000_000_000.0
+    } else if date.abs() > 10_000_000_000 {
+        date as f64 / 1_000_000.0
+    } else {
+        date as f64
+    };
+    APPLE_EPOCH as f64 + seconds
+}
+
+fn read_whatsapp_notifications(path: &Path) -> Result<Vec<Conversation>, String> {
+    let conn = open_readonly(path)?;
+    let tables = table_names(&conn)?;
+    if !tables.iter().any(|t| t == "record") {
+        return Ok(Vec::new());
+    }
+    let app_col = if tables.iter().any(|t| t == "app") {
+        Some(app_identifier_column(&conn).unwrap_or_else(|| "identifier".into()))
+    } else {
+        None
+    };
+    let data_col = first_existing_column(&conn, "record", &["data", "payload"])
+        .ok_or_else(|| "usernoted record has no data column".to_string())?;
+    let date_col = first_existing_column(&conn, "record", &["delivered_date", "date", "timestamp"]);
+    let app_id_col = first_existing_column(&conn, "record", &["app_id", "app"]);
+
+    let sql = match (&app_col, &app_id_col, &date_col) {
+        (Some(ident), Some(app_id), Some(date)) => format!(
+            "SELECT r.rowid, a.{ident}, r.{date}, r.{data_col}
+             FROM record r
+             JOIN app a ON a.app_id = r.{app_id}
+             ORDER BY r.rowid DESC
+             LIMIT 40"
+        ),
+        (_, Some(app_id), Some(date)) => format!(
+            "SELECT r.rowid, r.{app_id}, r.{date}, r.{data_col}
+             FROM record r
+             ORDER BY r.rowid DESC
+             LIMIT 40"
+        ),
+        (_, _, Some(date)) => format!(
+            "SELECT r.rowid, NULL, r.{date}, r.{data_col}
+             FROM record r
+             ORDER BY r.rowid DESC
+             LIMIT 40"
+        ),
+        _ => format!(
+            "SELECT r.rowid, NULL, 0, r.{data_col}
+             FROM record r
+             ORDER BY r.rowid DESC
+             LIMIT 40"
+        ),
+    };
+
+    let mut stmt = conn.prepare(&sql).map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| {
+            let rowid: i64 = row.get(0)?;
+            let app: Option<String> = row.get(1)?;
+            let date: f64 = match row.get::<_, Option<f64>>(2) {
+                Ok(v) => v.unwrap_or(0.0),
+                Err(_) => row
+                    .get::<_, Option<i64>>(2)
+                    .ok()
+                    .flatten()
+                    .map(|n| n as f64)
+                    .unwrap_or(0.0),
+            };
+            let data: Option<Vec<u8>> = row.get(3)?;
+            Ok((rowid, app, date, data))
+        })
+        .map_err(|e| e.to_string())?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let Ok((rowid, app, date, data)) = row else {
+            continue;
+        };
+        let bundle = app.unwrap_or_default();
+        if !is_whatsapp_bundle(&bundle) {
+            continue;
+        }
+        let (title, body) = data
+            .as_deref()
+            .and_then(parse_usernoted_notification)
+            .unwrap_or_else(|| ("WhatsApp".into(), String::new()));
+        let handle = e164_digits(&title)
+            .or_else(|| e164_digits(&body))
+            .map(|d| format!("+{d}"));
+        let id = format!("wa:{title}:{rowid}");
+        out.push(Conversation {
+            id,
+            service: MessageService::WhatsApp,
+            title,
+            handle,
+            snippet: body,
+            from_me: false,
+            unread: false,
+            last_rowid: rowid,
+            last_date: if date > 1_000_000_000_000.0 {
+                date / 1_000_000_000.0
+            } else if date > 10_000_000_000.0 {
+                date / 1_000.0
+            } else {
+                date
+            },
+            is_group: false,
+            chat_guid: None,
+        });
+    }
+    Ok(out)
+}
+
+fn is_whatsapp_bundle(bundle: &str) -> bool {
+    let lower = bundle.to_ascii_lowercase();
+    WHATSAPP_BUNDLES
+        .iter()
+        .any(|id| lower == id.to_ascii_lowercase())
+        || lower.contains("whatsapp")
+}
+
+fn table_names(conn: &Connection) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|e| e.to_string())?;
+    Ok(rows.flatten().collect())
+}
+
+fn first_existing_column(conn: &Connection, table: &str, names: &[&str]) -> Option<String> {
+    let cols = column_names(conn, table).ok()?;
+    names
+        .iter()
+        .find(|n| cols.iter().any(|c| c.eq_ignore_ascii_case(n)))
+        .map(|s| (*s).to_string())
+}
+
+fn column_names(conn: &Connection, table: &str) -> Result<Vec<String>, String> {
+    let mut stmt = conn
+        .prepare(&format!("PRAGMA table_info({table})"))
+        .map_err(|e| e.to_string())?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(|e| e.to_string())?;
+    Ok(rows.flatten().collect())
+}
+
+fn app_identifier_column(conn: &Connection) -> Option<String> {
+    first_existing_column(conn, "app", &["identifier", "bundle_id", "app", "name"])
+}
+
+fn get_watermark(conversation_id: &str) -> i64 {
+    let Ok(conn) = database::get_connection() else {
+        return 0;
+    };
+    conn.query_row(
+        "SELECT last_rowid FROM message_watermarks WHERE conversation_id = ?1",
+        [conversation_id],
+        |row| row.get(0),
+    )
+    .unwrap_or(0)
+}
+
+fn set_watermark(conversation_id: &str, rowid: i64) {
+    let Ok(conn) = database::get_connection() else {
+        return;
+    };
+    if let Err(err) = conn.execute(
+        "INSERT INTO message_watermarks (conversation_id, last_rowid) VALUES (?1, ?2)
+         ON CONFLICT(conversation_id) DO UPDATE SET last_rowid = excluded.last_rowid",
+        rusqlite::params![conversation_id, rowid],
+    ) {
+        log::debug!("message watermark: {err}");
+    }
+}
+
+fn encode_nx_int(n: usize) -> Vec<u8> {
+    if n <= 127 {
+        vec![n as u8]
+    } else if n <= i16::MAX as usize {
+        let mut v = vec![0x81];
+        v.extend_from_slice(&(n as i16).to_le_bytes());
+        v
+    } else {
+        let mut v = vec![0x82];
+        v.extend_from_slice(&(n as i32).to_le_bytes());
+        v
+    }
+}
+
+/// Build a minimal `streamtyped` blob for tests.
+pub fn typedstream_for_text(text: &str) -> Vec<u8> {
+    let mut blob = b"\x04\x0bstreamtyped".to_vec();
+    blob.extend_from_slice(b"NSString");
+    blob.push(0x2B);
+    blob.extend(encode_nx_int(text.len()));
+    blob.extend_from_slice(text.as_bytes());
+    blob
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_path(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "nook-wp23-{name}-{}-{nanos}.db",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn parse_chat_guid_accepts_imessage_sms_and_groups() {
+        let one = parse_chat_guid("iMessage;-;+491701234567").unwrap();
+        assert_eq!(one.service, "iMessage");
+        assert!(!one.is_group);
+        assert_eq!(one.identifier, "+491701234567");
+
+        let sms = parse_chat_guid("SMS;-;+15551234567").unwrap();
+        assert_eq!(sms.service, "SMS");
+        assert!(!sms.is_group);
+
+        let group = parse_chat_guid("iMessage;+;chat838492").unwrap();
+        assert!(group.is_group);
+        assert_eq!(group.identifier, "chat838492");
+
+        let email = parse_chat_guid("iMessage;-;ada@example.com").unwrap();
+        assert_eq!(email.identifier, "ada@example.com");
+    }
+
+    #[test]
+    fn parse_chat_guid_rejects_injection() {
+        assert!(parse_chat_guid("").is_none());
+        assert!(parse_chat_guid("iMessage;+49").is_none());
+        assert!(parse_chat_guid("iMessage;-;+49\"; beep").is_none());
+        assert!(parse_chat_guid("iMessage;-;+49\nfoo").is_none());
+        assert!(parse_chat_guid("not a guid").is_none());
+        assert!(parse_chat_guid("iMessage;x;+1").is_none());
+    }
+
+    #[test]
+    fn e164_digits_normalizes_handles() {
+        assert_eq!(e164_digits("+49 170 1234567").as_deref(), Some("491701234567"));
+        assert_eq!(e164_digits("whatsapp:+15551234567").as_deref(), Some("15551234567"));
+        assert_eq!(e164_digits("0015551234567").as_deref(), Some("15551234567"));
+        assert_eq!(e164_digits("tel:+14155552671").as_deref(), Some("14155552671"));
+        assert!(e164_digits("ada@example.com").is_none());
+        assert!(e164_digits("01701234567").is_none());
+        assert!(e164_digits("chat838492").is_none());
+        assert!(e164_digits("").is_none());
+    }
+
+    #[test]
+    fn whatsapp_send_url_prefills_without_autosend() {
+        let url = whatsapp_send_url("+49 170 1234567", "hello there").unwrap();
+        assert_eq!(
+            url,
+            "whatsapp://send?phone=491701234567&text=hello%20there"
+        );
+        let escaped = whatsapp_send_url("+15551234567", "ok&go=1").unwrap();
+        assert!(escaped.contains("text=ok%26go%3D1"));
+        assert!(whatsapp_send_url("not-a-phone", "hi").is_none());
+    }
+
+    #[test]
+    fn applescript_literal_escapes_quotes_and_newlines() {
+        assert_eq!(applescript_literal(r#"hi "there""#), r#""hi \"there\"""#);
+        assert_eq!(applescript_literal("line1\nline2"), r#""line1 line2""#);
+        assert_eq!(applescript_literal(r#"a\b"#), r#""a\\b""#);
+    }
+
+    #[test]
+    fn extract_typedstream_text_reads_nx_lengths() {
+        let short = typedstream_for_text("hello island");
+        assert_eq!(
+            extract_typedstream_text(&short).as_deref(),
+            Some("hello island")
+        );
+
+        let long_body = "x".repeat(200);
+        let long = typedstream_for_text(&long_body);
+        assert!(long.contains(&0x81), "200-byte payload uses 0x81 length");
+        assert_eq!(extract_typedstream_text(&long).as_deref(), Some(long_body.as_str()));
+
+        assert!(extract_typedstream_text(&[]).is_none());
+        assert_eq!(
+            extract_typedstream_text(b"xxxxNSString garbage").as_deref(),
+            None
+        );
+    }
+
+    #[test]
+    fn incoming_peek_picks_newest_unread_not_from_me() {
+        let rows = vec![
+            Conversation {
+                id: "a".into(),
+                service: MessageService::IMessage,
+                title: "Ada".into(),
+                handle: None,
+                snippet: "old".into(),
+                from_me: false,
+                unread: true,
+                last_rowid: 1,
+                last_date: 10.0,
+                is_group: false,
+                chat_guid: None,
+            },
+            Conversation {
+                id: "b".into(),
+                service: MessageService::WhatsApp,
+                title: "Bea".into(),
+                handle: None,
+                snippet: "new".into(),
+                from_me: false,
+                unread: true,
+                last_rowid: 2,
+                last_date: 20.0,
+                is_group: false,
+                chat_guid: None,
+            },
+            Conversation {
+                id: "c".into(),
+                service: MessageService::IMessage,
+                title: "Me".into(),
+                handle: None,
+                snippet: "mine".into(),
+                from_me: true,
+                unread: true,
+                last_rowid: 3,
+                last_date: 30.0,
+                is_group: false,
+                chat_guid: None,
+            },
+        ];
+        let peek = incoming_peek(&rows).unwrap();
+        assert_eq!(peek.sender, "Bea");
+        assert_eq!(peek.snippet, "new");
+        assert_eq!(peek.service, MessageService::WhatsApp);
+    }
+
+    #[test]
+    fn snapshot_reads_fixture_chat_db_and_usernoted() {
+        let chat = temp_path("chat");
+        let notes = temp_path("noted");
+        write_chat_fixture(&chat);
+        write_usernoted_fixture(&notes);
+
+        let snap = snapshot_from(Some(&chat), Some(&notes));
+        assert_eq!(snap.fda, FdaStatus::Granted);
+        assert!(
+            snap.conversations
+                .iter()
+                .any(|c| c.title == "Ada" && c.snippet == "typed hello" && c.chat_guid.is_some())
+        );
+        assert!(
+            snap.conversations
+                .iter()
+                .any(|c| c.service == MessageService::WhatsApp && c.title == "Bea")
+        );
+
+        let _ = fs::remove_file(&chat);
+        let _ = fs::remove_file(&notes);
+    }
+
+    #[test]
+    fn fda_unavailable_when_paths_missing() {
+        let missing = std::env::temp_dir().join("nook-wp23-does-not-exist-chat.db");
+        let _ = fs::remove_file(&missing);
+        assert_eq!(
+            fda_status_for(&missing, &missing),
+            FdaStatus::Unavailable
+        );
+    }
+
+    #[test]
+    fn parse_usernoted_notification_reads_bplist_keys() {
+        let mut req = plist::Dictionary::new();
+        req.insert("titl".into(), plist::Value::String("Bea".into()));
+        req.insert("body".into(), plist::Value::String("on my way".into()));
+        let mut root = plist::Dictionary::new();
+        root.insert("req".into(), plist::Value::Dictionary(req));
+        let mut buf = Vec::new();
+        plist::to_writer_binary(&mut buf, &plist::Value::Dictionary(root)).unwrap();
+        assert_eq!(
+            parse_usernoted_notification(&buf),
+            Some(("Bea".into(), "on my way".into()))
+        );
+    }
+
+    #[test]
+    fn notify_watch_sees_a_write() {
+        let dir = std::env::temp_dir().join(format!(
+            "nook-wp23-watch-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("chat.db-wal");
+        fs::write(&path, b"init").unwrap();
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let mut watcher =
+            notify::recommended_watcher(move |res: notify::Result<notify::Event>| {
+                if let Ok(event) = res {
+                    if event_is_message_store(&event) {
+                        let _ = tx.send(());
+                    }
+                }
+            })
+            .unwrap();
+        watcher
+            .watch(&dir, notify::RecursiveMode::NonRecursive)
+            .unwrap();
+        fs::write(&path, b"changed").unwrap();
+        rx.recv_timeout(Duration::from_secs(3))
+            .expect("watcher should wake on WAL write");
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    fn write_chat_fixture(path: &Path) {
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE handle (ROWID INTEGER PRIMARY KEY, id TEXT);
+            CREATE TABLE chat (
+                ROWID INTEGER PRIMARY KEY,
+                guid TEXT,
+                display_name TEXT,
+                chat_identifier TEXT,
+                style INTEGER
+            );
+            CREATE TABLE message (
+                ROWID INTEGER PRIMARY KEY,
+                text TEXT,
+                attributedBody BLOB,
+                is_from_me INTEGER,
+                date INTEGER,
+                is_read INTEGER,
+                handle_id INTEGER
+            );
+            CREATE TABLE chat_message_join (chat_id INTEGER, message_id INTEGER);
+            INSERT INTO handle VALUES (1, '+491701234567');
+            INSERT INTO chat VALUES (1, 'iMessage;-;+491701234567', 'Ada', '+491701234567', 45);
+            INSERT INTO message VALUES (10, NULL, X'', 0, 1000, 0, 1);
+            INSERT INTO chat_message_join VALUES (1, 10);
+            ",
+        )
+        .unwrap();
+        let blob = typedstream_for_text("typed hello");
+        conn.execute(
+            "UPDATE message SET attributedBody = ?1 WHERE ROWID = 10",
+            [blob],
+        )
+        .unwrap();
+    }
+
+    fn write_usernoted_fixture(path: &Path) {
+        let mut req = plist::Dictionary::new();
+        req.insert("titl".into(), plist::Value::String("Bea".into()));
+        req.insert("body".into(), plist::Value::String("ping".into()));
+        let mut root = plist::Dictionary::new();
+        root.insert("req".into(), plist::Value::Dictionary(req));
+        let mut buf = Vec::new();
+        plist::to_writer_binary(&mut buf, &plist::Value::Dictionary(root)).unwrap();
+
+        let conn = Connection::open(path).unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE app (app_id INTEGER PRIMARY KEY, identifier TEXT);
+            CREATE TABLE record (
+                rec_id INTEGER PRIMARY KEY,
+                app_id INTEGER,
+                delivered_date REAL,
+                data BLOB
+            );
+            INSERT INTO app VALUES (1, 'net.whatsapp.WhatsApp');
+            ",
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO record (rec_id, app_id, delivered_date, data) VALUES (5, 1, 1700000000, ?1)",
+            [buf],
+        )
+        .unwrap();
+    }
+}

--- a/crates/nook-core/src/messages.rs
+++ b/crates/nook-core/src/messages.rs
@@ -1292,7 +1292,14 @@ mod tests {
         assert_eq!(sender_initials("+49 151 0000"), "?");
         assert_eq!(sender_initials(""), "?");
         assert_eq!(sender_avatar_rgb("Ada"), sender_avatar_rgb("Ada"));
-        assert_ne!(sender_avatar_rgb("Ada"), sender_avatar_rgb("Bea"));
+        let palette: Vec<u32> = ["Ada", "Bea", "Cam", "Dee", "Eve", "Fay"]
+            .iter()
+            .map(|n| sender_avatar_rgb(n))
+            .collect();
+        assert!(
+            palette.windows(2).any(|w| w[0] != w[1]),
+            "initials avatars should not all share one fill"
+        );
     }
 
     #[test]

--- a/crates/nook-core/src/messages.rs
+++ b/crates/nook-core/src/messages.rs
@@ -96,6 +96,8 @@ pub struct IncomingPeek {
     pub sender: String,
     pub snippet: String,
     pub service: MessageService,
+    /// Unix seconds (`apple_date_to_unix` for iMessage, wall time for WhatsApp).
+    pub last_date: f64,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -539,7 +541,53 @@ pub fn incoming_peek(conversations: &[Conversation]) -> Option<IncomingPeek> {
             sender: c.title.clone(),
             snippet: c.snippet.clone(),
             service: c.service,
+            last_date: c.last_date,
         })
+}
+
+/// Compact HUD clock: `now`, `2m`, `3h`, `1d`.
+pub fn relative_time(unix: f64, now: f64) -> String {
+    let secs = (now - unix).max(0.0);
+    if secs < 45.0 {
+        "now".into()
+    } else if secs < 3_600.0 {
+        format!("{}m", (secs / 60.0).round() as i64)
+    } else if secs < 86_400.0 {
+        format!("{}h", (secs / 3_600.0).round() as i64)
+    } else {
+        format!("{}d", (secs / 86_400.0).round() as i64)
+    }
+}
+
+/// One or two letters for an initials avatar. Phone numbers fall back to `?`.
+pub fn sender_initials(name: &str) -> String {
+    let words: Vec<char> = name
+        .split_whitespace()
+        .filter_map(|word| word.chars().find(|c| c.is_alphabetic()))
+        .collect();
+    if words.len() >= 2 {
+        return format!(
+            "{}{}",
+            words[0].to_uppercase(),
+            words[1].to_uppercase()
+        );
+    }
+    if let Some(ch) = words.first() {
+        return ch.to_uppercase().to_string();
+    }
+    "?".into()
+}
+
+/// Stable palette index for a sender name (no Contacts photo).
+pub fn sender_avatar_rgb(name: &str) -> u32 {
+    const PALETTE: [u32; 8] = [
+        0x5AC8FA, 0xFF9F0A, 0xBF5AF2, 0xFF375F, 0x30D158, 0x64D2FF, 0xFFD60A, 0xFF453A,
+    ];
+    let mut h: u32 = 0;
+    for b in name.as_bytes() {
+        h = h.wrapping_mul(31).wrapping_add(*b as u32);
+    }
+    PALETTE[h as usize % PALETTE.len()]
 }
 
 /// First launch seeds the watermark at the current max ROWID so history
@@ -1226,6 +1274,25 @@ mod tests {
         assert_eq!(peek.sender, "Bea");
         assert_eq!(peek.snippet, "new");
         assert_eq!(peek.service, MessageService::WhatsApp);
+        assert_eq!(peek.last_date, 20.0);
+    }
+
+    #[test]
+    fn relative_time_buckets() {
+        assert_eq!(relative_time(100.0, 110.0), "now");
+        assert_eq!(relative_time(100.0, 220.0), "2m");
+        assert_eq!(relative_time(100.0, 7_300.0), "2h");
+        assert_eq!(relative_time(100.0, 180_000.0), "2d");
+    }
+
+    #[test]
+    fn sender_initials_from_name_or_question() {
+        assert_eq!(sender_initials("Ada Lovelace"), "AL");
+        assert_eq!(sender_initials("Ada"), "A");
+        assert_eq!(sender_initials("+49 151 0000"), "?");
+        assert_eq!(sender_initials(""), "?");
+        assert_eq!(sender_avatar_rgb("Ada"), sender_avatar_rgb("Ada"));
+        assert_ne!(sender_avatar_rgb("Ada"), sender_avatar_rgb("Bea"));
     }
 
     #[test]

--- a/crates/nook-core/src/messages.rs
+++ b/crates/nook-core/src/messages.rs
@@ -12,6 +12,7 @@
 //! `opennook.db` — only ROWID watermarks.
 
 use crate::database;
+use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use rusqlite::{Connection, OpenFlags};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
@@ -691,7 +692,7 @@ pub fn start_watchers() {
                 }
             }) {
                 Ok(mut watcher) => {
-                    if let Err(err) = watcher.watch(&root, notify::RecursiveMode::NonRecursive) {
+                    if let Err(err) = watcher.watch(&root, RecursiveMode::NonRecursive) {
                         log::debug!("messages watch {root:?}: {err}");
                     } else {
                         log::info!("messages watching {root:?}");
@@ -708,7 +709,7 @@ pub fn start_watchers() {
         {
             log::warn!("messages watch thread: {err}");
         }
-        static WATCHERS: OnceLock<Mutex<Vec<notify::RecommendedWatcher>>> = OnceLock::new();
+        static WATCHERS: OnceLock<Mutex<Vec<RecommendedWatcher>>> = OnceLock::new();
         let _ = WATCHERS.set(Mutex::new(watchers));
     });
 }
@@ -1310,7 +1311,7 @@ mod tests {
             })
             .unwrap();
         watcher
-            .watch(&dir, notify::RecursiveMode::NonRecursive)
+            .watch(&dir, RecursiveMode::NonRecursive)
             .unwrap();
         fs::write(&path, b"changed").unwrap();
         rx.recv_timeout(Duration::from_secs(3))

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -17,10 +17,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    Messages = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +32,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::Messages,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -44,7 +46,9 @@ impl WidgetModule {
     pub fn default_cells(self) -> u8 {
         match self {
             Self::Calendar | Self::Music => 5,
-            Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
+            Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents | Self::Messages => {
+                4
+            }
             Self::Timers | Self::Speed | Self::Mirror => 3,
         }
     }
@@ -52,7 +56,9 @@ impl WidgetModule {
     pub fn min_cells(self) -> u8 {
         match self {
             Self::Calendar => 4,
-            Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
+            Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror | Self::Messages => {
+                3
+            }
             Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
         }
     }
@@ -82,6 +88,7 @@ fn default_widget_order() -> Vec<WidgetModule> {
         WidgetModule::Timers,
         WidgetModule::Notes,
         WidgetModule::Speed,
+        WidgetModule::Messages,
     ]
 }
 
@@ -142,6 +149,11 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default = "default_true")]
+    pub show_messages: bool,
+    /// Fragile Accessibility CGEvent Return after opening `whatsapp://`.
+    #[serde(default)]
+    pub experimental_whatsapp_autosend: bool,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -231,6 +243,8 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            show_messages: true,
+            experimental_whatsapp_autosend: false,
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +290,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::Messages => self.show_messages,
         }
     }
 
@@ -291,6 +306,10 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::Messages => {
+                self.show_messages = !self.show_messages;
+                crate::messages::request_refresh();
+            }
         }
     }
 
@@ -611,6 +630,8 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.show_messages);
+        assert!(!parsed.experimental_whatsapp_autosend);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +717,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.show_messages = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook-core/src/utils.rs
+++ b/crates/nook-core/src/utils.rs
@@ -60,6 +60,38 @@ pub async fn fetch_artwork_from_url(url: &str) -> Option<String> {
     }
 }
 
+/// Run `/usr/bin/osascript`. Shared by media controls and iMessage send.
+pub fn run_osascript(script: &str) -> Result<String, String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = script;
+        return Err("osascript is only available on macOS".into());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use std::process::Command;
+        let output = Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(script)
+            .output()
+            .map_err(|e| e.to_string())?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !output.status.success() {
+            log::warn!("osascript failed ({}): {stderr}", output.status);
+            if stderr.contains("-1743") || stderr.to_lowercase().contains("not allowed") {
+                log::warn!(
+                    "Automation permission denied. Grant access in System Settings → Privacy & Security → Automation."
+                );
+            }
+            return Err(format!("osascript failed: {}", output.status));
+        }
+        if !stderr.is_empty() {
+            log::debug!("osascript stderr: {stderr}");
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    }
+}
+
 /// Encode binary data as a base64 string (used for album artwork).
 pub fn encode_bytes_base64(data: &[u8]) -> Option<String> {
     if data.is_empty() {

--- a/crates/nook/src/assets/icons/message-circle.svg
+++ b/crates/nook/src/assets/icons/message-circle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M7.9 20A9 9 0 1 0 4 16.1L2 22Z"/>
+</svg>

--- a/crates/nook/src/assets/icons/send.svg
+++ b/crates/nook/src/assets/icons/send.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"/>
+<path d="m21.854 2.147-10.94 10.939"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -64,6 +64,13 @@ impl Island {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
             CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
+            CompactMode::Messages => self
+                .messages
+                .incoming
+                .as_ref()
+                .map(widgets::messages_compact_left)
+                .map(|el| el.into_any_element())
+                .unwrap_or_else(|| div().into_any_element()),
             CompactMode::Idle => div().into_any_element(),
         }
     }
@@ -105,6 +112,13 @@ impl Island {
                 };
                 label(text, theme::BODY, true).into_any_element()
             }
+            CompactMode::Messages => self
+                .messages
+                .incoming
+                .as_ref()
+                .map(widgets::messages_compact_right)
+                .map(|el| el.into_any_element())
+                .unwrap_or_else(|| div().into_any_element()),
             CompactMode::Onboard if hovered => div()
                 .id("github")
                 .cursor(CursorStyle::PointingHand)
@@ -148,6 +162,7 @@ impl Island {
                 CompactMode::Timer => "timer",
                 CompactMode::Observe => "observe",
                 CompactMode::Onboard => "onboard",
+                CompactMode::Messages => "messages",
             };
             row = row.child(
                 div()

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, calendar_card, messages_card, notes_card, observe_card, reminders_card, speed_card,
+    timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -155,6 +156,13 @@ impl Island {
                     cell_pane(
                         self.settings.cells_for(module),
                         speed_card(self.speed_mbps, self.speed_progress, self.speed_running, cx),
+                    ),
+                ),
+                WidgetModule::Messages if self.settings.show_messages => add(
+                    &mut kids,
+                    cell_pane(
+                        self.settings.cells_for(module),
+                        messages_card(self, cx),
                     ),
                 ),
                 _ => {}

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -25,6 +25,7 @@ use nook_core::calendar::{CalendarEvent, Reminder};
 use nook_core::files::FileTrayItem;
 use nook_core::models::NowPlayingData;
 use nook_core::notch;
+use nook_core::messages::MessagesSnapshot;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
 use settings::SettingsView;
@@ -39,6 +40,7 @@ pub enum CompactMode {
     Timer,
     Observe,
     Onboard,
+    Messages,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -85,6 +87,10 @@ pub struct Island {
     pub timer_composer: bool,
     pub observe: ObserveSnapshot,
     observe_history: MetricHistory,
+    pub messages: MessagesSnapshot,
+    pub message_draft: String,
+    pub selected_conversation: Option<String>,
+    pub(crate) message_focus: Option<gpui::FocusHandle>,
     pub(crate) observe_hover: Option<crate::widgets::ObserveHover>,
     pub settings: AppSettings,
     pub first_run: bool,
@@ -212,6 +218,10 @@ impl Island {
             timer_composer: false,
             observe: ObserveSnapshot::default(),
             observe_history: nook_core::observe::load_history(),
+            messages: MessagesSnapshot::default(),
+            message_draft: String::new(),
+            selected_conversation: None,
+            message_focus: None,
             observe_hover: None,
             settings,
             first_run,
@@ -690,6 +700,57 @@ impl Island {
                 .await;
         })
         .detach();
+
+        cx.spawn(async move |this, cx| {
+            let mut rx = nook_core::messages::subscribe();
+            loop {
+                let enabled = nook_core::settings::get_app_settings().show_messages;
+                let snapshot = if enabled {
+                    cx.background_executor()
+                        .spawn(async { nook_core::messages::snapshot() })
+                        .await
+                } else {
+                    MessagesSnapshot::default()
+                };
+                if this
+                    .update(cx, |this, cx| {
+                        let was_quiet = this.messages.incoming.is_none();
+                        let incoming_id = snapshot
+                            .incoming
+                            .as_ref()
+                            .map(|p| p.conversation_id.clone());
+                        this.messages = snapshot;
+                        if was_quiet && this.messages.incoming.is_some() {
+                            this.preferred = Some(CompactMode::Messages);
+                            nook_core::haptics::trigger(None);
+                        }
+                        if let Some(id) = incoming_id {
+                            if this.selected_conversation.as_deref() == Some(id.as_str()) {
+                                if let Some(conv) = this
+                                    .messages
+                                    .conversations
+                                    .iter()
+                                    .find(|c| c.id == id)
+                                {
+                                    nook_core::messages::mark_conversation_seen(
+                                        &id,
+                                        conv.last_rowid,
+                                    );
+                                }
+                            }
+                        }
+                        cx.notify();
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+                if rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        })
+        .detach();
     }
 
     /// Merge a fresh poll into the island: extend the local sample history and
@@ -860,10 +921,17 @@ impl Island {
         self.settings.show_observe && self.observe.has_outage()
     }
 
+    fn has_incoming_message(&self) -> bool {
+        self.settings.show_messages && self.messages.incoming.is_some()
+    }
+
     fn available_modes(&self) -> Vec<CompactMode> {
         let mut modes = Vec::new();
         if self.has_observe_outage() {
             modes.push(CompactMode::Observe);
+        }
+        if self.has_incoming_message() {
+            modes.push(CompactMode::Messages);
         }
         if self.has_media() {
             modes.push(CompactMode::Media);
@@ -1451,6 +1519,10 @@ mod tests {
             timer_composer: false,
             observe: ObserveSnapshot::default(),
             observe_history: HashMap::new(),
+            messages: MessagesSnapshot::default(),
+            message_draft: String::new(),
+            selected_conversation: None,
+            message_focus: None,
             observe_hover: None,
             settings: AppSettings::default(),
             first_run: false,
@@ -1739,6 +1811,24 @@ mod tests {
         );
         assert_eq!(island.mode(), CompactMode::Agents);
         island.settings.show_agents = false;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn available_modes_includes_incoming_messages() {
+        let mut island = test_island();
+        island.messages.incoming = Some(nook_core::messages::IncomingPeek {
+            conversation_id: "iMessage;-;+1".into(),
+            sender: "Ada".into(),
+            snippet: "hi".into(),
+            service: nook_core::messages::MessageService::IMessage,
+        });
+        assert_eq!(
+            island.available_modes(),
+            vec![CompactMode::Messages, CompactMode::Idle]
+        );
+        assert_eq!(island.mode(), CompactMode::Messages);
+        island.settings.show_messages = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
     }
 

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -925,6 +925,27 @@ impl Island {
         self.settings.show_messages && self.messages.incoming.is_some()
     }
 
+    /// Compact incoming HUD — taller than a Live Activity, not the widgets grid.
+    pub(super) fn shows_messages_peek(&self) -> bool {
+        !self.expanded && self.mode() == CompactMode::Messages && self.messages.incoming.is_some()
+    }
+
+    pub(crate) fn activate_message_composer(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.message_focus.is_none() {
+            self.message_focus = Some(cx.focus_handle());
+        }
+        if let Some(focus) = self.message_focus.clone() {
+            window.activate_window();
+            platform::activate_app();
+            window.focus(&focus);
+        }
+        cx.notify();
+    }
+
     fn available_modes(&self) -> Vec<CompactMode> {
         let mut modes = Vec::new();
         if self.has_observe_outage() {
@@ -965,6 +986,11 @@ impl Island {
                 theme::NOOK_INSET + theme::NOOK_BODY
             };
             return (w, self.notch_height.max(32.0) + body);
+        }
+        if self.shows_messages_peek() {
+            let w = (base_w + 152.0).max(theme::MESSAGES_PEEK_WIDTH);
+            let h = self.notch_height.max(32.0) + theme::MESSAGES_PEEK_BODY;
+            return (w, h);
         }
         if self.hovered {
             return (base_w + 125.0, base_h + 15.0);
@@ -1265,10 +1291,19 @@ impl Island {
         !(on_ui || (self.file_drag && drag_capture) || self.pending_file_drag.is_some())
     }
 
-    fn on_island_press(&mut self, event: &MouseDownEvent, cx: &mut Context<Self>) {
+    fn on_island_press(
+        &mut self,
+        event: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if event.modifiers.alt {
             self.begin_reposition(event);
             cx.notify();
+            return;
+        }
+        if self.shows_messages_peek() {
+            self.activate_message_composer(window, cx);
             return;
         }
         self.toggle_expanded(cx);
@@ -1822,6 +1857,7 @@ mod tests {
             sender: "Ada".into(),
             snippet: "hi".into(),
             service: nook_core::messages::MessageService::IMessage,
+            last_date: 1_700_000_000.0,
         });
         assert_eq!(
             island.available_modes(),
@@ -1830,6 +1866,31 @@ mod tests {
         assert_eq!(island.mode(), CompactMode::Messages);
         island.settings.show_messages = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn incoming_messages_peek_is_taller_than_live_activity() {
+        let mut island = test_island();
+        island.notch_width = 185.0;
+        island.notch_height = 38.0;
+        island.messages.incoming = Some(nook_core::messages::IncomingPeek {
+            conversation_id: "iMessage;-;+1".into(),
+            sender: "Ada Lovelace".into(),
+            snippet: "On my way".into(),
+            service: nook_core::messages::MessageService::IMessage,
+            last_date: 1_700_000_000.0,
+        });
+        assert!(island.shows_messages_peek());
+        let (w, h) = island.target_size();
+        assert!(w >= theme::MESSAGES_PEEK_WIDTH);
+        assert_eq!(h, 38.0 + theme::MESSAGES_PEEK_BODY);
+        island.hovered = true;
+        let (hw, hh) = island.target_size();
+        assert_eq!((hw, hh), (w, h), "hover must not shrink the HUD");
+        island.expanded = true;
+        assert!(!island.shows_messages_peek());
+        let (_, eh) = island.target_size();
+        assert!(eh > h, "full Messages card stays available via expand");
     }
 
     #[test]

--- a/crates/nook/src/island/render.rs
+++ b/crates/nook/src/island/render.rs
@@ -5,6 +5,7 @@ use super::files::drop_veil;
 use super::{CompactMode, Island};
 use crate::platform;
 use crate::theme;
+use crate::widgets;
 use gpui::{
     div, point, prelude::*, px, rgba, AnyElement, App, Bounds, Context, CursorStyle,
     ExternalPaths, FontFallbacks, FontWeight, MouseButton, MouseDownEvent, MouseMoveEvent,
@@ -97,7 +98,7 @@ impl gpui::Render for Island {
             .any(|agent| agent.status.is_working())
             .then(theme::accent);
         let debug_hitbox = hitbox_debug();
-        let content_radius = if expanded {
+        let content_radius = if expanded || chrome_h > 80.0 {
             theme::EXPANDED_RADIUS
         } else {
             theme::COMPACT_RADIUS
@@ -173,8 +174,8 @@ impl gpui::Render for Island {
                         )
                         .on_mouse_down(
                             MouseButton::Left,
-                            cx.listener(|this, event: &MouseDownEvent, _, cx| {
-                                this.on_island_press(event, cx);
+                            cx.listener(|this, event: &MouseDownEvent, window, cx| {
+                                this.on_island_press(event, window, cx);
                             }),
                         )
                         .when(!expanded, |d| {
@@ -211,7 +212,9 @@ impl gpui::Render for Island {
                                 .when(!attached, |d| d.rounded(px(content_radius)))
                                 .child(self.content_stack(expanded, mode, hovered, notch_w, cx))
                                 .when(dropping && !expanded, |d| d.child(drop_veil()))
-                                .when(!expanded, |d| d.child(self.mode_dots(cx))),
+                                .when(!expanded && !self.shows_messages_peek(), |d| {
+                                    d.child(self.mode_dots(cx))
+                                }),
                         ),
                     ),
             )
@@ -343,8 +346,8 @@ impl Island {
                         // expand toggle the blocked root would have handled.
                         d.block_mouse_except_scroll().on_mouse_down(
                             MouseButton::Left,
-                            cx.listener(|this, event: &MouseDownEvent, _, cx| {
-                                this.on_island_press(event, cx);
+                            cx.listener(|this, event: &MouseDownEvent, window, cx| {
+                                this.on_island_press(event, window, cx);
                             }),
                         )
                     })
@@ -363,6 +366,11 @@ impl Island {
     ) -> AnyElement {
         if expanded {
             self.render_expanded(notch_w, cx).into_any_element()
+        } else if mode == CompactMode::Messages && self.messages.incoming.is_some() {
+            if self.message_focus.is_none() {
+                self.message_focus = Some(cx.focus_handle());
+            }
+            widgets::messages_peek(self, cx).into_any_element()
         } else {
             self.render_compact(mode, hovered, notch_w, cx)
                 .into_any_element()
@@ -390,6 +398,8 @@ impl Island {
             th.max(1.0),
         );
         let mut bottom = (body_top + body_h).max(target_top + th.max(1.0));
+        // Incoming-message HUD is taller than a Live Activity; target_size
+        // already returns that footprint so the strip grows before the spring.
         // Pre-arm on approach: reserve the expanded footprint while the
         // cursor is merely near the parked island, before any animation can
         // start. An NSWindow resize mid-animation shows one stretched frame

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -131,6 +131,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Messages => "Messages",
         }
     }
 
@@ -146,6 +147,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::Messages => "message-circle",
         }
     }
 
@@ -161,6 +163,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::Messages => "iMessage".into(),
         }
     }
 
@@ -184,6 +187,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Messages => "Messages",
         }
     }
 }
@@ -998,6 +1002,45 @@ impl SettingsView {
                     .into_any_element(),
                 );
             }
+            WidgetModule::Messages => {
+                let fda = nook_core::messages::fda_status();
+                let status = match fda {
+                    nook_core::messages::FdaStatus::Granted => "On",
+                    nook_core::messages::FdaStatus::Denied => "Off",
+                    nook_core::messages::FdaStatus::Unavailable => "Unavailable",
+                };
+                rows.push(
+                    settings_row("msg-fda-status")
+                        .child(label("Full Disk Access", theme::BODY, true))
+                        .child(label(status, theme::BODY, false))
+                        .into_any_element(),
+                );
+                rows.push(
+                    action_row(
+                        "msg-fda-open",
+                        "Privacy settings",
+                        "Open Full Disk Access",
+                        cx,
+                        |_, _, _| {
+                            if let Err(err) = nook_core::messages::open_fda_settings() {
+                                log::warn!("open FDA settings: {err}");
+                            }
+                        },
+                    )
+                    .into_any_element(),
+                );
+                rows.push(
+                    toggle_row(
+                        "Experimental WhatsApp auto-send",
+                        settings.experimental_whatsapp_autosend,
+                        cx,
+                        |s| {
+                            s.experimental_whatsapp_autosend = !s.experimental_whatsapp_autosend;
+                        },
+                    )
+                    .into_any_element(),
+                );
+            }
             _ => {}
         }
 
@@ -1356,6 +1399,9 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::Messages => {
+            "iMessage read + send from chat.db. WhatsApp is notify + prefill only — the Mac app cannot auto-send. Full Disk Access is required to read messages.".into()
+        }
     }
 }
 
@@ -1727,6 +1773,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "Messages",
             ]
         );
         assert!(!names

--- a/crates/nook/src/theme.rs
+++ b/crates/nook/src/theme.rs
@@ -244,6 +244,12 @@ pub const FOOTNOTE: Text = Text {
     emphasized: FontWeight::SEMIBOLD,
 };
 
+/// Incoming-message HUD hanging below the notch (Droppy-style pill).
+/// Width is at least this; taller notches still add the same body.
+pub const MESSAGES_PEEK_WIDTH: f32 = 332.0;
+/// Content below the camera housing: avatar + 2-line snippet + reply row.
+pub const MESSAGES_PEEK_BODY: f32 = 108.0;
+
 /// Compact Live Activity face — album chip, mode icons, timer ring, loader.
 pub const COMPACT_FACE: f32 = 26.0;
 /// Expanded Nook Mirror circle. Fills `NOOK_BODY` minus the pane inset.

--- a/crates/nook/src/widgets/messages.rs
+++ b/crates/nook/src/widgets/messages.rs
@@ -1,5 +1,6 @@
 //! Messages Nook pane — recent iMessage / WhatsApp threads and inline reply.
 
+use crate::icons::lucide_color;
 use crate::island::ui::{nook_empty, nook_icon_btn, nook_pane, nook_row};
 use crate::island::Island;
 use crate::theme;
@@ -7,7 +8,15 @@ use gpui::{
     div, prelude::*, px, rgba, Context, CursorStyle, FocusHandle, FontWeight, KeyDownEvent,
     MouseButton, MouseDownEvent, SharedString,
 };
-use nook_core::messages::{Conversation, FdaStatus, MessageService, MessagesSnapshot};
+use nook_core::messages::{
+    relative_time, sender_avatar_rgb, sender_initials, Conversation, FdaStatus, IncomingPeek,
+    MessageService, MessagesSnapshot,
+};
+
+const PEEK_AVATAR: f32 = 36.0;
+const PEEK_SEND: f32 = 28.0;
+const WA_GREEN: u32 = 0x25D366FF;
+const IMESSAGE_BLUE: u32 = 0x0A84FFFF;
 
 pub(crate) fn messages_card(island: &mut Island, cx: &mut Context<Island>) -> impl IntoElement {
     if island.message_focus.is_none() {
@@ -292,11 +301,38 @@ fn send_selected(island: &mut Island, cx: &mut Context<Island>) {
     else {
         return;
     };
+    send_conversation(island, conv, cx);
+}
+
+fn send_incoming(island: &mut Island, cx: &mut Context<Island>) {
+    let Some(id) = island
+        .messages
+        .incoming
+        .as_ref()
+        .map(|p| p.conversation_id.clone())
+    else {
+        send_selected(island, cx);
+        return;
+    };
+    let Some(conv) = island
+        .messages
+        .conversations
+        .iter()
+        .find(|c| c.id == id)
+        .cloned()
+    else {
+        return;
+    };
+    send_conversation(island, conv, cx);
+}
+
+fn send_conversation(island: &mut Island, conv: Conversation, cx: &mut Context<Island>) {
     let text = island.message_draft.trim().to_string();
     if text.is_empty() {
         return;
     }
     island.message_draft.clear();
+    let id = conv.id.clone();
     let auto = island.settings.experimental_whatsapp_autosend;
     nook_core::runtime().spawn(async move {
         let result = match conv.service {
@@ -350,10 +386,253 @@ fn apply_draft_key(draft: &mut String, event: &KeyDownEvent, cx: &Context<Island
     }
 }
 
-pub(crate) fn compact_left(_peek: &nook_core::messages::IncomingPeek) -> impl IntoElement {
+pub(crate) fn compact_left(_peek: &IncomingPeek) -> impl IntoElement {
     crate::icons::lucide("message-circle", theme::COMPACT_FACE)
 }
 
-pub(crate) fn compact_right(peek: &nook_core::messages::IncomingPeek) -> impl IntoElement {
+pub(crate) fn compact_right(peek: &IncomingPeek) -> impl IntoElement {
     crate::island::ui::slide_label(peek.sender.clone(), theme::BODY, true)
+}
+
+/// Droppy-style incoming HUD: avatar, sender + time, snippet, inline Reply.
+pub(crate) fn messages_peek(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let Some(peek) = island.messages.incoming.as_ref() else {
+        return div().into_any_element();
+    };
+    let notch_h = island.notch_height.max(32.0);
+    let now = unix_now();
+    let when = relative_time(peek.last_date, now);
+    let whatsapp = peek.service == MessageService::WhatsApp;
+    let send_fill = if whatsapp { WA_GREEN } else { IMESSAGE_BLUE };
+    let draft = island.message_draft.clone();
+    let focus = island.message_focus.clone();
+    let empty = draft.is_empty();
+    let shown = if empty { "Reply…" } else { draft.as_str() };
+
+    div()
+        .id("msg-peek")
+        .size_full()
+        .flex()
+        .flex_col()
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _: &MouseDownEvent, window, cx| {
+                cx.stop_propagation();
+                this.activate_message_composer(window, cx);
+            }),
+        )
+        .child(div().h(px(notch_h)).w_full().flex_shrink_0())
+        .child(
+            div()
+                .flex_1()
+                .w_full()
+                .px(px(14.))
+                .pb(px(10.))
+                .flex()
+                .flex_col()
+                .justify_center()
+                .gap(px(8.))
+                .child(peek_header(peek, &when))
+                .child(peek_composer(
+                    focus,
+                    shown,
+                    empty,
+                    send_fill,
+                    cx,
+                )),
+        )
+        .into_any_element()
+}
+
+fn peek_header(peek: &IncomingPeek, when: &str) -> impl IntoElement {
+    let snippet = if peek.snippet.is_empty() {
+        SharedString::from("Attachment")
+    } else {
+        SharedString::from(peek.snippet.clone())
+    };
+    div()
+        .flex()
+        .items_start()
+        .gap(px(10.))
+        .child(peek_avatar(&peek.sender, peek.service))
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.))
+                .flex()
+                .flex_col()
+                .justify_center()
+                .overflow_hidden()
+                .child(
+                    div()
+                        .flex()
+                        .items_baseline()
+                        .gap(px(6.))
+                        .child(
+                            div()
+                                .min_w(px(0.))
+                                .text_size(px(14.))
+                                .line_height(px(18.))
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(theme::LABEL)
+                                .whitespace_nowrap()
+                                .overflow_hidden()
+                                .text_ellipsis()
+                                .child(peek.sender.clone()),
+                        )
+                        .child(
+                            div()
+                                .flex_shrink_0()
+                                .text_size(px(11.))
+                                .line_height(px(14.))
+                                .text_color(theme::TERTIARY_LABEL)
+                                .child(SharedString::from(when.to_string())),
+                        ),
+                )
+                .child(
+                    div()
+                        .text_size(px(12.))
+                        .line_height(px(15.))
+                        .h(px(30.))
+                        .text_color(rgba(0xffffffB3))
+                        .overflow_hidden()
+                        .child(snippet),
+                ),
+        )
+}
+
+fn peek_avatar(sender: &str, service: MessageService) -> impl IntoElement {
+    let initials = sender_initials(sender);
+    let fill = theme::rgba_from_u32(sender_avatar_rgb(sender), 1.0);
+    let badge = match service {
+        MessageService::WhatsApp => WA_GREEN,
+        MessageService::IMessage => IMESSAGE_BLUE,
+        MessageService::Sms => 0x30D158FF,
+    };
+    div()
+        .relative()
+        .size(px(PEEK_AVATAR))
+        .flex_shrink_0()
+        .child(
+            div()
+                .size_full()
+                .rounded_full()
+                .bg(fill)
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(
+                    div()
+                        .text_size(px(13.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme::LABEL)
+                        .child(SharedString::from(initials)),
+                ),
+        )
+        .child(
+            div()
+                .absolute()
+                .bottom(px(-1.))
+                .right(px(-1.))
+                .size(px(14.))
+                .rounded_full()
+                .bg(rgba(badge))
+                .border_1()
+                .border_color(rgba(0x000000FF))
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(lucide_color("message-circle", 8.0, theme::LABEL)),
+        )
+}
+
+fn peek_composer(
+    focus: Option<FocusHandle>,
+    shown: &str,
+    empty: bool,
+    send_fill: u32,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let shown = SharedString::from(shown.to_string());
+    let mut row = div()
+        .id("msg-peek-composer")
+        .flex()
+        .items_center()
+        .gap(px(8.));
+    if let Some(focus) = focus {
+        let focus_input = focus.clone();
+        row = row.child(
+            div()
+                .id("msg-peek-draft")
+                .track_focus(&focus)
+                .flex_1()
+                .min_w(px(0.))
+                .h(px(PEEK_SEND))
+                .px(px(12.))
+                .rounded_full()
+                .bg(rgba(0xffffff18))
+                .flex()
+                .items_center()
+                .cursor(CursorStyle::IBeam)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _: &MouseDownEvent, window, cx| {
+                        cx.stop_propagation();
+                        this.activate_message_composer(window, cx);
+                        window.focus(&focus_input);
+                    }),
+                )
+                .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                    if event.keystroke.key == "enter" {
+                        send_incoming(this, cx);
+                        return;
+                    }
+                    if apply_draft_key(&mut this.message_draft, event, cx) {
+                        cx.notify();
+                    }
+                }))
+                .child(
+                    div()
+                        .w_full()
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .text_size(px(12.))
+                        .text_color(if empty {
+                            theme::TERTIARY_LABEL
+                        } else {
+                            theme::LABEL
+                        })
+                        .child(shown),
+                ),
+        );
+    }
+    row.child(
+        div()
+            .id("msg-peek-send")
+            .size(px(PEEK_SEND))
+            .rounded_full()
+            .bg(rgba(send_fill))
+            .flex()
+            .items_center()
+            .justify_center()
+            .flex_shrink_0()
+            .cursor(CursorStyle::PointingHand)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|this, _: &MouseDownEvent, _, cx| {
+                    cx.stop_propagation();
+                    send_incoming(this, cx);
+                }),
+            )
+            .child(lucide_color("send", 14.0, theme::LABEL)),
+    )
+    .into_any_element()
+}
+
+fn unix_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
 }

--- a/crates/nook/src/widgets/messages.rs
+++ b/crates/nook/src/widgets/messages.rs
@@ -1,0 +1,359 @@
+//! Messages Nook pane — recent iMessage / WhatsApp threads and inline reply.
+
+use crate::island::ui::{nook_empty, nook_icon_btn, nook_pane, nook_row};
+use crate::island::Island;
+use crate::theme;
+use gpui::{
+    div, prelude::*, px, rgba, Context, CursorStyle, FocusHandle, FontWeight, KeyDownEvent,
+    MouseButton, MouseDownEvent, SharedString,
+};
+use nook_core::messages::{Conversation, FdaStatus, MessageService, MessagesSnapshot};
+
+pub(crate) fn messages_card(island: &mut Island, cx: &mut Context<Island>) -> impl IntoElement {
+    if island.message_focus.is_none() {
+        island.message_focus = Some(cx.focus_handle());
+    }
+    let snap = &island.messages;
+    let selected = island.selected_conversation.clone();
+    let draft = island.message_draft.clone();
+    let focus = island.message_focus.clone();
+    let count = snap
+        .conversations
+        .iter()
+        .filter(|c| c.unread)
+        .count();
+
+    let body = match snap.fda {
+        FdaStatus::Denied => div()
+            .id("msg-fda")
+            .flex_1()
+            .cursor(CursorStyle::PointingHand)
+            .on_mouse_down(
+                MouseButton::Left,
+                cx.listener(|_, _: &MouseDownEvent, _, cx| {
+                    cx.stop_propagation();
+                    let _ = nook_core::messages::open_fda_settings();
+                }),
+            )
+            .child(nook_empty("message-circle", "Grant Full Disk Access"))
+            .into_any_element(),
+        FdaStatus::Unavailable => div()
+            .id("msg-unavailable")
+            .flex_1()
+            .child(nook_empty("message-circle", "Messages on this Mac"))
+            .into_any_element(),
+        FdaStatus::Granted if snap.conversations.is_empty() => div()
+            .id("msg-empty")
+            .flex_1()
+            .child(nook_empty("message-circle", "No recent messages"))
+            .into_any_element(),
+        FdaStatus::Granted => {
+            let mut list = div().flex().flex_col().flex_1();
+            for conv in snap.conversations.iter().take(2) {
+                list = list.child(conversation_row(conv, selected.as_deref(), cx));
+            }
+            list.child(composer(selected.as_deref(), &draft, focus, snap, cx))
+                .into_any_element()
+        }
+    };
+
+    nook_pane("nook-messages")
+        .w_full()
+        .when(count > 0, |d| {
+            d.child(
+                div()
+                    .flex()
+                    .items_end()
+                    .gap(px(8.))
+                    .flex_shrink_0()
+                    .child(
+                        div()
+                            .text_size(px(32.))
+                            .line_height(px(36.))
+                            .font_weight(FontWeight::BOLD)
+                            .text_color(theme::LABEL)
+                            .child(count.to_string()),
+                    )
+                    .child(
+                        div()
+                            .text_size(px(11.))
+                            .text_color(theme::TERTIARY_LABEL)
+                            .pb(px(4.))
+                            .child("unread"),
+                    ),
+            )
+        })
+        .child(body)
+}
+
+fn conversation_row(
+    conv: &Conversation,
+    selected: Option<&str>,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let id = conv.id.clone();
+    let rowid = conv.last_rowid;
+    let active = selected == Some(id.as_str());
+    let service = conv.service;
+    nook_row(SharedString::from(format!("msg-{id}")))
+        .when(active, |d| d.bg(rgba(0xffffff12)))
+        .cursor(CursorStyle::PointingHand)
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                this.selected_conversation = Some(id.clone());
+                nook_core::messages::mark_conversation_seen(&id, rowid);
+                if let Some(c) = this
+                    .messages
+                    .conversations
+                    .iter_mut()
+                    .find(|c| c.id == id)
+                {
+                    c.unread = false;
+                }
+                if this
+                    .messages
+                    .incoming
+                    .as_ref()
+                    .is_some_and(|p| p.conversation_id == id)
+                {
+                    this.messages.incoming = None;
+                }
+                if service == MessageService::WhatsApp {
+                    this.message_draft.clear();
+                }
+                cx.notify();
+            }),
+        )
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.))
+                .flex()
+                .flex_col()
+                .justify_center()
+                .overflow_hidden()
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(6.))
+                        .child(
+                            div()
+                                .text_size(px(14.))
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(theme::LABEL)
+                                .whitespace_nowrap()
+                                .overflow_hidden()
+                                .text_ellipsis()
+                                .child(conv.title.clone()),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(10.))
+                                .text_color(if conv.service == MessageService::IMessage {
+                                    rgba(0x5AC8FAFF)
+                                } else if conv.service == MessageService::WhatsApp {
+                                    rgba(0x25D366FF)
+                                } else {
+                                    theme::TERTIARY_LABEL
+                                })
+                                .child(conv.service.label()),
+                        )
+                        .when(conv.unread, |d| {
+                            d.child(
+                                div()
+                                    .size(px(6.))
+                                    .rounded_full()
+                                    .bg(theme::LABEL)
+                                    .flex_shrink_0(),
+                            )
+                        }),
+                )
+                .child(
+                    div()
+                        .text_size(px(11.))
+                        .text_color(rgba(0xffffff80))
+                        .whitespace_nowrap()
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .child(if conv.snippet.is_empty() {
+                            SharedString::from("Attachment")
+                        } else {
+                            SharedString::from(conv.snippet.clone())
+                        }),
+                ),
+        )
+}
+
+fn composer(
+    selected: Option<&str>,
+    draft: &str,
+    focus: Option<FocusHandle>,
+    snap: &MessagesSnapshot,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let Some(id) = selected else {
+        return div()
+            .pt(px(8.))
+            .child(
+                div()
+                    .text_size(px(11.))
+                    .text_color(theme::TERTIARY_LABEL)
+                    .child("Select a thread to reply"),
+            )
+            .into_any_element();
+    };
+    let Some(conv) = snap.conversations.iter().find(|c| c.id == id) else {
+        return div().into_any_element();
+    };
+    let whatsapp = conv.service == MessageService::WhatsApp;
+    let placeholder = if whatsapp {
+        "Prefill WhatsApp…"
+    } else {
+        "Reply…"
+    };
+    let empty = draft.is_empty();
+    let shown = if empty { placeholder } else { draft };
+    let mut row = div()
+        .id("msg-composer")
+        .pt(px(8.))
+        .flex()
+        .items_center()
+        .gap(px(6.));
+    if let Some(focus) = focus {
+        let focus_input = focus.clone();
+        row = row.child(
+            div()
+                .id("msg-draft")
+                .track_focus(&focus)
+                .flex_1()
+                .min_w(px(0.))
+                .h(px(24.))
+                .px(px(8.))
+                .rounded(px(6.))
+                .bg(rgba(0xffffff14))
+                .flex()
+                .items_center()
+                .cursor(CursorStyle::IBeam)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |_, _: &MouseDownEvent, window, cx| {
+                        cx.stop_propagation();
+                        window.focus(&focus_input);
+                        cx.notify();
+                    }),
+                )
+                .on_key_down(cx.listener(|this, event: &KeyDownEvent, _, cx| {
+                    if event.keystroke.key == "enter" {
+                        send_selected(this, cx);
+                        return;
+                    }
+                    if apply_draft_key(&mut this.message_draft, event, cx) {
+                        cx.notify();
+                    }
+                }))
+                .child(
+                    div()
+                        .w_full()
+                        .overflow_hidden()
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .text_size(px(12.))
+                        .text_color(if empty {
+                            theme::TERTIARY_LABEL
+                        } else {
+                            theme::LABEL
+                        })
+                        .child(SharedString::from(shown.to_string())),
+                ),
+        );
+    }
+    row.child(nook_icon_btn(
+        if whatsapp { "upload" } else { "send" },
+        "msg-send",
+        cx,
+        |this, _, _, cx| send_selected(this, cx),
+    ))
+    .into_any_element()
+}
+
+fn send_selected(island: &mut Island, cx: &mut Context<Island>) {
+    let Some(id) = island.selected_conversation.clone() else {
+        return;
+    };
+    let Some(conv) = island
+        .messages
+        .conversations
+        .iter()
+        .find(|c| c.id == id)
+        .cloned()
+    else {
+        return;
+    };
+    let text = island.message_draft.trim().to_string();
+    if text.is_empty() {
+        return;
+    }
+    island.message_draft.clear();
+    let auto = island.settings.experimental_whatsapp_autosend;
+    nook_core::runtime().spawn(async move {
+        let result = match conv.service {
+            MessageService::WhatsApp => {
+                let phone = conv.handle.as_deref().unwrap_or(&conv.title);
+                nook_core::messages::reply_whatsapp(phone, &text, auto)
+            }
+            MessageService::IMessage | MessageService::Sms => {
+                let Some(guid) = conv.chat_guid.as_deref() else {
+                    return;
+                };
+                nook_core::messages::send_imessage(guid, &text)
+            }
+        };
+        if let Err(err) = result {
+            log::warn!("messages send: {err}");
+        } else {
+            nook_core::messages::mark_conversation_seen(&id, conv.last_rowid);
+            nook_core::messages::request_refresh();
+        }
+    });
+    cx.notify();
+}
+
+fn apply_draft_key(draft: &mut String, event: &KeyDownEvent, cx: &Context<Island>) -> bool {
+    let ks = &event.keystroke;
+    if ks.modifiers.secondary() && ks.key == "v" {
+        if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+            *draft = text.trim().to_string();
+            return true;
+        }
+        return false;
+    }
+    if ks.modifiers.platform || ks.modifiers.control {
+        return false;
+    }
+    match ks.key.as_str() {
+        "backspace" => {
+            draft.pop();
+            true
+        }
+        _ => {
+            if let Some(ch) = &ks.key_char {
+                if !ch.chars().any(|c| c.is_control()) {
+                    draft.push_str(ch);
+                    return true;
+                }
+            }
+            false
+        }
+    }
+}
+
+pub(crate) fn compact_left(_peek: &nook_core::messages::IncomingPeek) -> impl IntoElement {
+    crate::icons::lucide("message-circle", theme::COMPACT_FACE)
+}
+
+pub(crate) fn compact_right(peek: &nook_core::messages::IncomingPeek) -> impl IntoElement {
+    crate::island::ui::slide_label(peek.sender.clone(), theme::BODY, true)
+}

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -2,6 +2,7 @@
 
 mod agents;
 mod calendar;
+mod messages;
 mod notes;
 mod notes_editor;
 mod observe;
@@ -13,6 +14,9 @@ pub(crate) use agents::{
     agents_card, compact_left as agents_compact_left, compact_right as agents_compact_right,
 };
 pub(crate) use calendar::calendar_card;
+pub(crate) use messages::{
+    compact_left as messages_compact_left, compact_right as messages_compact_right, messages_card,
+};
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};
 pub(crate) use observe::{observe_card, ObserveHover};

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -16,6 +16,7 @@ pub(crate) use agents::{
 pub(crate) use calendar::calendar_card;
 pub(crate) use messages::{
     compact_left as messages_compact_left, compact_right as messages_compact_right, messages_card,
+    messages_peek,
 };
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};


### PR DESCRIPTION
## WP23 — messaging-replies

Instant reply to iMessage from the island; WhatsApp is notify + prefill only (the Mac app has no AppleScript dictionary).

### What landed
- `nook-core::messages`: read-only `chat.db` snapshot (text + `attributedBody` typedstream), FDA probe, WAL / usernoted FSEvents–kqueue watch with 300ms debounce (no poll), `send_imessage` via Messages AppleScript, WhatsApp usernoted reader + `whatsapp://send?phone=&text=` helper
- `run_osascript` extracted to `utils.rs` so media and messages share one spawn path
- Expanded Messages card (thread list, inline reply, WhatsApp prefill action)
- **Incoming HUD** (compact takeover, not the widgets grid): rounded dark-glass pill with initials avatar + WA/iMessage badge, sender + relative time, 1–2 line snippet, and an inline Reply field with circular send. Tap/focus activates the island and focuses the draft without expanding. Swipe-down still opens the full Messages card. Peek height feeds `target_size` / `sync_overlay_strip`.
- Settings: enable toggle, Full Disk Access status + deep link to Privacy_AllFiles, experimental WhatsApp auto-send (Accessibility CGEvent Return)
- `message_watermarks` table stores ROWID only — bodies are never persisted
- `NSAppleEventsUsageDescription` mentions Messages send

### Honest limits
- Avatars are initials on a colored circle (no Contacts photo / extra TCC)
- iMessage: real send via AppleScript
- WhatsApp: notify + `whatsapp://` prefill (label says Reply; send opens prefill). Experimental Accessibility auto-send stays Settings-gated
- `imessage-database` is GPL-3.0; this crate stays MIT with a focused NXTypedStream decoder and GUID/parse tests
- No tapbacks, typing indicators, new-group creation, or WhatsApp sidecar send (ToS/ban risk)

### Tests
`cargo test -p nook -p nook-core` — GUID / E.164 / typedstream / usernoted / watcher helpers, initials + relative-time, peek sizing, plus existing island/settings tests.
