### PR TITLE
WP10: time-synced lyrics from LRCLIB

### DIFF
--- a/crates/nook-core/src/agents.rs
+++ b/crates/nook-core/src/agents.rs
@@ -10,6 +10,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+#[cfg(target_os = "macos")]
+use sysinfo::Pid;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 /// CPU % above which a descendant process counts as doing real work. The
@@ -153,6 +155,45 @@ fn process_system() -> &'static Mutex<System> {
 }
 
 fn scan_processes() -> HashMap<u32, ProcInfo> {
+    #[cfg(target_os = "macos")]
+    {
+        scan_processes_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        scan_processes_all()
+    }
+}
+
+fn proc_from_sysinfo(pid_u32: u32, proc_: &sysinfo::Process) -> Option<ProcInfo> {
+    let name = proc_.name().to_string_lossy().into_owned();
+    let argv: Vec<String> = if proc_.cmd().is_empty() {
+        if name.is_empty() {
+            return None;
+        }
+        vec![name.clone()]
+    } else {
+        proc_
+            .cmd()
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect()
+    };
+    Some(ProcInfo {
+        pid: pid_u32,
+        ppid: proc_.parent().map(|p| p.as_u32()).unwrap_or(0),
+        cpu_pct: proc_.cpu_usage(),
+        name,
+        argv,
+        cwd: proc_.cwd().map(PathBuf::from),
+        exe: proc_.exe().map(PathBuf::from),
+        start_time: proc_.start_time(),
+    })
+}
+
+/// Full-table refresh. Used off macOS, where the process list is small and
+/// there is no `proc_pidpath` two-stage split.
+fn scan_processes_all() -> HashMap<u32, ProcInfo> {
     let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
     // argv (KERN_PROCARGS2 sysctl) and the exe path are fixed at exec time, so
     // OnlyIfNotSet fetches them once per new pid instead of re-reading them
@@ -172,35 +213,119 @@ fn scan_processes() -> HashMap<u32, ProcInfo> {
 
     let mut map = HashMap::new();
     for (pid, proc_) in sys.processes() {
-        let pid_u32 = pid.as_u32();
-        let name = proc_.name().to_string_lossy().into_owned();
-        let argv: Vec<String> = if proc_.cmd().is_empty() {
-            if name.is_empty() {
-                continue;
-            }
-            vec![name.clone()]
-        } else {
-            proc_
-                .cmd()
-                .iter()
-                .map(|s| s.to_string_lossy().into_owned())
-                .collect()
-        };
-        map.insert(
-            pid_u32,
-            ProcInfo {
-                pid: pid_u32,
-                ppid: proc_.parent().map(|p| p.as_u32()).unwrap_or(0),
-                cpu_pct: proc_.cpu_usage(),
-                name,
-                argv,
-                cwd: proc_.cwd().map(PathBuf::from),
-                exe: proc_.exe().map(PathBuf::from),
-                start_time: proc_.start_time(),
-            },
-        );
+        if let Some(info) = proc_from_sysinfo(pid.as_u32(), proc_) {
+            map.insert(info.pid, info);
+        }
     }
     map
+}
+
+/// macOS two-stage scan: list every pid with a cheap `proc_pidpath` (exe
+/// OnlyIfNotSet), then fetch argv / cwd / cpu only for agent candidates and
+/// their descendants. Avoids KERN_PROCARGS2 on hundreds of unrelated pids.
+#[cfg(target_os = "macos")]
+fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
+    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing()
+            .without_tasks()
+            .with_exe(UpdateKind::OnlyIfNotSet),
+    );
+
+    let sidecar: HashSet<u32> = grok_sessions()
+        .keys()
+        .chain(claude_sessions().keys())
+        .copied()
+        .collect();
+
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut seeds = Vec::new();
+    for (pid, proc_) in sys.processes() {
+        let pid_u32 = pid.as_u32();
+        let ppid = proc_.parent().map(|p| p.as_u32()).unwrap_or(0);
+        children.entry(ppid).or_default().push(pid_u32);
+        let name = proc_.name().to_string_lossy();
+        let exe = proc_
+            .exe()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if is_scan_seed(&exe, &name) || sidecar.contains(&pid_u32) {
+            seeds.push(pid_u32);
+        }
+    }
+
+    let mut detail = HashSet::new();
+    let mut stack = seeds;
+    while let Some(pid) = stack.pop() {
+        if detail.insert(pid) {
+            if let Some(kids) = children.get(&pid) {
+                stack.extend(kids.iter().copied());
+            }
+        }
+    }
+    if detail.is_empty() {
+        return HashMap::new();
+    }
+
+    let pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&pids),
+        true,
+        ProcessRefreshKind::nothing()
+            .without_tasks()
+            .with_cpu()
+            .with_cmd(UpdateKind::OnlyIfNotSet)
+            .with_cwd(UpdateKind::Always)
+            .with_exe(UpdateKind::OnlyIfNotSet),
+    );
+
+    let mut map = HashMap::new();
+    for pid in detail {
+        let Some(proc_) = sys.process(Pid::from_u32(pid)) else {
+            continue;
+        };
+        if let Some(info) = proc_from_sysinfo(pid, proc_) {
+            map.insert(info.pid, info);
+        }
+    }
+    map
+}
+
+/// Stage-1 filter: exe path or `comm` looks like an agent or a wrapper that
+/// may hide the real binary in argv (`node …/claude`).
+fn is_scan_seed(path: &str, comm: &str) -> bool {
+    if grok_install_path(path) {
+        return true;
+    }
+    if is_wrapper_comm(comm) || is_wrapper_comm(path.rsplit('/').next().unwrap_or(path)) {
+        return true;
+    }
+    [
+        AgentKind::Cursor,
+        AgentKind::OpenCode,
+        AgentKind::Claude,
+        AgentKind::Codex,
+        AgentKind::Fx,
+        AgentKind::Grok,
+        AgentKind::Aider,
+        AgentKind::Gemini,
+    ]
+    .into_iter()
+    .any(|kind| {
+        kind.binaries()
+            .iter()
+            .any(|bin| token_has_binary(path, bin) || token_has_binary(comm, bin))
+    })
+}
+
+fn is_wrapper_comm(name: &str) -> bool {
+    const WRAPPERS: &[&str] = &["node", "bun", "deno", "ruby", "perl", "npx", "python", "python3"];
+    let base = name.rsplit(['/', '\\']).next().unwrap_or(name);
+    let base = base.strip_suffix(".exe").unwrap_or(base);
+    let lower = base.to_ascii_lowercase();
+    WRAPPERS.iter().any(|w| lower == *w) || lower.starts_with("python")
 }
 
 fn assemble(procs: &HashMap<u32, ProcInfo>) -> Vec<AgentSession> {
@@ -1086,6 +1211,22 @@ mod tests {
             ),
             Some(AgentKind::Cursor)
         );
+    }
+
+    #[test]
+    fn scan_seed_matches_agent_paths_and_wrappers() {
+        assert!(is_scan_seed("/usr/local/bin/claude", "claude"));
+        assert!(is_scan_seed(
+            "/Users/a/.local/share/claude/versions/2.1.121",
+            "claude"
+        ));
+        assert!(is_scan_seed("/bin/cursor-agent", "cursor-agent"));
+        assert!(is_scan_seed("/opt/homebrew/bin/node", "node"));
+        assert!(is_scan_seed("/usr/bin/python3.12", "Python"));
+        assert!(is_scan_seed("/Users/a/.grok/bin/agent", "agent"));
+        assert!(!is_scan_seed("/usr/bin/grep", "grep"));
+        assert!(!is_scan_seed("/Applications/Safari.app/Contents/MacOS/Safari", "Safari"));
+        assert!(!is_scan_seed("/usr/sbin/syslogd", "syslogd"));
     }
 
     #[test]

--- a/crates/nook-core/src/agents.rs
+++ b/crates/nook-core/src/agents.rs
@@ -220,19 +220,48 @@ fn scan_processes_all() -> HashMap<u32, ProcInfo> {
     map
 }
 
-/// macOS two-stage scan: list every pid with a cheap `proc_pidpath` (exe
-/// OnlyIfNotSet), then fetch argv / cwd / cpu only for agent candidates and
-/// their descendants. Avoids KERN_PROCARGS2 on hundreds of unrelated pids.
+/// Cached argv/cwd/exe for a live pid. Invalidated when start_time changes
+/// (pid reuse) or the pid disappears.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Debug, PartialEq)]
+struct CachedDetail {
+    start_time: u64,
+    name: String,
+    argv: Vec<String>,
+    cwd: Option<PathBuf>,
+    exe: Option<PathBuf>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn cache_lookup<'a>(
+    cache: &'a HashMap<u32, CachedDetail>,
+    pid: u32,
+    start_time: u64,
+) -> Option<&'a CachedDetail> {
+    let hit = cache.get(&pid)?;
+    (start_time > 0 && hit.start_time == start_time).then_some(hit)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn prune_detail_cache(cache: &mut HashMap<u32, CachedDetail>, live: &HashSet<u32>) {
+    cache.retain(|pid, _| live.contains(pid));
+}
+
+#[cfg(target_os = "macos")]
+fn detail_cache() -> &'static Mutex<HashMap<u32, CachedDetail>> {
+    static CACHE: OnceLock<Mutex<HashMap<u32, CachedDetail>>> = OnceLock::new();
+    CACHE.get_or_init(Mutex::default)
+}
+
+/// macOS two-stage scan: `proc_listallpids` + `proc_pidpath` / `PROC_PIDTBSDINFO`
+/// first (cheap), then argv (KERN_PROCARGS2) and cwd only for agent candidates
+/// and their descendants, and only when `(pid, start_time)` is not cached.
 #[cfg(target_os = "macos")]
 fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
-    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::All,
-        true,
-        ProcessRefreshKind::nothing()
-            .without_tasks()
-            .with_exe(UpdateKind::OnlyIfNotSet),
-    );
+    let stage = list_stage1();
+    if stage.is_empty() {
+        return scan_processes_all();
+    }
 
     let sidecar: HashSet<u32> = grok_sessions()
         .keys()
@@ -241,19 +270,14 @@ fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
         .collect();
 
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut by_pid: HashMap<u32, Stage1> = HashMap::new();
     let mut seeds = Vec::new();
-    for (pid, proc_) in sys.processes() {
-        let pid_u32 = pid.as_u32();
-        let ppid = proc_.parent().map(|p| p.as_u32()).unwrap_or(0);
-        children.entry(ppid).or_default().push(pid_u32);
-        let name = proc_.name().to_string_lossy();
-        let exe = proc_
-            .exe()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        if is_scan_seed(&exe, &name) || sidecar.contains(&pid_u32) {
-            seeds.push(pid_u32);
+    for info in stage {
+        children.entry(info.ppid).or_default().push(info.pid);
+        if is_scan_seed(&info.path, &info.comm) || sidecar.contains(&info.pid) {
+            seeds.push(info.pid);
         }
+        by_pid.insert(info.pid, info);
     }
 
     let mut detail = HashSet::new();
@@ -266,31 +290,233 @@ fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
         }
     }
     if detail.is_empty() {
+        let mut cache = detail_cache().lock().unwrap_or_else(|e| e.into_inner());
+        cache.clear();
         return HashMap::new();
     }
 
-    let pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::Some(&pids),
-        true,
-        ProcessRefreshKind::nothing()
-            .without_tasks()
-            .with_cpu()
-            .with_cmd(UpdateKind::OnlyIfNotSet)
-            .with_cwd(UpdateKind::Always)
-            .with_exe(UpdateKind::OnlyIfNotSet),
-    );
+    let mut cache = detail_cache().lock().unwrap_or_else(|e| e.into_inner());
+    let mut hits: HashMap<u32, CachedDetail> = HashMap::new();
+    let mut misses = Vec::new();
+    for pid in &detail {
+        let start = by_pid.get(pid).map(|s| s.start_time).unwrap_or(0);
+        if let Some(hit) = cache_lookup(&cache, *pid, start) {
+            hits.insert(*pid, hit.clone());
+        } else {
+            misses.push(*pid);
+        }
+    }
+
+    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
+    let cpu_kind = ProcessRefreshKind::nothing().without_tasks().with_cpu();
+    let all_pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
+    sys.refresh_processes_specifics(ProcessesToUpdate::Some(&all_pids), true, cpu_kind);
+    if !misses.is_empty() {
+        let miss_pids: Vec<Pid> = misses.iter().copied().map(Pid::from_u32).collect();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&miss_pids),
+            true,
+            ProcessRefreshKind::nothing()
+                .without_tasks()
+                .with_cpu()
+                .with_cmd(UpdateKind::OnlyIfNotSet)
+                .with_cwd(UpdateKind::OnlyIfNotSet)
+                .with_exe(UpdateKind::OnlyIfNotSet),
+        );
+    }
 
     let mut map = HashMap::new();
     for pid in detail {
+        let stage = by_pid.get(&pid);
+        let start = stage.map(|s| s.start_time).unwrap_or(0);
+        let ppid = stage.map(|s| s.ppid).unwrap_or(0);
+        let cpu_pct = sys
+            .process(Pid::from_u32(pid))
+            .map(|p| p.cpu_usage())
+            .unwrap_or(0.0);
+        if let Some(hit) = hits.get(&pid) {
+            map.insert(
+                pid,
+                ProcInfo {
+                    pid,
+                    ppid,
+                    cpu_pct,
+                    name: hit.name.clone(),
+                    argv: hit.argv.clone(),
+                    cwd: hit.cwd.clone(),
+                    exe: hit.exe.clone(),
+                    start_time: hit.start_time,
+                },
+            );
+            continue;
+        }
         let Some(proc_) = sys.process(Pid::from_u32(pid)) else {
             continue;
         };
-        if let Some(info) = proc_from_sysinfo(pid, proc_) {
-            map.insert(info.pid, info);
+        let Some(mut info) = proc_from_sysinfo(pid, proc_) else {
+            continue;
+        };
+        if info.start_time == 0 {
+            info.start_time = start;
         }
+        if info.ppid == 0 {
+            info.ppid = ppid;
+        }
+        cache.insert(
+            pid,
+            CachedDetail {
+                start_time: info.start_time,
+                name: info.name.clone(),
+                argv: info.argv.clone(),
+                cwd: info.cwd.clone(),
+                exe: info.exe.clone(),
+            },
+        );
+        map.insert(pid, info);
     }
+    prune_detail_cache(&mut cache, &map.keys().copied().collect());
     map
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+struct Stage1 {
+    pid: u32,
+    ppid: u32,
+    start_time: u64,
+    path: String,
+    comm: String,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct ProcBsdInfo {
+    pbi_flags: u32,
+    pbi_status: u32,
+    pbi_xstatus: u32,
+    pbi_pid: u32,
+    pbi_ppid: u32,
+    pbi_uid: u32,
+    pbi_gid: u32,
+    pbi_ruid: u32,
+    pbi_rgid: u32,
+    pbi_svuid: u32,
+    pbi_svgid: u32,
+    rfu_1: u32,
+    pbi_comm: [u8; 16],
+    pbi_name: [u8; 32],
+    pbi_nfiles: u32,
+    pbi_pgid: u32,
+    pbi_pjobc: u32,
+    e_tdev: u32,
+    e_tpgid: u32,
+    pbi_nice: i32,
+    pbi_start_tvsec: u64,
+    pbi_start_tvusec: u64,
+}
+
+#[cfg(target_os = "macos")]
+const PROC_PIDTBSDINFO: i32 = 3;
+
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn proc_listallpids(buffer: *mut std::ffi::c_void, buffersize: i32) -> i32;
+    fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, buffersize: u32) -> i32;
+    fn proc_pidinfo(
+        pid: i32,
+        flavor: i32,
+        arg: u64,
+        buffer: *mut std::ffi::c_void,
+        buffersize: i32,
+    ) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn c_name(buf: &[u8]) -> String {
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..end]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn list_all_pids() -> Vec<i32> {
+    unsafe {
+        let hint = proc_listallpids(std::ptr::null_mut(), 0);
+        if hint <= 0 {
+            return Vec::new();
+        }
+        let mut buf = vec![0i32; hint as usize + 64];
+        let bytes = (buf.len() * std::mem::size_of::<i32>()) as i32;
+        let n = proc_listallpids(buf.as_mut_ptr() as *mut std::ffi::c_void, bytes);
+        if n <= 0 {
+            return Vec::new();
+        }
+        buf.truncate(n as usize);
+        buf.retain(|&p| p > 0);
+        buf
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn pid_path(pid: i32) -> String {
+    let mut buf = [0u8; 4096];
+    let n = unsafe {
+        proc_pidpath(
+            pid,
+            buf.as_mut_ptr() as *mut std::ffi::c_void,
+            buf.len() as u32,
+        )
+    };
+    if n <= 0 {
+        return String::new();
+    }
+    String::from_utf8_lossy(&buf[..n as usize]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn pid_bsdinfo(pid: i32) -> Option<ProcBsdInfo> {
+    let mut info = ProcBsdInfo::default();
+    let sz = std::mem::size_of::<ProcBsdInfo>() as i32;
+    let n = unsafe {
+        proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut std::ffi::c_void,
+            sz,
+        )
+    };
+    (n == sz).then_some(info)
+}
+
+#[cfg(target_os = "macos")]
+fn list_stage1() -> Vec<Stage1> {
+    list_all_pids()
+        .into_iter()
+        .filter_map(|pid| {
+            let bsd = pid_bsdinfo(pid)?;
+            let path = pid_path(pid);
+            let comm = {
+                let name = c_name(&bsd.pbi_name);
+                if name.is_empty() {
+                    c_name(&bsd.pbi_comm)
+                } else {
+                    name
+                }
+            };
+            Some(Stage1 {
+                pid: if bsd.pbi_pid != 0 {
+                    bsd.pbi_pid
+                } else {
+                    pid as u32
+                },
+                ppid: bsd.pbi_ppid,
+                start_time: bsd.pbi_start_tvsec,
+                path,
+                comm,
+            })
+        })
+        .collect()
 }
 
 /// Stage-1 filter: exe path or `comm` looks like an agent or a wrapper that
@@ -1115,17 +1341,16 @@ fn activate(_pid: u32) -> bool {
     false
 }
 
-/// How long the island should wait between scans: quick while sessions are
-/// live (status changes matter), relaxed once none have been seen for a
-/// while — a newly started agent then appears within one slow tick, which is
-/// fine for a status glance and keeps the recurring process-table walk off
-/// the battery.
+/// How long the island should wait between scans: 2s while a session was
+/// seen recently, 5s once none are active — a newly started agent then
+/// appears within one slow tick, which is fine for a status glance and
+/// keeps the recurring process-table walk off the battery.
 pub fn poll_interval() -> Duration {
     let last = LAST_AGENT_SEEN.load(std::sync::atomic::Ordering::Relaxed);
     if unix_secs().saturating_sub(last) < 30 {
         Duration::from_secs(2)
     } else {
-        Duration::from_secs(6)
+        Duration::from_secs(5)
     }
 }
 
@@ -1227,6 +1452,37 @@ mod tests {
         assert!(!is_scan_seed("/usr/bin/grep", "grep"));
         assert!(!is_scan_seed("/Applications/Safari.app/Contents/MacOS/Safari", "Safari"));
         assert!(!is_scan_seed("/usr/sbin/syslogd", "syslogd"));
+    }
+
+    #[test]
+    fn argv_cache_hits_only_matching_start_time() {
+        let mut cache = HashMap::new();
+        cache.insert(
+            7,
+            CachedDetail {
+                start_time: 100,
+                name: "claude".into(),
+                argv: vec!["claude".into()],
+                cwd: None,
+                exe: None,
+            },
+        );
+        assert!(cache_lookup(&cache, 7, 100).is_some());
+        assert!(cache_lookup(&cache, 7, 101).is_none());
+        assert!(cache_lookup(&cache, 7, 0).is_none());
+        assert!(cache_lookup(&cache, 8, 100).is_none());
+        let live = HashSet::from([8u32]);
+        prune_detail_cache(&mut cache, &live);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn poll_interval_is_5s_when_no_recent_session() {
+        let prev = LAST_AGENT_SEEN.swap(0, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(poll_interval(), Duration::from_secs(5));
+        LAST_AGENT_SEEN.store(unix_secs(), std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(poll_interval(), Duration::from_secs(2));
+        LAST_AGENT_SEEN.store(prev, std::sync::atomic::Ordering::Relaxed);
     }
 
     #[test]

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -308,12 +308,75 @@ fn safari_artwork_url<'a>(page_url: &str, artwork_url: &'a str) -> Option<&'a st
 /// waiting out its idle cadence.
 static MEDIA_EVENT: AtomicBool = AtomicBool::new(false);
 
+/// Launch Services snapshot of the AppleScript fallback players, refreshed
+/// from `NSWorkspace` launch/terminate notifications instead of walking the
+/// process table. Bit0 = primed, bit1 = Spotify, bit2 = Music, bit3 = Safari.
+static MEDIA_APPS: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+const MEDIA_APPS_PRIMED: u8 = 1 << 0;
+const MEDIA_APP_SPOTIFY: u8 = 1 << 1;
+const MEDIA_APP_MUSIC: u8 = 1 << 2;
+const MEDIA_APP_SAFARI: u8 = 1 << 3;
+
 pub fn note_media_event() {
     MEDIA_EVENT.store(true, Ordering::Relaxed);
 }
 
 pub fn take_media_event() -> bool {
     MEDIA_EVENT.swap(false, Ordering::Relaxed)
+}
+
+/// Record that a media-capable app launched or quit. Unknown bundle ids are
+/// ignored so the workspace observers can be wired to every app event.
+pub fn note_media_app_running(bundle_id: &str, running: bool) {
+    let bit = match bundle_id {
+        "com.spotify.client" => MEDIA_APP_SPOTIFY,
+        "com.apple.Music" => MEDIA_APP_MUSIC,
+        "com.apple.Safari" => MEDIA_APP_SAFARI,
+        _ => return,
+    };
+    let mut packed = MEDIA_APPS.load(Ordering::Relaxed) | MEDIA_APPS_PRIMED;
+    if running {
+        packed |= bit;
+    } else {
+        packed &= !bit;
+    }
+    MEDIA_APPS.store(packed, Ordering::Relaxed);
+}
+
+/// `(spotify, music, safari)` from the launch/terminate cache, priming via
+/// `NSRunningApplication` once if no observer has run yet.
+#[cfg(target_os = "macos")]
+fn media_players_running() -> (bool, bool, bool) {
+    let packed = MEDIA_APPS.load(Ordering::Relaxed);
+    if packed & MEDIA_APPS_PRIMED == 0 {
+        return prime_media_apps();
+    }
+    (
+        packed & MEDIA_APP_SPOTIFY != 0,
+        packed & MEDIA_APP_MUSIC != 0,
+        packed & MEDIA_APP_SAFARI != 0,
+    )
+}
+
+/// Seed the media-app bits from Launch Services. Called from
+/// `install_media_observers` so the first AppleScript poll does not race.
+#[cfg(target_os = "macos")]
+pub fn prime_media_apps() -> (bool, bool, bool) {
+    let spotify = app_running(c"com.spotify.client");
+    let music = app_running(c"com.apple.Music");
+    let safari = app_running(c"com.apple.Safari");
+    let mut packed = MEDIA_APPS_PRIMED;
+    if spotify {
+        packed |= MEDIA_APP_SPOTIFY;
+    }
+    if music {
+        packed |= MEDIA_APP_MUSIC;
+    }
+    if safari {
+        packed |= MEDIA_APP_SAFARI;
+    }
+    MEDIA_APPS.store(packed, Ordering::Relaxed);
+    (spotify, music, safari)
 }
 
 /// Whether an app with this bundle id is running, via Launch Services.
@@ -365,11 +428,7 @@ pub async fn get_now_playing() -> NowPlayingData {
         // Services' in-process app list — no walk of the whole process table
         // (the sysinfo refresh this replaces enumerated every pid on the
         // system each poll, a measurable slice of idle CPU).
-        let (spotify_running, music_running, safari_running) = (
-            app_running(c"com.spotify.client"),
-            app_running(c"com.apple.Music"),
-            app_running(c"com.apple.Safari"),
-        );
+        let (spotify_running, music_running, safari_running) = media_players_running();
 
         // If no relevant apps are running, return early with no overhead
         if !spotify_running && !music_running && !safari_running {
@@ -1402,6 +1461,22 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn media_app_running_cache_ignores_unrelated_bundles() {
+        note_media_app_running("com.apple.finder", true);
+        note_media_app_running("com.spotify.client", true);
+        note_media_app_running("com.apple.Music", false);
+        note_media_app_running("com.apple.Safari", true);
+        let packed = MEDIA_APPS.load(Ordering::Relaxed);
+        assert_ne!(packed & MEDIA_APPS_PRIMED, 0);
+        assert_ne!(packed & MEDIA_APP_SPOTIFY, 0);
+        assert_eq!(packed & MEDIA_APP_MUSIC, 0);
+        assert_ne!(packed & MEDIA_APP_SAFARI, 0);
+        note_media_app_running("com.spotify.client", false);
+        let packed = MEDIA_APPS.load(Ordering::Relaxed);
+        assert_eq!(packed & MEDIA_APP_SPOTIFY, 0);
     }
 
     #[test]

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -25,6 +25,8 @@ pub fn init_audio_state() {
     let _ = AUDIO_LEVELS.set(std::sync::Mutex::new(vec![0.15; 6]));
     let _ = TRACK_CACHE.set(std::sync::Mutex::new((None, None, None)));
     let _ = LAST_PLAYED.set(std::sync::Mutex::new(None));
+    #[cfg(target_os = "macos")]
+    crate::mediaremote::ensure_stream();
 }
 
 fn lock_mutex<T>(m: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
@@ -337,7 +339,8 @@ fn app_running(bundle_id: &std::ffi::CStr) -> bool {
 /// Get currently playing music information.
 ///
 /// On macOS this prefers MediaRemote via [mediaremote-adapter]
-/// (`get --now`), which works for any now-playing app on 15.4+.
+/// (live `stream` cell, `get --now` only as primer / fallback),
+/// which works for any now-playing app on 15.4+.
 /// AppleScript (Spotify / Music / Safari) is the fallback.
 ///
 /// [mediaremote-adapter]: https://github.com/ungive/mediaremote-adapter

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -2,6 +2,9 @@ use crate::models::NowPlayingData;
 use crate::utils::fetch_artwork_from_url;
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::Notify;
 
 /// Global state for audio levels (updated by audio monitoring thread)
 static AUDIO_LEVELS: std::sync::OnceLock<std::sync::Mutex<Vec<f64>>> = std::sync::OnceLock::new();
@@ -317,12 +320,38 @@ const MEDIA_APP_SPOTIFY: u8 = 1 << 1;
 const MEDIA_APP_MUSIC: u8 = 1 << 2;
 const MEDIA_APP_SAFARI: u8 = 1 << 3;
 
+static MEDIA_WAKE: OnceLock<Notify> = OnceLock::new();
+
+fn media_wake() -> &'static Notify {
+    MEDIA_WAKE.get_or_init(Notify::new)
+}
+
 pub fn note_media_event() {
     MEDIA_EVENT.store(true, Ordering::Relaxed);
+    media_wake().notify_waiters();
 }
 
 pub fn take_media_event() -> bool {
     MEDIA_EVENT.swap(false, Ordering::Relaxed)
+}
+
+/// Park until a playback-change poke or `timeout`.
+///
+/// The island now-playing loop uses this so idle is one timer, not a 250 ms
+/// poll of the event flag. Subscribe before checking the flag so a poke that
+/// lands in between cannot be missed.
+pub async fn wait_media_or_timeout(timeout: Duration) {
+    let notified = media_wake().notified();
+    tokio::pin!(notified);
+    if MEDIA_EVENT.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    tokio::select! {
+        _ = notified => {
+            let _ = MEDIA_EVENT.swap(false, Ordering::Relaxed);
+        }
+        _ = tokio::time::sleep(timeout) => {}
+    }
 }
 
 /// Record that a media-capable app launched or quit. Unknown bundle ids are
@@ -1488,5 +1517,41 @@ mod tests {
             ),
             Some("https://music.youtube.com/favicon.ico")
         );
+    }
+
+    static MEDIA_WAIT_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn wait_media_returns_when_event_already_set() {
+        let _g = MEDIA_WAIT_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = take_media_event();
+        note_media_event();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let start = std::time::Instant::now();
+        rt.block_on(wait_media_or_timeout(Duration::from_secs(3)));
+        assert!(start.elapsed() < Duration::from_millis(250));
+    }
+
+    #[test]
+    fn wait_media_wakes_on_note() {
+        let _g = MEDIA_WAIT_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = take_media_event();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let start = std::time::Instant::now();
+        rt.block_on(async {
+            let waiter = wait_media_or_timeout(Duration::from_secs(3));
+            let poker = async {
+                tokio::time::sleep(Duration::from_millis(15)).await;
+                note_media_event();
+            };
+            tokio::join!(waiter, poker);
+        });
+        assert!(start.elapsed() < Duration::from_millis(500));
     }
 }

--- a/crates/nook-core/src/database.rs
+++ b/crates/nook-core/src/database.rs
@@ -74,6 +74,16 @@ fn migrate(conn: &Connection) -> Result<()> {
         [],
     )?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS lyrics (
+            cache_key TEXT PRIMARY KEY,
+            payload TEXT,
+            hit INTEGER NOT NULL DEFAULT 0,
+            fetched_at INTEGER NOT NULL
+        )",
+        [],
+    )?;
+
     Ok(())
 }
 

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,7 +10,6 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
-#[cfg(target_os = "macos")]
 mod mediaremote;
 pub mod models;
 pub mod mouse;

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
+#[cfg(any(target_os = "macos", test))]
 mod mediaremote;
 pub mod models;
 pub mod mouse;

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
+pub mod lyrics;
 #[cfg(any(target_os = "macos", test))]
 mod mediaremote;
 pub mod models;
@@ -22,7 +23,7 @@ pub mod settings;
 pub mod utils;
 pub mod widgets;
 
-pub use models::{NotchInfo, NowPlayingData};
+pub use models::{LyricLine, NotchInfo, NowPlayingData, SyncedLyrics};
 pub use settings::{AppSettings, WindowSettings};
 
 use std::sync::{Once, OnceLock};

--- a/crates/nook-core/src/lyrics.rs
+++ b/crates/nook-core/src/lyrics.rs
@@ -1,0 +1,586 @@
+//! Time-synced lyrics: LRC parser, LRCLIB client, and SQLite cache.
+//!
+//! Network is one HTTPS request per new track (and only when the lyrics
+//! toggle is on). Positive hits stay cached forever; misses expire after
+//! seven days. Playback position is interpolated by the island — this
+//! module does not poll.
+
+use crate::database;
+use crate::models::{LyricLine, SyncedLyrics};
+use crate::utils::read_response_limited;
+use reqwest::Client;
+use serde::Deserialize;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+const LRCLIB_BASE: &str = "https://lrclib.net";
+const CLIENT_ID: &str = concat!(
+    "openNook/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/prodBirdy/openNook-gpui)"
+);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
+const MAX_BODY_BYTES: usize = 256 * 1024;
+const NEGATIVE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+const DURATION_TOLERANCE_SECS: f64 = 2.0;
+const MIN_LINE_WAIT: Duration = Duration::from_millis(16);
+
+impl SyncedLyrics {
+    pub fn has_synced(&self) -> bool {
+        !self.lines.is_empty()
+    }
+
+    /// Last line whose timestamp is at or before `pos_ms`. `None` before
+    /// the first line.
+    pub fn active_index(&self, pos_ms: u64) -> Option<usize> {
+        active_line_index(&self.lines, pos_ms)
+    }
+
+    /// Delay until the next line after `pos_ms`. `None` on the last line
+    /// or when there is nothing to highlight.
+    pub fn delay_until_next(&self, pos_ms: u64) -> Option<Duration> {
+        if self.lines.is_empty() {
+            return None;
+        }
+        let start = match self.lines.binary_search_by_key(&pos_ms, |line| line.time_ms) {
+            Ok(mut i) => {
+                while i < self.lines.len() && self.lines[i].time_ms <= pos_ms {
+                    i += 1;
+                }
+                i
+            }
+            Err(i) => i,
+        };
+        let next_ms = self.lines.get(start)?.time_ms;
+        Some(Duration::from_millis(next_ms.saturating_sub(pos_ms)).max(MIN_LINE_WAIT))
+    }
+
+    /// Three-line highlight window: previous, current, next.
+    pub fn highlight_window(&self, pos_ms: u64) -> [Option<&str>; 3] {
+        match self.active_index(pos_ms) {
+            None => [None, None, self.lines.first().map(|line| line.text.as_str())],
+            Some(i) => [
+                i.checked_sub(1)
+                    .and_then(|j| self.lines.get(j))
+                    .map(|line| line.text.as_str()),
+                self.lines.get(i).map(|line| line.text.as_str()),
+                self.lines.get(i + 1).map(|line| line.text.as_str()),
+            ],
+        }
+    }
+}
+
+/// Last line with `time_ms <= pos_ms`.
+pub fn active_line_index(lines: &[LyricLine], pos_ms: u64) -> Option<usize> {
+    if lines.is_empty() {
+        return None;
+    }
+    match lines.binary_search_by_key(&pos_ms, |line| line.time_ms) {
+        Ok(i) => Some(i),
+        Err(0) => None,
+        Err(i) => Some(i - 1),
+    }
+}
+
+/// Parse LRC into a time-sorted line list. Metadata tags are skipped;
+/// `[offset:±ms]` applies to following lines. Enhanced word tags (`<mm:ss>`)
+/// are stripped. Duplicate timestamps keep insertion order after the sort.
+pub fn parse_lrc(src: &str) -> Vec<LyricLine> {
+    let mut offset_ms: i64 = 0;
+    let mut lines = Vec::new();
+    for raw in src.lines() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some(offset) = parse_offset_tag(line) {
+            offset_ms = offset;
+            continue;
+        }
+        if is_id_tag(line) {
+            continue;
+        }
+        let (times, rest) = split_timestamps(line);
+        if times.is_empty() {
+            continue;
+        }
+        let text = collapse_ws(&strip_word_tags(rest));
+        if text.is_empty() {
+            continue;
+        }
+        for time_ms in times {
+            let shifted = (time_ms as i64 + offset_ms).max(0) as u64;
+            lines.push(LyricLine {
+                time_ms: shifted,
+                text: text.clone(),
+            });
+        }
+    }
+    lines.sort_by(|a, b| a.time_ms.cmp(&b.time_ms));
+    lines
+}
+
+/// Fetch lyrics for a track. Cache first; one LRCLIB request on miss.
+/// `None` is a miss (instrumental / no lyrics / network error).
+pub async fn fetch_for_track(
+    artist: &str,
+    title: &str,
+    album: Option<&str>,
+    duration: Option<f64>,
+) -> Option<SyncedLyrics> {
+    if artist.trim().is_empty() && title.trim().is_empty() {
+        return None;
+    }
+    let key = cache_key(artist, title);
+    if let Some(cached) = cache_read(&key) {
+        return cached;
+    }
+    match fetch_lrclib(artist, title, album, duration).await {
+        Ok(result) => {
+            cache_write(&key, result.as_ref());
+            result
+        }
+        Err(err) => {
+            log::debug!("lrclib: {err}");
+            None
+        }
+    }
+}
+
+fn cache_key(artist: &str, title: &str) -> String {
+    format!(
+        "{}\u{1f}{}",
+        artist.trim().to_lowercase(),
+        title.trim().to_lowercase()
+    )
+}
+
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// `Some(Some(lyrics))` hit, `Some(None)` valid negative, `None` miss/expired.
+fn cache_read(key: &str) -> Option<Option<SyncedLyrics>> {
+    let Ok(conn) = database::get_connection() else {
+        return None;
+    };
+    let (payload, hit, fetched_at): (Option<String>, i64, i64) = conn
+        .query_row(
+            "SELECT payload, hit, fetched_at FROM lyrics WHERE cache_key = ?1",
+            [key],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .ok()?;
+    let now = unix_now();
+    if hit == 0 {
+        if now.saturating_sub(fetched_at) > NEGATIVE_TTL_SECS {
+            return None;
+        }
+        return Some(None);
+    }
+    let lyrics = payload.and_then(|json| serde_json::from_str(&json).ok())?;
+    Some(Some(lyrics))
+}
+
+fn cache_write(key: &str, value: Option<&SyncedLyrics>) {
+    let Ok(conn) = database::get_connection() else {
+        return;
+    };
+    let (payload, hit) = match value {
+        Some(lyrics) => (serde_json::to_string(lyrics).ok(), 1i64),
+        None => (None, 0i64),
+    };
+    if let Err(err) = conn.execute(
+        "INSERT OR REPLACE INTO lyrics (cache_key, payload, hit, fetched_at)
+         VALUES (?1, ?2, ?3, ?4)",
+        rusqlite::params![key, payload, hit, unix_now()],
+    ) {
+        log::debug!("lyrics cache write: {err}");
+    }
+}
+
+fn http_client() -> Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .user_agent(CLIENT_ID)
+                .build()
+                .unwrap_or_else(|_| Client::new())
+        })
+        .clone()
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct LrclibTrack {
+    #[serde(default)]
+    duration: Option<f64>,
+    #[serde(default)]
+    instrumental: Option<bool>,
+    #[serde(default)]
+    plain_lyrics: Option<String>,
+    #[serde(default)]
+    synced_lyrics: Option<String>,
+}
+
+impl LrclibTrack {
+    fn into_lyrics(self) -> Option<SyncedLyrics> {
+        let instrumental = self.instrumental.unwrap_or(false);
+        let lines = self
+            .synced_lyrics
+            .as_deref()
+            .map(parse_lrc)
+            .unwrap_or_default();
+        let plain = self
+            .plain_lyrics
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        if instrumental {
+            return Some(SyncedLyrics {
+                lines,
+                plain,
+                instrumental: true,
+                source: "lrclib".into(),
+            });
+        }
+        if lines.is_empty() && plain.is_none() {
+            return None;
+        }
+        Some(SyncedLyrics {
+            lines,
+            plain,
+            instrumental: false,
+            source: "lrclib".into(),
+        })
+    }
+}
+
+async fn fetch_lrclib(
+    artist: &str,
+    title: &str,
+    album: Option<&str>,
+    duration: Option<f64>,
+) -> Result<Option<SyncedLyrics>, String> {
+    let client = http_client();
+    let mut query: Vec<(&str, String)> = vec![
+        ("artist_name", artist.to_string()),
+        ("track_name", title.to_string()),
+    ];
+    if let Some(album) = album.filter(|s| !s.is_empty()) {
+        query.push(("album_name", album.to_string()));
+    }
+    if let Some(secs) = duration.filter(|d| *d > 0.0) {
+        query.push(("duration", format!("{secs:.0}")));
+    }
+
+    let get = client
+        .get(format!("{LRCLIB_BASE}/api/get"))
+        .header("Lrclib-Client", CLIENT_ID)
+        .query(&query)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+
+    if get.status().is_success() {
+        let bytes = read_response_limited(get, MAX_BODY_BYTES).await?;
+        if let Ok(track) = serde_json::from_slice::<LrclibTrack>(&bytes) {
+            if let Some(lyrics) = track.into_lyrics() {
+                return Ok(Some(lyrics));
+            }
+        }
+    } else if get.status() != reqwest::StatusCode::NOT_FOUND {
+        return Err(format!("lrclib get {}", get.status()));
+    }
+
+    let search = client
+        .get(format!("{LRCLIB_BASE}/api/search"))
+        .header("Lrclib-Client", CLIENT_ID)
+        .query(&[("artist_name", artist), ("track_name", title)])
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+    if !search.status().is_success() {
+        return Err(format!("lrclib search {}", search.status()));
+    }
+    let bytes = read_response_limited(search, MAX_BODY_BYTES).await?;
+    let tracks: Vec<LrclibTrack> = serde_json::from_slice(&bytes).map_err(|err| err.to_string())?;
+    Ok(pick_search(tracks, duration))
+}
+
+fn pick_search(tracks: Vec<LrclibTrack>, want_duration: Option<f64>) -> Option<SyncedLyrics> {
+    let mut best: Option<(i64, SyncedLyrics)> = None;
+    for track in tracks {
+        let duration = track.duration;
+        let Some(lyrics) = track.into_lyrics() else {
+            continue;
+        };
+        let mut score = 0i64;
+        if lyrics.has_synced() {
+            score += 100;
+        } else if lyrics.plain.is_some() {
+            score += 20;
+        }
+        if let (Some(want), Some(got)) = (want_duration, duration) {
+            let delta = (want - got).abs();
+            if delta <= DURATION_TOLERANCE_SECS {
+                score += 50;
+            } else {
+                score -= delta.min(40.0) as i64;
+            }
+        }
+        match &best {
+            Some((best_score, _)) if *best_score >= score => {}
+            _ => best = Some((score, lyrics)),
+        }
+    }
+    best.map(|(_, lyrics)| lyrics)
+}
+
+fn parse_offset_tag(line: &str) -> Option<i64> {
+    let inner = line
+        .strip_prefix('[')?
+        .strip_suffix(']')?
+        .strip_prefix("offset:")?;
+    inner.trim().parse().ok()
+}
+
+fn is_id_tag(line: &str) -> bool {
+    let Some(inner) = line.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+        return false;
+    };
+    let name = inner.split_once(':').map(|(k, _)| k).unwrap_or(inner);
+    name.chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+}
+
+fn split_timestamps(line: &str) -> (Vec<u64>, &str) {
+    let mut times = Vec::new();
+    let mut rest = line;
+    while rest.starts_with('[') {
+        let Some(end) = rest.find(']') else {
+            break;
+        };
+        let inner = &rest[1..end];
+        let Some(time_ms) = parse_timestamp(inner) else {
+            break;
+        };
+        times.push(time_ms);
+        rest = &rest[end + 1..];
+    }
+    (times, rest)
+}
+
+fn parse_timestamp(tag: &str) -> Option<u64> {
+    let tag = tag.trim();
+    if tag.is_empty() || !tag.chars().next()?.is_ascii_digit() {
+        return None;
+    }
+    let (clock, frac) = match tag.split_once('.') {
+        Some((clock, frac)) => (clock, Some(frac)),
+        None => (tag, None),
+    };
+    let segs: Vec<&str> = clock.split(':').collect();
+    let (minutes, seconds) = match segs.as_slice() {
+        [m, s] => (m.parse::<u64>().ok()?, s.parse::<u64>().ok()?),
+        [h, m, s] => {
+            let hours = h.parse::<u64>().ok()?;
+            let minutes = m.parse::<u64>().ok()?;
+            let seconds = s.parse::<u64>().ok()?;
+            (hours * 60 + minutes, seconds)
+        }
+        _ => return None,
+    };
+    if seconds >= 60 {
+        return None;
+    }
+    let ms = match frac {
+        None => 0,
+        Some(raw) => {
+            let digits: String = raw.chars().filter(|c| c.is_ascii_digit()).take(3).collect();
+            if digits.is_empty() {
+                return None;
+            }
+            let n = digits.parse::<u64>().ok()?;
+            match digits.len() {
+                1 => n * 100,
+                2 => n * 10,
+                _ => n,
+            }
+        }
+    };
+    Some((minutes * 60 + seconds) * 1000 + ms)
+}
+
+fn strip_word_tags(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(start) = rest.find('<') {
+        out.push_str(&rest[..start]);
+        match rest[start..].find('>') {
+            Some(rel_end) => {
+                let inner = &rest[start + 1..start + rel_end];
+                if parse_timestamp(inner).is_none() {
+                    out.push_str(&rest[start..start + rel_end + 1]);
+                }
+                rest = &rest[start + rel_end + 1..];
+            }
+            None => {
+                out.push_str(rest);
+                return out;
+            }
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn collapse_ws(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lrc(src: &str) -> Vec<LyricLine> {
+        parse_lrc(src)
+    }
+
+    #[test]
+    fn parse_standard_lrc_times_and_text() {
+        let lines = lrc("[00:12.00] Hello\n[00:15.50] World\n");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].time_ms, 12_000);
+        assert_eq!(lines[0].text, "Hello");
+        assert_eq!(lines[1].time_ms, 15_500);
+        assert_eq!(lines[1].text, "World");
+    }
+
+    #[test]
+    fn parse_skips_metadata_and_applies_offset() {
+        let lines = lrc("[ti:Song]\n[ar:Artist]\n[offset:+500]\n[00:01.00] Hi\n");
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0].time_ms, 1_500);
+        assert_eq!(lines[0].text, "Hi");
+    }
+
+    #[test]
+    fn parse_negative_offset_clamps_at_zero() {
+        let lines = lrc("[offset:-2000]\n[00:01.00] Hi\n");
+        assert_eq!(lines[0].time_ms, 0);
+    }
+
+    #[test]
+    fn parse_multiple_timestamps_on_one_line() {
+        let lines = lrc("[00:10.00][00:20.00] Chorus\n");
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].time_ms, 10_000);
+        assert_eq!(lines[1].time_ms, 20_000);
+        assert_eq!(lines[0].text, "Chorus");
+        assert_eq!(lines[1].text, "Chorus");
+    }
+
+    #[test]
+    fn parse_centiseconds_milliseconds_and_hours() {
+        assert_eq!(parse_timestamp("01:02.5"), Some(62_500));
+        assert_eq!(parse_timestamp("01:02.50"), Some(62_500));
+        assert_eq!(parse_timestamp("01:02.500"), Some(62_500));
+        assert_eq!(parse_timestamp("1:02"), Some(62_000));
+        assert_eq!(parse_timestamp("01:02:03.00"), Some(3_723_000));
+        assert!(parse_timestamp("ar:Artist").is_none());
+        assert!(parse_timestamp("00:99.00").is_none());
+    }
+
+    #[test]
+    fn parse_strips_enhanced_word_tags() {
+        let lines = lrc("[00:12.00] Hello <00:12.50>world\n");
+        assert_eq!(lines[0].text, "Hello world");
+    }
+
+    #[test]
+    fn parse_windows_line_endings_and_blank_lines() {
+        let lines = lrc("[00:01.00] A\r\n\r\n[00:02.00] B\r\n");
+        assert_eq!(
+            lines.iter().map(|l| l.text.as_str()).collect::<Vec<_>>(),
+            ["A", "B"]
+        );
+    }
+
+    #[test]
+    fn parse_sorts_out_of_order_lines() {
+        let lines = lrc("[00:20.00] Late\n[00:10.00] Early\n");
+        assert_eq!(lines[0].text, "Early");
+        assert_eq!(lines[1].text, "Late");
+    }
+
+    #[test]
+    fn active_line_binary_search() {
+        let lines = lrc("[00:00.00] A\n[00:10.00] B\n[00:20.00] C\n");
+        assert_eq!(active_line_index(&lines, 0), Some(0));
+        assert_eq!(active_line_index(&lines, 9_999), Some(0));
+        assert_eq!(active_line_index(&lines, 10_000), Some(1));
+        assert_eq!(active_line_index(&lines, 19_999), Some(1));
+        assert_eq!(active_line_index(&lines, 20_000), Some(2));
+        assert_eq!(active_line_index(&lines, 99_999), Some(2));
+        assert_eq!(active_line_index(&[], 0), None);
+    }
+
+    #[test]
+    fn active_line_none_before_first() {
+        let lines = lrc("[00:05.00] A\n[00:10.00] B\n");
+        assert_eq!(active_line_index(&lines, 0), None);
+        assert_eq!(active_line_index(&lines, 4_999), None);
+        assert_eq!(active_line_index(&lines, 5_000), Some(0));
+    }
+
+    #[test]
+    fn delay_until_next_line() {
+        let lyrics = SyncedLyrics {
+            lines: lrc("[00:01.00] A\n[00:03.00] B\n"),
+            ..SyncedLyrics::default()
+        };
+        assert_eq!(
+            lyrics.delay_until_next(0),
+            Some(Duration::from_millis(1_000))
+        );
+        assert_eq!(
+            lyrics.delay_until_next(1_000),
+            Some(Duration::from_millis(2_000))
+        );
+        assert!(lyrics.delay_until_next(3_000).is_none());
+        assert!(SyncedLyrics::default().delay_until_next(0).is_none());
+    }
+
+    #[test]
+    fn highlight_window_tracks_active_line() {
+        let lyrics = SyncedLyrics {
+            lines: lrc("[00:00.00] A\n[00:10.00] B\n[00:20.00] C\n"),
+            ..SyncedLyrics::default()
+        };
+        assert_eq!(lyrics.highlight_window(0), [None, Some("A"), Some("B")]);
+        assert_eq!(
+            lyrics.highlight_window(10_000),
+            [Some("A"), Some("B"), Some("C")]
+        );
+        assert_eq!(lyrics.highlight_window(20_000), [Some("B"), Some("C"), None]);
+        let late = SyncedLyrics {
+            lines: lrc("[00:05.00] A\n"),
+            ..SyncedLyrics::default()
+        };
+        assert_eq!(late.highlight_window(0), [None, None, Some("A")]);
+    }
+
+    #[test]
+    fn cache_key_is_case_insensitive() {
+        assert_eq!(
+            cache_key(" Radiohead ", " Karma Police "),
+            cache_key("radiohead", "karma police")
+        );
+    }
+}

--- a/crates/nook-core/src/mediaremote.rs
+++ b/crates/nook-core/src/mediaremote.rs
@@ -11,10 +11,14 @@
 //!
 //! [mediaremote-adapter]: https://github.com/ungive/mediaremote-adapter
 
-use serde_json::Value;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::sync::OnceLock;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, Once, OnceLock};
+use std::time::{Duration, Instant};
 
 /// MediaRemote `MRCommand` / adapter `MRACommand` IDs.
 #[derive(Debug, Clone, Copy)]
@@ -180,6 +184,247 @@ fn find_media_control() -> Option<PathBuf> {
     None
 }
 
+fn adapter_supports_stream() -> bool {
+    matches!(backend(), Some(Backend::Adapter { .. }))
+}
+
+struct StreamState {
+    merged: Value,
+    track: Option<AdapterTrack>,
+    elapsed_base: Option<f64>,
+    elapsed_at: Instant,
+    playing: bool,
+    primed: bool,
+}
+
+impl StreamState {
+    fn fresh() -> Self {
+        Self {
+            merged: Value::Object(Map::new()),
+            track: None,
+            elapsed_base: None,
+            elapsed_at: Instant::now(),
+            playing: false,
+            primed: false,
+        }
+    }
+}
+
+fn stream_state() -> &'static Mutex<StreamState> {
+    static STATE: OnceLock<Mutex<StreamState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(StreamState::fresh()))
+}
+
+static STREAM_CHANGED: AtomicBool = AtomicBool::new(false);
+static STREAM_ALIVE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Deserialize)]
+struct StreamEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    diff: bool,
+    #[serde(default)]
+    payload: Value,
+}
+
+/// Spawn the long-lived adapter `stream --diff` child (once). No-op for the
+/// debug `media-control` backend and when the adapter is missing.
+pub fn ensure_stream() {
+    if !adapter_supports_stream() {
+        return;
+    }
+    static STARTED: Once = Once::new();
+    STARTED.call_once(|| {
+        let _ = std::thread::Builder::new()
+            .name("nook-mr-stream".into())
+            .spawn(stream_supervisor);
+    });
+}
+
+/// Latest snapshot from the live stream, with `elapsed_time` interpolated
+/// from the last event while playing. `None` if the stream has not produced
+/// a snapshot yet (caller should one-shot `get --now`).
+pub fn latest_now_playing() -> Option<Option<AdapterTrack>> {
+    let Ok(state) = stream_state().lock() else {
+        return None;
+    };
+    if !state.primed {
+        return None;
+    }
+    Some(interpolated_track(&state))
+}
+
+pub fn take_stream_changed() -> bool {
+    STREAM_CHANGED.swap(false, Ordering::Relaxed)
+}
+
+pub fn stream_is_live() -> bool {
+    STREAM_ALIVE.load(Ordering::Relaxed)
+}
+
+fn interpolated_track(state: &StreamState) -> Option<AdapterTrack> {
+    let mut track = state.track.clone()?;
+    if state.playing {
+        if let Some(base) = state.elapsed_base.or(track.elapsed_time) {
+            let mut elapsed = base + state.elapsed_at.elapsed().as_secs_f64();
+            if let Some(duration) = track.duration {
+                elapsed = elapsed.min(duration.max(0.0));
+            }
+            track.elapsed_time = Some(elapsed);
+        }
+    }
+    Some(track)
+}
+
+fn merge_diff(target: &mut Value, diff: Value) {
+    let Value::Object(diff_map) = diff else {
+        if !diff.is_null() {
+            *target = diff;
+        }
+        return;
+    };
+    if !target.is_object() {
+        *target = Value::Object(Map::new());
+    }
+    let Some(map) = target.as_object_mut() else {
+        return;
+    };
+    for (k, v) in diff_map {
+        if v.is_null() {
+            map.remove(&k);
+        } else {
+            map.insert(k, v);
+        }
+    }
+}
+
+fn apply_payload(diff: bool, payload: Value) {
+    let mut state = stream_state().lock().unwrap_or_else(|e| e.into_inner());
+    if diff {
+        merge_diff(&mut state.merged, payload);
+    } else {
+        state.merged = match payload {
+            Value::Object(map) => Value::Object(map),
+            Value::Null => Value::Object(Map::new()),
+            other => other,
+        };
+    }
+    let json = serde_json::to_string(&state.merged).unwrap_or_else(|_| "{}".into());
+    let track = parse_get_output(&json).ok().flatten();
+    state.playing = track.as_ref().map(|t| t.is_playing).unwrap_or(false);
+    state.elapsed_base = track.as_ref().and_then(|t| t.elapsed_time);
+    state.elapsed_at = Instant::now();
+    state.track = track;
+    state.primed = true;
+    STREAM_CHANGED.store(true, Ordering::Relaxed);
+    drop(state);
+    crate::audio::note_media_event();
+}
+
+fn apply_stream_event(line: &str) -> bool {
+    let ev: StreamEvent = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(err) => {
+            log::debug!("MediaRemote stream JSON: {err}");
+            return false;
+        }
+    };
+    if ev.kind != "data" {
+        return false;
+    }
+    apply_payload(ev.diff, ev.payload);
+    true
+}
+
+fn apply_primer_stdout(stdout: &str) {
+    let trimmed = stdout.trim();
+    let payload = if trimmed.is_empty() || trimmed == "null" {
+        Value::Object(Map::new())
+    } else {
+        serde_json::from_str(trimmed).unwrap_or_else(|_| Value::Object(Map::new()))
+    };
+    apply_payload(false, payload);
+}
+
+fn stream_supervisor() {
+    if let Ok(out) = run(&["get", "--now"]) {
+        apply_primer_stdout(&out);
+    }
+    let mut backoff = Duration::from_millis(200);
+    loop {
+        match spawn_stream_child() {
+            Ok(mut child) => {
+                STREAM_ALIVE.store(true, Ordering::Relaxed);
+                backoff = Duration::from_millis(200);
+                let _ = read_stream(&mut child);
+                STREAM_ALIVE.store(false, Ordering::Relaxed);
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            Err(err) => {
+                log::debug!("MediaRemote stream spawn failed: {err}");
+            }
+        }
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_secs(8));
+    }
+}
+
+fn spawn_stream_child() -> Result<std::process::Child, String> {
+    let Some(Backend::Adapter {
+        perl,
+        script,
+        framework,
+    }) = backend()
+    else {
+        return Err("MediaRemote stream needs the adapter backend".into());
+    };
+    Command::new(perl)
+        .arg(script)
+        .arg(framework)
+        .arg("stream")
+        .arg("--diff")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn MediaRemote stream: {e}"))
+}
+
+fn read_stream(child: &mut std::process::Child) -> bool {
+    let Some(stdout) = child.stdout.take() else {
+        return false;
+    };
+    let pid = child.id();
+    let first = std::sync::Arc::new(AtomicBool::new(false));
+    let first_flag = first.clone();
+    let _ = std::thread::Builder::new()
+        .name("nook-mr-watchdog".into())
+        .spawn(move || {
+            std::thread::sleep(Duration::from_secs(3));
+            if !first_flag.load(Ordering::Relaxed) {
+                let _ = Command::new("/bin/kill").arg(pid.to_string()).status();
+            }
+        });
+    let reader = BufReader::new(stdout);
+    let mut saw_line = false;
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            break;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if !saw_line {
+            saw_line = true;
+            first.store(true, Ordering::Relaxed);
+        }
+        apply_stream_event(&line);
+    }
+    saw_line
+}
+
 fn run(args: &[&str]) -> Result<String, String> {
     let backend = backend().ok_or_else(|| "MediaRemote adapter not available".to_string())?;
     let mut cmd = match backend {
@@ -211,7 +456,13 @@ fn run(args: &[&str]) -> Result<String, String> {
 }
 
 /// `adapter_get` / `get --now`. `Ok(None)` means no now-playing item (`null`).
+/// Prefers the live `stream` cell when the supervisor has primed it so a
+/// poll never forks perl. One-shot `get --now` remains the startup primer
+/// and the debug `media-control` path.
 pub fn get_now_playing() -> Result<Option<AdapterTrack>, String> {
+    if let Some(cached) = latest_now_playing() {
+        return Ok(cached);
+    }
     let stdout = run(&["get", "--now"])?;
     parse_get_output(&stdout)
 }
@@ -442,6 +693,94 @@ mod tests {
     #[test]
     fn release_build_has_no_ambient_backend_fallback() {
         assert!(development_backend().is_none());
+    }
+
+    static STREAM_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn reset_stream() {
+        let mut state = stream_state().lock().unwrap_or_else(|e| e.into_inner());
+        *state = StreamState::fresh();
+        STREAM_CHANGED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn stream_full_replace_then_diff_merge() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        assert!(apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{
+                "title":"Helpless","artist":"The Staves","playing":true,
+                "duration":214.2,"elapsedTime":12,
+                "bundleIdentifier":"com.spotify.client"
+            }}"#
+        ));
+        let track = latest_now_playing().unwrap().unwrap();
+        assert_eq!(track.title.as_deref(), Some("Helpless"));
+        let elapsed = track.elapsed_time.unwrap();
+        assert!(elapsed >= 12.0 && elapsed < 12.2, "elapsed={elapsed}");
+        assert!(track.is_playing);
+
+        assert!(apply_stream_event(
+            r#"{"type":"data","diff":true,"payload":{"elapsedTime":40,"playing":false}}"#
+        ));
+        let track = latest_now_playing().unwrap().unwrap();
+        assert_eq!(track.title.as_deref(), Some("Helpless"));
+        assert_eq!(track.elapsed_time, Some(40.0));
+        assert!(!track.is_playing);
+        assert!(take_stream_changed());
+    }
+
+    #[test]
+    fn stream_empty_payload_is_idle() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"X","playing":true,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        apply_stream_event(r#"{"type":"data","diff":false,"payload":{}}"#);
+        assert!(latest_now_playing().unwrap().is_none());
+    }
+
+    #[test]
+    fn stream_diff_null_removes_key() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","artist":"B","playing":true,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        apply_stream_event(r#"{"type":"data","diff":true,"payload":{"title":null}}"#);
+        assert!(latest_now_playing().unwrap().is_none());
+    }
+
+    #[test]
+    fn elapsed_interpolates_while_playing() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","playing":true,"elapsedTime":10,"duration":100,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        let elapsed = latest_now_playing()
+            .unwrap()
+            .unwrap()
+            .elapsed_time
+            .unwrap();
+        assert!(elapsed >= 10.03, "elapsed={elapsed}");
+        assert!(elapsed < 11.0, "elapsed={elapsed}");
+    }
+
+    #[test]
+    fn elapsed_does_not_advance_when_paused() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","playing":false,"elapsedTime":10,"duration":100,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        assert_eq!(
+            latest_now_playing().unwrap().unwrap().elapsed_time,
+            Some(10.0)
+        );
     }
 
     #[test]

--- a/crates/nook-core/src/models.rs
+++ b/crates/nook-core/src/models.rs
@@ -42,3 +42,24 @@ pub struct NowPlayingData {
     #[serde(default)]
     pub bundle_id: Option<String>,
 }
+
+/// One timed line from an LRC file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LyricLine {
+    pub time_ms: u64,
+    pub text: String,
+}
+
+/// Lyrics for the current track. `lines` is empty when only plain text (or
+/// an instrumental) is available. Text is fetched at runtime and never bundled.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct SyncedLyrics {
+    #[serde(default)]
+    pub lines: Vec<LyricLine>,
+    #[serde(default)]
+    pub plain: Option<String>,
+    #[serde(default)]
+    pub instrumental: bool,
+    #[serde(default)]
+    pub source: String,
+}

--- a/crates/nook-core/src/mouse.rs
+++ b/crates/nook-core/src/mouse.rs
@@ -185,7 +185,11 @@ fn contains((x0, x1, y0, y1): (f64, f64, f64, f64), x: f64, y: f64) -> bool {
     x >= x0 && x <= x1 && y >= y0 && y <= y1
 }
 
-/// Sample the cursor off the UI thread. Safe to call more than once.
+/// Sample the cursor. On macOS this is a 250 ms backstop — NSEvent global
+/// and local monitors (installed on the main thread from `platform`) write
+/// the same atomics on every move/drag. Monitors can drop during secure
+/// input or some full-screen games; the slow poll is how hover still exits.
+/// Windows/Linux keep the tighter poll (no AppKit monitors).
 pub fn start_polling() {
     if POLL_STARTED.swap(true, Ordering::SeqCst) {
         return;
@@ -195,20 +199,33 @@ pub fn start_polling() {
         .name("nook-mouse".into())
         .spawn(|| loop {
             sample_now();
-            let inside = {
-                let (mx, my) = current_mouse_logical();
-                hit_test(mx, my)
-            };
-            let ms = if inside || DRAG_ACTIVE.load(Ordering::Relaxed) {
-                20
-            } else {
-                33
-            };
+            let ms = poll_interval_ms();
             std::thread::sleep(std::time::Duration::from_millis(ms));
         });
 }
 
-fn sample_now() {
+fn poll_interval_ms() -> u64 {
+    #[cfg(target_os = "macos")]
+    {
+        250
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let inside = {
+            let (mx, my) = current_mouse_logical();
+            hit_test(mx, my)
+        };
+        if inside || DRAG_ACTIVE.load(Ordering::Relaxed) {
+            20
+        } else {
+            33
+        }
+    }
+}
+
+/// Read cursor + drag into the atomics. Safe from NSEvent monitor handlers
+/// (main thread) and from the safety-poll thread.
+pub fn sample_now() {
     let (x, y) = read_mouse_logical();
     MOUSE_X.store(x.to_bits(), Ordering::Relaxed);
     MOUSE_Y.store(y.to_bits(), Ordering::Relaxed);

--- a/crates/nook-core/src/occupancy.rs
+++ b/crates/nook-core/src/occupancy.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Refresh at most this often — `CGWindowListCopyWindowInfo` is not cheap
-/// enough for the 20 ms mouse poll.
-const CACHE_MS: u64 = 250;
+/// enough for the mouse path. App-activate notifications invalidate sooner.
+const CACHE_MS: u64 = 1000;
 
 static CACHE: AtomicBool = AtomicBool::new(false);
 static LAST_MS: AtomicU64 = AtomicU64::new(0);
@@ -42,9 +42,19 @@ pub fn window_fills_display(window: ScreenRect, screen: ScreenRect, visible: Scr
     window.covers(screen, TOL) || window.covers(visible, TOL)
 }
 
+/// Drop the occupancy cache so the next sample talks to the window server.
+/// Driven from `NSWorkspaceDidActivateApplicationNotification`.
+pub fn invalidate() {
+    LAST_MS.store(0, Ordering::Relaxed);
+}
+
 /// Cached sample of [`query_frontmost_fills`]. Safe to call from the island
-/// poll loop.
+/// poll loop. No-ops when hide-when-maximized is off so the window-list
+/// walk never runs for users who disabled the setting.
 pub fn frontmost_fills_display() -> bool {
+    if !crate::settings::get_app_settings().hide_when_maximized {
+        return false;
+    }
     let now = unix_ms();
     let last = LAST_MS.load(Ordering::Relaxed);
     if now.saturating_sub(last) < CACHE_MS {
@@ -297,5 +307,15 @@ mod tests {
             screen,
             visible
         ));
+    }
+
+    #[test]
+    fn hide_when_maximized_off_is_a_cheap_false() {
+        invalidate();
+        assert!(
+            !crate::settings::get_app_settings().hide_when_maximized,
+            "default settings keep the occupancy walk off"
+        );
+        assert!(!frontmost_fills_display());
     }
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -124,6 +124,9 @@ pub struct AppSettings {
     pub widget_order: Vec<WidgetModule>,
     #[serde(default = "default_true")]
     pub show_media: bool,
+    /// Opt-in time-synced lyrics beside Now Playing (LRCLIB, cached locally).
+    #[serde(default)]
+    pub show_lyrics: bool,
     #[serde(default = "default_true")]
     pub show_calendar: bool,
     #[serde(default = "default_true")]
@@ -222,6 +225,7 @@ impl Default for AppSettings {
         Self {
             widget_order: default_widget_order(),
             show_media: true,
+            show_lyrics: false,
             show_calendar: true,
             show_reminders: true,
             show_agents: true,
@@ -602,6 +606,7 @@ mod tests {
         let parsed: AppSettings = serde_json::from_str(r#"{"liquid_glass_mode":true}"#).unwrap();
         assert_eq!(parsed.widget_order, default_widget_order());
         assert!(parsed.show_media);
+        assert!(!parsed.show_lyrics);
         assert!(parsed.show_calendar);
         assert!(parsed.show_reminders);
         assert!(parsed.show_agents);

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -99,7 +99,7 @@ impl Island {
                     &mut kids,
                     cell_pane(
                         self.settings.cells_for(module),
-                        nook_media_pane(&self.now_playing, cx),
+                        nook_media_pane(self, cx),
                     ),
                 ),
                 WidgetModule::Calendar if self.settings.show_calendar => add(

--- a/crates/nook/src/island/media.rs
+++ b/crates/nook/src/island/media.rs
@@ -76,8 +76,7 @@ pub(super) fn album_chip(
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                this.now_playing.is_playing = !this.now_playing.is_playing;
-                cx.notify();
+                this.note_media_play_pause(cx);
                 nook_core::runtime().spawn(async {
                     let _ = nook_core::audio::media_play_pause().await;
                 });
@@ -241,12 +240,15 @@ const APP_BADGE: f32 = 22.0;
 const APP_BADGE_RADIUS: f32 = 5.0;
 
 /// Horizontal Now Playing strip for the Nook tab (art + metadata + transport).
-pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> impl IntoElement {
+/// When lyrics are on and a fetch has landed, a 3-line highlight window sits
+/// beside the artwork column.
+pub(crate) fn nook_media_pane(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let np = &island.now_playing;
     let title = np.title.clone().unwrap_or_else(|| "Unknown Title".into());
     let artist = np.artist.clone().unwrap_or_else(|| "Unknown Artist".into());
     let album = np.album.clone().filter(|s| !s.is_empty());
     let playing = np.is_playing;
-    let elapsed = np.elapsed_time.unwrap_or(0.0);
+    let elapsed = island.lyrics_position();
     let duration = np.duration.unwrap_or(0.0);
     let progress = if duration > 0.0 {
         (elapsed / duration) as f32
@@ -258,6 +260,7 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
         .artwork_base64
         .as_deref()
         .and_then(|b64| artwork_element(b64, NOOK_ART, NOOK_ART_RADIUS));
+    let lyrics = lyrics_pane(island);
 
     div()
         .id("nook-media")
@@ -309,13 +312,15 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                 .flex_col()
                 .justify_center()
                 .min_w(px(0.))
-                .w(px(160.))
+                .w(px(if lyrics.is_some() { 120. } else { 160. }))
                 .overflow_hidden()
                 .child(slide_label(title, theme::TITLE_3, true).w_full())
-                .when_some(album, |d, album| {
+                .when_some(album.filter(|_| lyrics.is_none()), |d, album| {
                     d.child(slide_label(album, theme::CALLOUT, false).w_full())
                 })
-                .child(slide_label(artist, theme::CALLOUT, false).w_full())
+                .when(lyrics.is_none(), |d| {
+                    d.child(slide_label(artist, theme::CALLOUT, false).w_full())
+                })
                 .child(
                     div()
                         .flex()
@@ -336,6 +341,59 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                 )
                 .child(nook_progress(progress, elapsed, duration, seekable, cx)),
         )
+        .when_some(lyrics, |d, pane| d.child(pane))
+}
+
+fn lyrics_pane(island: &Island) -> Option<AnyElement> {
+    if !island.settings.show_lyrics {
+        return None;
+    }
+    let lyrics = island.lyrics.as_ref()?;
+    if lyrics.instrumental {
+        return None;
+    }
+    if lyrics.has_synced() {
+        let [prev, cur, next] = lyrics.highlight_window(island.lyrics_position_ms());
+        return Some(lyrics_window(prev, cur, next));
+    }
+    let plain = lyrics.plain.as_deref()?;
+    let mut lines = plain.lines().filter(|line| !line.trim().is_empty());
+    let first = lines.next()?;
+    Some(lyrics_window(
+        None,
+        Some(first.trim()),
+        lines.next().map(str::trim),
+    ))
+}
+
+fn lyrics_window(prev: Option<&str>, cur: Option<&str>, next: Option<&str>) -> AnyElement {
+    div()
+        .id("lyrics-pane")
+        .flex_1()
+        .min_w(px(72.))
+        .max_w(px(220.))
+        .h(px(NOOK_ART))
+        .flex()
+        .flex_col()
+        .justify_center()
+        .gap(px(2.))
+        .overflow_hidden()
+        .child(lyric_line(prev.unwrap_or(""), false))
+        .child(lyric_line(cur.unwrap_or(""), true))
+        .child(lyric_line(next.unwrap_or(""), false))
+        .into_any_element()
+}
+
+fn lyric_line(text: &str, current: bool) -> AnyElement {
+    if text.is_empty() {
+        return div()
+            .h(px(theme::CALLOUT.leading))
+            .w_full()
+            .into_any_element();
+    }
+    slide_label(text.to_string(), theme::CALLOUT, current)
+        .w_full()
+        .into_any_element()
 }
 
 fn app_badge(bundle_id: Option<&str>, app_name: Option<&str>) -> AnyElement {
@@ -463,8 +521,7 @@ fn nook_seek_hits(cx: &mut Context<Island>) -> impl IntoElement {
                             return;
                         };
                         let position = duration * ratio as f64;
-                        this.now_playing.elapsed_time = Some(position);
-                        cx.notify();
+                        this.note_media_seek(position, cx);
                         nook_core::runtime().spawn(async move {
                             let _ = nook_core::audio::media_seek(position).await;
                         });
@@ -520,8 +577,7 @@ fn nook_play(playing: bool, cx: &mut Context<Island>) -> impl IntoElement {
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                this.now_playing.is_playing = !this.now_playing.is_playing;
-                cx.notify();
+                this.note_media_play_pause(cx);
                 nook_core::runtime().spawn(async {
                     let _ = nook_core::audio::media_play_pause().await;
                 });
@@ -666,8 +722,7 @@ fn seek_hits(cx: &mut Context<Island>) -> impl IntoElement {
                             return;
                         };
                         let position = duration * ratio as f64;
-                        this.now_playing.elapsed_time = Some(position);
-                        cx.notify();
+                        this.note_media_seek(position, cx);
                         nook_core::runtime().spawn(async move {
                             let _ = nook_core::audio::media_seek(position).await;
                         });
@@ -756,8 +811,7 @@ fn play_btn(playing: bool, cx: &mut Context<Island>) -> impl IntoElement {
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                this.now_playing.is_playing = !this.now_playing.is_playing;
-                cx.notify();
+                this.note_media_play_pause(cx);
                 nook_core::runtime().spawn(async {
                     let _ = nook_core::audio::media_play_pause().await;
                 });

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -857,13 +857,15 @@ impl Island {
         self.disarm_lyrics_timer();
         let album = self.now_playing.album.clone();
         let duration = self.now_playing.duration;
+        let artist = key.1.clone();
+        let title = key.0.clone();
         cx.spawn(async move |this, cx| {
             let fetched = cx
                 .background_executor()
                 .spawn(async move {
                     nook_core::runtime().block_on(nook_core::lyrics::fetch_for_track(
-                        &key.1,
-                        &key.0,
+                        &artist,
+                        &title,
                         album.as_deref(),
                         duration,
                     ))

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -286,14 +286,18 @@ impl Island {
                 platform::apply_island_chrome();
             }
             platform::request_pin();
+            // Park until a screen/space notification (or a 30s backstop).
+            // The previous 250 ms poll was an idle wakeup; handlers already
+            // pin on the main thread, this only covers a missed first pin.
             loop {
-                cx.background_executor()
-                    .timer(Duration::from_millis(250))
+                let needed = cx
+                    .background_executor()
+                    .spawn(async { platform::wait_pin_needed(Duration::from_secs(30)) })
                     .await;
                 if this.update(cx, |_, _| ()).is_err() {
                     break;
                 }
-                if platform::take_pin_needed() {
+                if needed || platform::take_pin_needed() {
                     platform::pin_island_windows();
                 }
             }
@@ -573,22 +577,19 @@ impl Island {
                 // Stream-backed adapter reads are a cheap lock; cadence is
                 // for interpolated elapsed (1s while playing) and the
                 // AppleScript fallback (5s idle). Distributed-notification
-                // observers and the MediaRemote stream flip `take_media_event`
-                // so the wait wakes instantly on real changes.
+                // observers and the MediaRemote stream poke `note_media_event`
+                // so this parks until a real change instead of slicing 250 ms.
                 let cadence = if is_playing {
                     Duration::from_secs(1)
                 } else {
                     Duration::from_secs(5)
                 };
-                let slice = Duration::from_millis(250);
-                let mut waited = Duration::ZERO;
-                loop {
-                    cx.background_executor().timer(slice).await;
-                    waited += slice;
-                    if nook_core::audio::take_media_event() || waited >= cadence {
-                        break;
-                    }
-                }
+                cx.background_executor()
+                    .spawn(async move {
+                        nook_core::runtime()
+                            .block_on(nook_core::audio::wait_media_or_timeout(cadence))
+                    })
+                    .await;
             }
         })
         .detach();

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -23,11 +23,12 @@ use gpui::{
 use nook_core::agents::AgentSession;
 use nook_core::calendar::{CalendarEvent, Reminder};
 use nook_core::files::FileTrayItem;
-use nook_core::models::NowPlayingData;
+use nook_core::models::{NowPlayingData, SyncedLyrics};
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
 use settings::SettingsView;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -68,6 +69,12 @@ pub struct Island {
     pub tab: Tab,
     pub now_playing: NowPlayingData,
     pub visualizer_color: Option<gpui::Rgba>,
+    /// Cached lyrics for the current title/artist. `None` until a fetch lands.
+    pub lyrics: Option<Arc<SyncedLyrics>>,
+    lyrics_key: Option<(String, String)>,
+    lyrics_anchor_elapsed: f64,
+    lyrics_anchor_at: Instant,
+    lyrics_timer_gen: u64,
     pub files: Vec<FileTrayItem>,
     pub events: Vec<CalendarEvent>,
     pub reminders: Vec<Reminder>,
@@ -198,6 +205,11 @@ impl Island {
             tab: Tab::Widgets,
             now_playing: NowPlayingData::default(),
             visualizer_color: None,
+            lyrics: None,
+            lyrics_key: None,
+            lyrics_anchor_elapsed: 0.0,
+            lyrics_anchor_at: Instant::now(),
+            lyrics_timer_gen: 0,
             files,
             events: Vec::new(),
             reminders: Vec::new(),
@@ -339,6 +351,7 @@ impl Island {
                         } else {
                             this.settings = settings;
                         }
+                        this.sync_lyrics(cx);
                         dirty = true;
                     }
                     if this.repositioning {
@@ -560,13 +573,17 @@ impl Island {
                     this.now_playing.is_playing = playing.is_playing;
                     this.now_playing.app_name = playing.app_name;
                     this.now_playing.bundle_id = playing.bundle_id;
+                    this.lyrics_anchor_elapsed = this.now_playing.elapsed_time.unwrap_or(0.0);
+                    this.lyrics_anchor_at = Instant::now();
                     this.visualizer_color = media::visualizer_color_from_art(
                         this.now_playing.artwork_base64.as_deref(),
                     );
                     if !was_media && this.has_media() {
                         this.preferred = Some(CompactMode::Media);
                     }
+                    this.sync_lyrics(cx);
                     if changed {
+                        this.arm_lyrics_line_timer(cx);
                         cx.notify();
                     }
                     this.has_media() && this.now_playing.is_playing
@@ -737,6 +754,131 @@ impl Island {
             && (self.now_playing.is_playing
                 || self.now_playing.title.is_some()
                 || self.now_playing.artist.is_some())
+    }
+
+    /// Interpolated playback position from the last now-playing snapshot.
+    pub(crate) fn lyrics_position(&self) -> f64 {
+        let extra = if self.now_playing.is_playing {
+            self.lyrics_anchor_at.elapsed().as_secs_f64()
+        } else {
+            0.0
+        };
+        let pos = (self.lyrics_anchor_elapsed + extra).max(0.0);
+        match self.now_playing.duration {
+            Some(duration) if duration > 0.0 => pos.min(duration),
+            _ => pos,
+        }
+    }
+
+    pub(crate) fn lyrics_position_ms(&self) -> u64 {
+        (self.lyrics_position() * 1000.0).max(0.0) as u64
+    }
+
+    pub(crate) fn note_media_seek(&mut self, position: f64, cx: &mut Context<Self>) {
+        let position = position.max(0.0);
+        self.now_playing.elapsed_time = Some(position);
+        self.lyrics_anchor_elapsed = position;
+        self.lyrics_anchor_at = Instant::now();
+        self.arm_lyrics_line_timer(cx);
+        cx.notify();
+    }
+
+    pub(crate) fn note_media_play_pause(&mut self, cx: &mut Context<Self>) {
+        let pos = self.lyrics_position();
+        self.now_playing.is_playing = !self.now_playing.is_playing;
+        self.lyrics_anchor_elapsed = pos;
+        self.lyrics_anchor_at = Instant::now();
+        self.arm_lyrics_line_timer(cx);
+        cx.notify();
+    }
+
+    fn lyrics_timer_should_run(&self) -> bool {
+        self.settings.show_lyrics
+            && self.settings.show_media
+            && self.expanded
+            && self.now_playing.is_playing
+            && self.lyrics.as_ref().is_some_and(|lyrics| lyrics.has_synced())
+    }
+
+    fn disarm_lyrics_timer(&mut self) {
+        self.lyrics_timer_gen = self.lyrics_timer_gen.wrapping_add(1);
+    }
+
+    /// One-shot timer for the next lyric line. Bumping `lyrics_timer_gen`
+    /// cancels a previously armed wait. Not a poll loop.
+    fn arm_lyrics_line_timer(&mut self, cx: &mut Context<Self>) {
+        self.disarm_lyrics_timer();
+        if !self.lyrics_timer_should_run() {
+            return;
+        }
+        let Some(lyrics) = self.lyrics.clone() else {
+            return;
+        };
+        let Some(wait) = lyrics.delay_until_next(self.lyrics_position_ms()) else {
+            return;
+        };
+        let gen = self.lyrics_timer_gen;
+        cx.spawn(async move |this, cx| {
+            cx.background_executor().timer(wait).await;
+            let _ = this.update(cx, |this, cx| {
+                if this.lyrics_timer_gen != gen {
+                    return;
+                }
+                cx.notify();
+                this.arm_lyrics_line_timer(cx);
+            });
+        })
+        .detach();
+    }
+
+    fn sync_lyrics(&mut self, cx: &mut Context<Self>) {
+        if !self.settings.show_lyrics || !self.settings.show_media {
+            if self.lyrics.is_some() || self.lyrics_key.is_some() {
+                self.lyrics = None;
+                self.lyrics_key = None;
+                self.disarm_lyrics_timer();
+            }
+            return;
+        }
+        let title = self.now_playing.title.clone().unwrap_or_default();
+        let artist = self.now_playing.artist.clone().unwrap_or_default();
+        if title.is_empty() && artist.is_empty() {
+            self.lyrics = None;
+            self.lyrics_key = None;
+            self.disarm_lyrics_timer();
+            return;
+        }
+        let key = (title, artist);
+        if self.lyrics_key.as_ref() == Some(&key) {
+            return;
+        }
+        self.lyrics_key = Some(key.clone());
+        self.lyrics = None;
+        self.disarm_lyrics_timer();
+        let album = self.now_playing.album.clone();
+        let duration = self.now_playing.duration;
+        cx.spawn(async move |this, cx| {
+            let fetched = cx
+                .background_executor()
+                .spawn(async move {
+                    nook_core::runtime().block_on(nook_core::lyrics::fetch_for_track(
+                        &key.1,
+                        &key.0,
+                        album.as_deref(),
+                        duration,
+                    ))
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.lyrics_key.as_ref() != Some(&key) {
+                    return;
+                }
+                this.lyrics = fetched.map(Arc::new);
+                this.arm_lyrics_line_timer(cx);
+                cx.notify();
+            });
+        })
+        .detach();
     }
 
     pub(crate) fn running_timer(&self) -> Option<&Timer> {
@@ -1089,6 +1231,7 @@ impl Island {
             self.stop_mirror(cx);
         }
         nook_core::haptics::trigger(None);
+        self.arm_lyrics_line_timer(cx);
         cx.notify();
     }
 
@@ -1115,6 +1258,7 @@ impl Island {
             if !self.expanded {
                 self.close_notes_editor(cx);
             }
+            self.arm_lyrics_line_timer(cx);
             cx.notify();
         }
     }
@@ -1443,6 +1587,11 @@ mod tests {
             tab: Tab::Widgets,
             now_playing: NowPlayingData::default(),
             visualizer_color: None,
+            lyrics: None,
+            lyrics_key: None,
+            lyrics_anchor_elapsed: 0.0,
+            lyrics_anchor_at: Instant::now(),
+            lyrics_timer_gen: 0,
             files: Vec::new(),
             events: Vec::new(),
             reminders: Vec::new(),
@@ -2100,6 +2249,30 @@ mod tests {
         // ...and collapse to one crisp layer once parked.
         assert_eq!(island.blur, 0.0);
         assert!(island.blur_offset().is_none());
+    }
+
+    #[test]
+    fn lyrics_position_holds_when_paused_and_advances_when_playing() {
+        let mut island = test_island();
+        island.lyrics_anchor_elapsed = 12.0;
+        island.lyrics_anchor_at = Instant::now() - Duration::from_millis(80);
+        island.now_playing.is_playing = false;
+        assert!((island.lyrics_position() - 12.0).abs() < 0.01);
+        island.now_playing.is_playing = true;
+        island.now_playing.duration = Some(100.0);
+        let pos = island.lyrics_position();
+        assert!(pos >= 12.05, "pos={pos}");
+        assert!(pos < 13.0, "pos={pos}");
+        assert!(!island.lyrics_timer_should_run());
+        island.settings.show_lyrics = true;
+        island.expanded = true;
+        island.lyrics = Some(Arc::new(SyncedLyrics {
+            lines: nook_core::lyrics::parse_lrc("[00:00.00] A\n[00:20.00] B\n"),
+            ..SyncedLyrics::default()
+        }));
+        assert!(island.lyrics_timer_should_run());
+        island.expanded = false;
+        assert!(!island.lyrics_timer_should_run());
     }
 
     #[test]

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -263,6 +263,7 @@ impl Island {
         this.anim_h.set(h);
 
         platform::install_media_observers();
+        platform::install_mouse_monitors();
         nook_core::runtime().spawn(async {
             let _ = nook_core::calendar::request_calendar_access().await;
         });
@@ -284,12 +285,17 @@ impl Island {
                     .await;
                 platform::apply_island_chrome();
             }
+            platform::request_pin();
             loop {
-                cx.background_executor().timer(Duration::from_secs(2)).await;
+                cx.background_executor()
+                    .timer(Duration::from_millis(250))
+                    .await;
                 if this.update(cx, |_, _| ()).is_err() {
                     break;
                 }
-                platform::pin_island_windows();
+                if platform::take_pin_needed() {
+                    platform::pin_island_windows();
+                }
             }
         })
         .detach();
@@ -564,12 +570,11 @@ impl Island {
                 let Ok(is_playing) = alive else {
                     break;
                 };
-                // Every poll spawns an osascript/perl child, so cadence is
-                // the battery cost that matters: 1s while playing (the
-                // elapsed display ticks in whole seconds anyway), 5s
-                // otherwise. The distributed-notification observers wake the
-                // wait instantly on Spotify/Music play/pause/track changes —
-                // the slow cadence only gates Safari/YouTube pickup.
+                // Stream-backed adapter reads are a cheap lock; cadence is
+                // for interpolated elapsed (1s while playing) and the
+                // AppleScript fallback (5s idle). Distributed-notification
+                // observers and the MediaRemote stream flip `take_media_event`
+                // so the wait wakes instantly on real changes.
                 let cadence = if is_playing {
                     Duration::from_secs(1)
                 } else {

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -960,6 +960,14 @@ impl SettingsView {
         let enabled = self.module.enabled(settings);
         let mut rows = vec![self.width_slider(settings, cx).into_any_element()];
         match self.module {
+            WidgetModule::Music => {
+                rows.push(
+                    toggle_row("Show lyrics", settings.show_lyrics, cx, |s| {
+                        s.show_lyrics = !s.show_lyrics;
+                    })
+                    .into_any_element(),
+                );
+            }
             WidgetModule::Calendar => {
                 rows.push(
                     action_row(
@@ -1345,8 +1353,8 @@ fn module_blurb(module: WidgetModule) -> SharedString {
         WidgetModule::Observe => {
             "Pinned metrics on the compact island and the expanded card.".into()
         }
-        WidgetModule::Music => {
-            "Now Playing from MediaRemote on macOS, with an AppleScript fallback.".into()
+            WidgetModule::Music => {
+            "Now Playing from MediaRemote. Optional time-synced lyrics from LRCLIB — opt-in, fetched at runtime, never bundled.".into()
         }
         WidgetModule::Files => "Drop zone and tray live on the Tray tab of the expanded island.".into(),
         WidgetModule::Timers => "Countdown presets and a compact ring while a timer is running.".into(),

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -20,6 +20,9 @@ use nook_core::notch::{CGPoint, CGRect, CGSize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::Once;
+#[cfg(target_os = "macos")]
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 static INSTALL: Once = Once::new();
@@ -46,7 +49,14 @@ pub fn install() {
 /// handlers also pin immediately on the main thread.
 pub fn request_pin() {
     #[cfg(target_os = "macos")]
-    PIN_NEEDED.store(true, Ordering::Release);
+    {
+        PIN_NEEDED.store(true, Ordering::Release);
+        let wait = pin_wait();
+        if let Ok(mut ready) = wait.ready.lock() {
+            *ready = true;
+            wait.cv.notify_one();
+        }
+    }
 }
 
 pub fn take_pin_needed() -> bool {
@@ -56,6 +66,52 @@ pub fn take_pin_needed() -> bool {
     }
     #[cfg(not(target_os = "macos"))]
     false
+}
+
+#[cfg(target_os = "macos")]
+struct PinWait {
+    ready: Mutex<bool>,
+    cv: Condvar,
+}
+
+#[cfg(target_os = "macos")]
+fn pin_wait() -> &'static PinWait {
+    static WAIT: OnceLock<PinWait> = OnceLock::new();
+    WAIT.get_or_init(|| PinWait {
+        ready: Mutex::new(false),
+        cv: Condvar::new(),
+    })
+}
+
+/// Block until [`request_pin`] or `timeout`. Must run off the main thread.
+pub fn wait_pin_needed(timeout: Duration) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if PIN_NEEDED.load(Ordering::Acquire) {
+            return true;
+        }
+        let wait = pin_wait();
+        let Ok(mut ready) = wait.ready.lock() else {
+            std::thread::sleep(timeout);
+            return PIN_NEEDED.load(Ordering::Acquire);
+        };
+        if *ready {
+            *ready = false;
+            return true;
+        }
+        let (mut ready, _) = wait
+            .cv
+            .wait_timeout(ready, timeout)
+            .unwrap_or_else(|e| e.into_inner());
+        let signaled = *ready;
+        *ready = false;
+        signaled || PIN_NEEDED.load(Ordering::Acquire)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::thread::sleep(timeout);
+        false
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -887,6 +943,17 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(colorsChanged:),
         name: colors_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let appearance_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSApplicationDidChangeEffectiveAppearanceNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        center,
+        addObserver: target,
+        selector: sel!(colorsChanged:),
+        name: appearance_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -806,6 +806,16 @@ fn install_app_target() {
         extern "C" fn app_activated(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
             nook_core::occupancy::invalidate();
         }
+        extern "C" fn accessibility_changed(
+            _this: *mut AnyObject,
+            _cmd: Sel,
+            _note: *mut AnyObject,
+        ) {
+            invalidate_accessibility_flags();
+        }
+        extern "C" fn colors_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            invalidate_accent_color();
+        }
 
         let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
         let cls = objc_allocateClassPair(super_cls, c"NookAppTarget".as_ptr(), 0);
@@ -826,10 +836,18 @@ fn install_app_target() {
         let imp_app: Imp = std::mem::transmute(
             app_activated as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
         );
+        let imp_a11y: Imp = std::mem::transmute(
+            accessibility_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
+        let imp_colors: Imp = std::mem::transmute(
+            colors_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
         let _ = class_addMethod(cls, sel!(openSettings:), imp_settings, types.as_ptr());
         let _ = class_addMethod(cls, sel!(screenChanged:), imp_screen, types.as_ptr());
         let _ = class_addMethod(cls, sel!(spaceChanged:), imp_space, types.as_ptr());
         let _ = class_addMethod(cls, sel!(appActivated:), imp_app, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(accessibilityChanged:), imp_a11y, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(colorsChanged:), imp_colors, types.as_ptr());
         objc_registerClassPair(cls);
         observe_screen_changes();
     }
@@ -857,6 +875,18 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(screenChanged:),
         name: name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+
+    let colors_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSSystemColorsDidChangeNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        center,
+        addObserver: target,
+        selector: sel!(colorsChanged:),
+        name: colors_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 
@@ -888,6 +918,18 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(appActivated:),
         name: app_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let a11y_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification"
+            .as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(accessibilityChanged:),
+        name: a11y_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 }
@@ -1380,16 +1422,43 @@ pub fn open_calendar() {
     }
 }
 
+#[cfg(target_os = "macos")]
+static ACCENT_VALID: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static ACCENT_R: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+#[cfg(target_os = "macos")]
+static ACCENT_G: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+#[cfg(target_os = "macos")]
+static ACCENT_B: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+#[cfg(target_os = "macos")]
+fn invalidate_accent_color() {
+    ACCENT_VALID.store(false, Ordering::Relaxed);
+}
+
 /// System Settings → Appearance → *Accent color* (`NSColor.controlAccentColor`),
 /// as sRGB components in 0..=1. `None` when there is no AppKit to ask or the
 /// color cannot be converted to an RGB space — callers fall back to systemBlue.
 ///
-/// Read live rather than cached so switching the accent in System Settings
-/// shows up on the next frame. Must be called on the main thread.
+/// Cached until `NSSystemColorsDidChangeNotification` so idle frames do not
+/// walk CoreUI catalog colors. Must be called on the main thread for the
+/// first resolve.
 pub fn accent_color() -> Option<(f32, f32, f32)> {
     #[cfg(target_os = "macos")]
     {
-        accent_color_macos()
+        if ACCENT_VALID.load(Ordering::Relaxed) {
+            return Some((
+                f32::from_bits(ACCENT_R.load(Ordering::Relaxed)),
+                f32::from_bits(ACCENT_G.load(Ordering::Relaxed)),
+                f32::from_bits(ACCENT_B.load(Ordering::Relaxed)),
+            ));
+        }
+        let color = accent_color_macos()?;
+        ACCENT_R.store(color.0.to_bits(), Ordering::Relaxed);
+        ACCENT_G.store(color.1.to_bits(), Ordering::Relaxed);
+        ACCENT_B.store(color.2.to_bits(), Ordering::Relaxed);
+        ACCENT_VALID.store(true, Ordering::Relaxed);
+        Some(color)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1432,10 +1501,23 @@ fn accent_color_macos() -> Option<(f32, f32, f32)> {
     })
 }
 
+#[cfg(target_os = "macos")]
+static REDUCE_TRANSPARENCY_CACHE: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_os = "macos")]
+static REDUCE_MOTION_CACHE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(target_os = "macos")]
+fn invalidate_accessibility_flags() {
+    REDUCE_TRANSPARENCY_CACHE.store(0, Ordering::Relaxed);
+    REDUCE_MOTION_CACHE.store(0, Ordering::Relaxed);
+}
+
 /// 1s-TTL cache for an AppKit accessibility flag. Both flags below are read
 /// from the 20ms island tick; two ObjC round-trips per tick is pointless for
-/// settings a human toggles at most a few times a day. Layout: bit0 = value,
-/// bit1 = valid, upper bits = last-read unix ms.
+/// settings a human toggles at most a few times a day. The workspace
+/// accessibility-display observer also invalidates these so a toggle applies
+/// on the next tick. Layout: bit0 = value, bit1 = valid, upper bits = last-read
+/// unix ms.
 #[cfg(target_os = "macos")]
 fn cached_accessibility_flag(cache: &AtomicU64, read: unsafe fn() -> bool) -> bool {
     let now_ms = std::time::SystemTime::now()
@@ -1457,7 +1539,6 @@ fn cached_accessibility_flag(cache: &AtomicU64, read: unsafe fn() -> bool) -> bo
 pub fn reduce_transparency() -> bool {
     #[cfg(target_os = "macos")]
     {
-        static CACHE: AtomicU64 = AtomicU64::new(0);
         unsafe fn read() -> bool {
             use objc2::runtime::AnyObject;
             use objc2::*;
@@ -1467,7 +1548,7 @@ pub fn reduce_transparency() -> bool {
             }
             msg_send![workspace, accessibilityDisplayShouldReduceTransparency]
         }
-        cached_accessibility_flag(&CACHE, read)
+        cached_accessibility_flag(&REDUCE_TRANSPARENCY_CACHE, read)
     }
     #[cfg(not(target_os = "macos"))]
     false
@@ -1480,7 +1561,6 @@ pub fn reduce_transparency() -> bool {
 pub fn reduce_motion() -> bool {
     #[cfg(target_os = "macos")]
     {
-        static CACHE: AtomicU64 = AtomicU64::new(0);
         unsafe fn read() -> bool {
             use objc2::runtime::AnyObject;
             use objc2::*;
@@ -1490,10 +1570,44 @@ pub fn reduce_motion() -> bool {
             }
             msg_send![workspace, accessibilityDisplayShouldReduceMotion]
         }
-        cached_accessibility_flag(&CACHE, read)
+        cached_accessibility_flag(&REDUCE_MOTION_CACHE, read)
     }
     #[cfg(not(target_os = "macos"))]
     false
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn workspace_note_bundle_id(note: *mut objc2::runtime::AnyObject) -> Option<String> {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    if note.is_null() {
+        return None;
+    }
+    let info: *mut AnyObject = msg_send![note, userInfo];
+    if info.is_null() {
+        return None;
+    }
+    let key: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceApplicationKey".as_ptr()
+    ];
+    let app: *mut AnyObject = msg_send![info, objectForKey: key];
+    if app.is_null() {
+        return None;
+    }
+    let ident: *mut AnyObject = msg_send![app, bundleIdentifier];
+    if ident.is_null() {
+        return None;
+    }
+    let utf8: *const std::ffi::c_char = msg_send![ident, UTF8String];
+    if utf8.is_null() {
+        return None;
+    }
+    Some(
+        std::ffi::CStr::from_ptr(utf8)
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Subscribe to Spotify's and Music's public playback-change broadcasts.
@@ -1514,23 +1628,60 @@ pub fn install_media_observers() {
 
         static INSTALLED: Once = Once::new();
         INSTALLED.call_once(|| {
+            let _ = nook_core::audio::prime_media_apps();
+
             let center: *mut AnyObject =
                 msg_send![class!(NSDistributedNotificationCenter), defaultCenter];
-            if center.is_null() {
+            if !center.is_null() {
+                for name in [
+                    c"com.spotify.client.PlaybackStateChanged",
+                    c"com.apple.Music.playerInfo",
+                    c"com.apple.iTunes.playerInfo",
+                ] {
+                    let ns_name: *mut AnyObject =
+                        msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
+                    let block = RcBlock::new(move |_note: *mut AnyObject| {
+                        nook_core::audio::note_media_event();
+                    });
+                    let token: *mut AnyObject = msg_send![
+                        center,
+                        addObserverForName: ns_name,
+                        object: std::ptr::null_mut::<AnyObject>(),
+                        queue: std::ptr::null_mut::<AnyObject>(),
+                        usingBlock: &*block
+                    ];
+                    std::mem::forget(block);
+                    let _ = token;
+                }
+            }
+
+            let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+            if workspace.is_null() {
                 return;
             }
-            for name in [
-                c"com.spotify.client.PlaybackStateChanged",
-                c"com.apple.Music.playerInfo",
-                c"com.apple.iTunes.playerInfo",
+            let wsnc: *mut AnyObject = msg_send![workspace, notificationCenter];
+            if wsnc.is_null() {
+                return;
+            }
+            for (name, running) in [
+                (c"NSWorkspaceDidLaunchApplicationNotification", true),
+                (c"NSWorkspaceDidTerminateApplicationNotification", false),
             ] {
                 let ns_name: *mut AnyObject =
                     msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
-                let block = RcBlock::new(move |_note: *mut AnyObject| {
-                    nook_core::audio::note_media_event();
+                let block = RcBlock::new(move |note: *mut AnyObject| {
+                    if let Some(id) = workspace_note_bundle_id(note) {
+                        nook_core::audio::note_media_app_running(&id, running);
+                        if matches!(
+                            id.as_str(),
+                            "com.spotify.client" | "com.apple.Music" | "com.apple.Safari"
+                        ) {
+                            nook_core::audio::note_media_event();
+                        }
+                    }
                 });
                 let token: *mut AnyObject = msg_send![
-                    center,
+                    wsnc,
                     addObserverForName: ns_name,
                     object: std::ptr::null_mut::<AnyObject>(),
                     queue: std::ptr::null_mut::<AnyObject>(),

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -28,13 +28,34 @@ static LOGGED_PIN: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static OPEN_SETTINGS: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
+static PIN_NEEDED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
 static STATUS_ITEM: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 /// Call once before `open_island`. Safe to call again.
 pub fn install() {
     #[cfg(target_os = "macos")]
-    install_macos();
+    {
+        install_macos();
+        install_mouse_monitors();
+    }
+}
+
+/// Ask the pin backstop loop to restyle/pin island windows. Notification
+/// handlers also pin immediately on the main thread.
+pub fn request_pin() {
+    #[cfg(target_os = "macos")]
+    PIN_NEEDED.store(true, Ordering::Release);
+}
+
+pub fn take_pin_needed() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        return PIN_NEEDED.swap(false, Ordering::AcqRel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
 }
 
 #[cfg(target_os = "macos")]
@@ -774,7 +795,16 @@ fn install_app_target() {
         }
         extern "C" fn screen_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
             nook_core::notch::invalidate_screen_cache();
+            request_pin();
             pin_island_windows();
+        }
+        extern "C" fn space_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            nook_core::notch::invalidate_screen_cache();
+            request_pin();
+            pin_island_windows();
+        }
+        extern "C" fn app_activated(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            nook_core::occupancy::invalidate();
         }
 
         let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
@@ -790,8 +820,16 @@ fn install_app_target() {
         let imp_screen: Imp = std::mem::transmute(
             screen_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
         );
+        let imp_space: Imp = std::mem::transmute(
+            space_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
+        let imp_app: Imp = std::mem::transmute(
+            app_activated as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
         let _ = class_addMethod(cls, sel!(openSettings:), imp_settings, types.as_ptr());
         let _ = class_addMethod(cls, sel!(screenChanged:), imp_screen, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(spaceChanged:), imp_space, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(appActivated:), imp_app, types.as_ptr());
         objc_registerClassPair(cls);
         observe_screen_changes();
     }
@@ -821,6 +859,78 @@ unsafe fn observe_screen_changes() {
         name: name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
+
+    let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+    if workspace.is_null() {
+        return;
+    }
+    let wsnc: *mut AnyObject = msg_send![workspace, notificationCenter];
+    if wsnc.is_null() {
+        return;
+    }
+    let space_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceActiveSpaceDidChangeNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(spaceChanged:),
+        name: space_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let app_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceDidActivateApplicationNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(appActivated:),
+        name: app_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+}
+
+/// NSEvent global + local monitors for mouse moved / left-drag / left-up.
+/// Main thread only. Handlers write the same atomics as the 250 ms backstop
+/// poll in `nook_core::mouse`. Local handler must return the event.
+pub fn install_mouse_monitors() {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use block2::RcBlock;
+        use objc2::runtime::AnyObject;
+        use objc2::*;
+
+        static INSTALLED: Once = Once::new();
+        INSTALLED.call_once(|| {
+            // MouseMoved | LeftMouseDragged | LeftMouseUp
+            const MASK: u64 = (1 << 5) | (1 << 6) | (1 << 2);
+
+            let global = RcBlock::new(move |_event: *mut AnyObject| {
+                nook_core::mouse::sample_now();
+            });
+            let g: *mut AnyObject = msg_send![
+                class!(NSEvent),
+                addGlobalMonitorForEventsMatchingMask: MASK,
+                handler: &*global
+            ];
+            std::mem::forget(global);
+            let _ = g;
+
+            let local = RcBlock::new(move |event: *mut AnyObject| -> *mut AnyObject {
+                nook_core::mouse::sample_now();
+                event
+            });
+            let l: *mut AnyObject = msg_send![
+                class!(NSEvent),
+                addLocalMonitorForEventsMatchingMask: MASK,
+                handler: &*local
+            ];
+            std::mem::forget(local);
+            let _ = l;
+        });
+    }
 }
 
 /// Hand files to the system AirDrop picker (`NSSharingServiceNameSendViaAirDrop`).


### PR DESCRIPTION
## WP10 — Time-synced lyrics

Opt-in, line-level lyrics beside the expanded Now Playing card. Fetched at runtime from [LRCLIB](https://lrclib.net); never bundled.

**Base:** `cursor/wp01-media-stream-mouse-a6ea` (MediaRemote `stream --diff`). This PR vs `main` therefore also includes WP01.

### What landed
- New `nook-core` `lyrics` module: LRC parser (sorted lines + binary-search active line), LRCLIB client (`User-Agent` / `Lrclib-Client`), SQLite cache (positive forever, negative 7-day TTL)
- `show_lyrics` setting (default **off**, copyright-safe opt-in) on the Music widget in Settings
- Expanded media pane: 3-line highlight window next to artwork when lyrics exist; instrumental / miss hides the pane
- Event-driven next-line timer (one-shot, disarmed when paused / collapsed / hidden). Interpolates elapsed from the last now-playing snapshot — **no new poll loop**
- Compact current-line marquee left off (handoff: optional, default off)

### Tests
`cargo test -p nook -p nook-core` — **82 + 107 passed** (LRC parse, active line, delay-until-next, highlight window, interpolated position).

### Notes
- Network: one HTTPS GET per new track, only when the toggle is on
- Sync accuracy is line-level (adapter `elapsedTimeNow`); not word-level karaoke
- No new TCC / entitlements