### PR TITLE
WP25: Apple Clock timer sync (read + Shortcuts + notification mirror)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1383,6 +1383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3818,6 +3824,8 @@ dependencies = [
  "log",
  "nook-core",
  "objc2",
+ "objc2-foundation",
+ "objc2-user-notifications",
  "pulldown-cmark",
  "raw-window-handle",
  "rust-embed",
@@ -3833,11 +3841,13 @@ dependencies = [
  "dirs 6.0.0",
  "futures-executor",
  "futures-util",
+ "libc",
  "log",
  "objc2",
  "objc2-event-kit",
  "objc2-foundation",
  "open",
+ "plist",
  "reqwest",
  "rusqlite",
  "security-framework",
@@ -3952,6 +3962,12 @@ dependencies = [
  "bytemuck",
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -4192,6 +4208,19 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation",
  "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "objc2",
+ "objc2-core-location",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -4507,6 +4536,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,6 +4634,12 @@ checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -6380,6 +6428,36 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Info.plist
+++ b/Info.plist
@@ -30,5 +30,7 @@
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
+	<key>NSUserNotificationsUsageDescription</key>
+	<string>openNook mirrors island timers into Notification Center so a countdown still fires if the overlay is hidden.</string>
 </dict>
 </plist>

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -17,10 +17,12 @@ reqwest.workspace = true
 futures-util.workspace = true
 open.workspace = true
 sysinfo = "0.37"
+plist = "1"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
 objc2-foundation = "0.3"
+libc = "0.2"
 objc2-event-kit = { version = "0.3", features = ["EKEventStore", "EKEvent", "EKReminder", "EKCalendar"] }
 block2 = "0.6"
 security-framework = "3.7"

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -19,6 +19,8 @@ pub mod notes;
 pub mod observe;
 pub mod occupancy;
 pub mod settings;
+pub mod shortcuts;
+pub mod system_timers;
 pub mod utils;
 pub mod widgets;
 
@@ -63,5 +65,6 @@ pub fn init() {
         audio::init_audio_state();
         audio::setup_audio_monitoring();
         mouse::start_polling();
+        system_timers::start_watcher();
     });
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -142,6 +142,9 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    /// Mirror Apple Clock timers in the Timers widget (plist / vnode watch).
+    #[serde(default = "default_true")]
+    pub sync_clock_timers: bool,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -231,6 +234,7 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            sync_clock_timers: true,
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -611,6 +615,7 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.sync_clock_timers);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);

--- a/crates/nook-core/src/shortcuts.rs
+++ b/crates/nook-core/src/shortcuts.rs
@@ -6,6 +6,7 @@
 //! the island runs them with `/usr/bin/shortcuts`.
 
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
 use std::process::Command;
 use std::sync::{Mutex, OnceLock};
 

--- a/crates/nook-core/src/shortcuts.rs
+++ b/crates/nook-core/src/shortcuts.rs
@@ -1,0 +1,279 @@
+//! Shortcuts CLI wrappers for Clock.app App Intents.
+//!
+//! Direct `MTTimerManager` XPC needs `com.apple.private.mobiletimerd` (blocked
+//! for a dev-signed app). Clock ships Pause / Resume / Cancel / Start Timer
+//! intents; the user imports the bundled `Nook * Timer` shortcuts once, then
+//! the island runs them with `/usr/bin/shortcuts`.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+pub const NAME_START: &str = "Nook Start Timer";
+pub const NAME_PAUSE: &str = "Nook Pause Timer";
+pub const NAME_RESUME: &str = "Nook Resume Timer";
+pub const NAME_CANCEL: &str = "Nook Cancel Timer";
+
+pub const CLOCK_BUNDLE: &str = "com.apple.clock";
+pub const CLOCK_URL: &str = "x-apple-clock:";
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ClockShortcuts {
+    pub start: bool,
+    pub pause: bool,
+    pub resume: bool,
+    pub cancel: bool,
+}
+
+impl ClockShortcuts {
+    pub fn can_control(self) -> bool {
+        self.pause && self.resume && self.cancel
+    }
+
+    pub fn any(self) -> bool {
+        self.start || self.pause || self.resume || self.cancel
+    }
+}
+
+pub fn shortcut_names() -> [&'static str; 4] {
+    [NAME_START, NAME_PAUSE, NAME_RESUME, NAME_CANCEL]
+}
+
+/// Parse `shortcuts list` stdout (one name per line).
+pub fn parse_shortcut_list(stdout: &str) -> ClockShortcuts {
+    let mut found = ClockShortcuts::default();
+    for line in stdout.lines() {
+        match line.trim() {
+            NAME_START => found.start = true,
+            NAME_PAUSE => found.pause = true,
+            NAME_RESUME => found.resume = true,
+            NAME_CANCEL => found.cancel = true,
+            _ => {}
+        }
+    }
+    found
+}
+
+fn cache() -> &'static Mutex<Option<ClockShortcuts>> {
+    static CACHE: OnceLock<Mutex<Option<ClockShortcuts>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(None))
+}
+
+/// Cached `shortcuts list`. Call [`refresh_shortcuts`] after import.
+pub fn cached_shortcuts() -> ClockShortcuts {
+    if let Ok(guard) = cache().lock() {
+        if let Some(found) = *guard {
+            return found;
+        }
+    }
+    refresh_shortcuts()
+}
+
+pub fn refresh_shortcuts() -> ClockShortcuts {
+    let found = list_clock_shortcuts();
+    if let Ok(mut guard) = cache().lock() {
+        *guard = Some(found);
+    }
+    found
+}
+
+pub fn list_clock_shortcuts() -> ClockShortcuts {
+    #[cfg(not(target_os = "macos"))]
+    {
+        return ClockShortcuts::default();
+    }
+    #[cfg(target_os = "macos")]
+    {
+        match Command::new("/usr/bin/shortcuts").arg("list").output() {
+            Ok(out) if out.status.success() => {
+                parse_shortcut_list(&String::from_utf8_lossy(&out.stdout))
+            }
+            Ok(out) => {
+                log::debug!(
+                    "shortcuts list exited {}: {}",
+                    out.status,
+                    String::from_utf8_lossy(&out.stderr)
+                );
+                ClockShortcuts::default()
+            }
+            Err(err) => {
+                log::debug!("shortcuts list: {err}");
+                ClockShortcuts::default()
+            }
+        }
+    }
+}
+
+pub fn run_shortcut(name: &str, input: Option<&str>) -> Result<String, String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (name, input);
+        return Err("Shortcuts CLI is only available on macOS".into());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut cmd = Command::new("/usr/bin/shortcuts");
+        cmd.arg("run").arg(name);
+        if let Some(input) = input {
+            cmd.arg("-i").arg(input);
+        }
+        let out = cmd.output().map_err(|err| err.to_string())?;
+        if !out.status.success() {
+            let err = String::from_utf8_lossy(&out.stderr);
+            return Err(if err.trim().is_empty() {
+                format!("shortcuts run {name} failed")
+            } else {
+                err.trim().to_string()
+            });
+        }
+        Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    }
+}
+
+fn spawn_shortcut(name: &'static str, input: Option<String>) {
+    crate::runtime().spawn(async move {
+        match run_shortcut(name, input.as_deref()) {
+            Ok(_) => log::debug!("ran shortcut {name}"),
+            Err(err) => log::info!("shortcut {name}: {err}"),
+        }
+    });
+}
+
+/// Pause the current Clock timer, or open Clock if the shortcut is missing.
+pub fn pause_timer() {
+    dispatch(NAME_PAUSE);
+}
+
+pub fn resume_timer() {
+    dispatch(NAME_RESUME);
+}
+
+pub fn cancel_timer() {
+    dispatch(NAME_CANCEL);
+}
+
+pub fn start_timer(seconds: u32) {
+    if cached_shortcuts().start {
+        spawn_shortcut(NAME_START, Some(seconds.to_string()));
+    } else {
+        open_clock();
+    }
+}
+
+fn dispatch(name: &'static str) {
+    let found = cached_shortcuts();
+    let present = match name {
+        NAME_PAUSE => found.pause,
+        NAME_RESUME => found.resume,
+        NAME_CANCEL => found.cancel,
+        NAME_START => found.start,
+        _ => false,
+    };
+    if present {
+        spawn_shortcut(name, None);
+    } else {
+        open_clock();
+    }
+}
+
+pub fn open_timer(id: &str) {
+    let url = format!("{}{id}", crate::system_timers::CLOCK_TIMER_SCHEME);
+    let _ = open_url(&url);
+}
+
+pub fn open_clock() {
+    if open_url(CLOCK_URL).is_err() {
+        let _ = open::that_detached(CLOCK_BUNDLE);
+    }
+}
+
+fn open_url(url: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("/usr/bin/open")
+            .arg(url)
+            .spawn()
+            .map(|_| ())
+            .map_err(|err| err.to_string())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        open::that_detached(url).map_err(|err| err.to_string())
+    }
+}
+
+/// Directory of bundled `.shortcut` files (app Resources, then repo checkout).
+pub fn bundled_shortcut_dir() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(macos) = exe.parent() {
+            let resources = macos.join("../Resources/shortcuts");
+            if resources.is_dir() {
+                return resources.canonicalize().ok();
+            }
+        }
+    }
+    let repo = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../resources/shortcuts");
+    if repo.is_dir() {
+        return repo.canonicalize().ok();
+    }
+    None
+}
+
+/// Open bundled shortcut files so Shortcuts.app can import them.
+pub fn import_bundled_shortcuts() -> Result<(), String> {
+    let Some(dir) = bundled_shortcut_dir() else {
+        open_clock();
+        return Err("Clock shortcuts are not bundled in this build".into());
+    };
+    let mut opened = 0u32;
+    if let Ok(entries) = std::fs::read_dir(&dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("shortcut") {
+                if open::that_detached(&path).is_ok() {
+                    opened += 1;
+                }
+            }
+        }
+    }
+    if opened == 0 {
+        let _ = open::that_detached(&dir);
+    }
+    // Re-read after a beat so the next tap sees a fresh `shortcuts list`.
+    crate::runtime().spawn(async {
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let _ = refresh_shortcuts();
+    });
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_shortcut_list_detects_nook_clock_names() {
+        let list = "All Photos\nNook Pause Timer\nNook Resume Timer\nWeather\nNook Cancel Timer\n";
+        let found = parse_shortcut_list(list);
+        assert!(found.can_control());
+        assert!(!found.start);
+        assert!(found.pause && found.resume && found.cancel);
+        assert!(found.any());
+    }
+
+    #[test]
+    fn parse_shortcut_list_empty_is_read_only() {
+        let found = parse_shortcut_list("Morning Routine\n");
+        assert!(!found.can_control());
+        assert!(!found.any());
+        assert_eq!(found, ClockShortcuts::default());
+    }
+
+    #[test]
+    fn parse_shortcut_list_start_only() {
+        let found = parse_shortcut_list("Nook Start Timer\n");
+        assert!(found.start);
+        assert!(!found.can_control());
+        assert_eq!(shortcut_names()[0], NAME_START);
+    }
+}

--- a/crates/nook-core/src/system_timers.rs
+++ b/crates/nook-core/src/system_timers.rs
@@ -1,0 +1,1024 @@
+//! Apple Clock (`mobiletimerd`) timer reader and vnode change stream.
+//!
+//! Primary store: CFPreferences domain `com.apple.mobiletimerd`
+//! (`~/Library/Preferences/com.apple.mobiletimerd.plist`). Fallback: the
+//! group-container Core Data sqlite. Change detection is a kqueue vnode
+//! watch on those two files — no polling.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::sync::watch;
+
+/// Seconds between the Apple reference date (2001-01-01 UTC) and the Unix epoch.
+pub const APPLE_EPOCH: f64 = 978_307_200.0;
+
+pub const PREFS_DOMAIN: &str = "com.apple.mobiletimerd";
+pub const PREFS_KEY_TIMERS: &str = "MTTimers";
+
+/// Clock App Intents deep-link scheme (Clock.app PrivateURLSchemes).
+pub const CLOCK_TIMER_SCHEME: &str = "x-apple-clock:timer?id=";
+
+/// Calibrated against MobileTimer.framework `MTTimerState` (iOS / macOS).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[repr(i64)]
+pub enum MTTimerState {
+    #[default]
+    Invalid = 0,
+    Stopped = 1,
+    Running = 2,
+    Paused = 3,
+    Fired = 4,
+    Dismissed = 5,
+}
+
+impl MTTimerState {
+    pub fn from_raw(value: i64) -> Self {
+        match value {
+            1 => Self::Stopped,
+            2 => Self::Running,
+            3 => Self::Paused,
+            4 => Self::Fired,
+            5 => Self::Dismissed,
+            _ => Self::Invalid,
+        }
+    }
+
+    pub fn is_active(self) -> bool {
+        matches!(self, Self::Running | Self::Paused | Self::Fired)
+    }
+
+    pub fn is_running(self) -> bool {
+        matches!(self, Self::Running)
+    }
+
+    pub fn is_counting(self) -> bool {
+        matches!(self, Self::Running | Self::Fired)
+    }
+}
+
+/// One Clock.app timer, as mirrored by mobiletimerd.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SystemTimer {
+    pub id: String,
+    pub title: String,
+    pub duration: f64,
+    pub state: MTTimerState,
+    /// Absolute Unix fire date while running.
+    pub fire_date: Option<f64>,
+    /// Remaining seconds while paused / stopped (from `MTTimerFireTime` interval).
+    pub remaining: Option<f64>,
+    pub deep_link: String,
+}
+
+impl SystemTimer {
+    pub fn remaining_secs(&self, now_unix: f64) -> u32 {
+        remaining_secs(
+            self.state,
+            self.fire_date,
+            self.remaining,
+            self.duration,
+            now_unix,
+        )
+    }
+
+    pub fn total_secs(&self) -> u32 {
+        self.duration.max(0.0).ceil() as u32
+    }
+}
+
+/// Remaining seconds from the stored fire date / interval. Pure; used by tests.
+pub fn remaining_secs(
+    state: MTTimerState,
+    fire_date: Option<f64>,
+    remaining: Option<f64>,
+    duration: f64,
+    now_unix: f64,
+) -> u32 {
+    match state {
+        MTTimerState::Running => fire_date
+            .map(|fire| (fire - now_unix).max(0.0).ceil() as u32)
+            .or_else(|| remaining.map(|r| r.max(0.0).ceil() as u32))
+            .unwrap_or(0),
+        MTTimerState::Paused | MTTimerState::Stopped => remaining
+            .map(|r| r.max(0.0).ceil() as u32)
+            .unwrap_or_else(|| duration.max(0.0).ceil() as u32),
+        MTTimerState::Fired => 0,
+        MTTimerState::Dismissed | MTTimerState::Invalid => 0,
+    }
+}
+
+pub fn unix_now() -> f64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0)
+}
+
+pub fn apple_to_unix(apple: f64) -> f64 {
+    apple + APPLE_EPOCH
+}
+
+pub fn unix_to_apple(unix: f64) -> f64 {
+    unix - APPLE_EPOCH
+}
+
+fn channel() -> &'static watch::Sender<Vec<SystemTimer>> {
+    static TX: OnceLock<watch::Sender<Vec<SystemTimer>>> = OnceLock::new();
+    TX.get_or_init(|| {
+        let (tx, _) = watch::channel(Vec::new());
+        tx
+    })
+}
+
+/// Subscribe to Clock timer snapshots. The sender is process-global; the
+/// vnode watcher publishes here and the island consumes `changed()`.
+pub fn subscribe() -> watch::Receiver<Vec<SystemTimer>> {
+    channel().subscribe()
+}
+
+pub fn current() -> Vec<SystemTimer> {
+    channel().borrow().clone()
+}
+
+/// Publish `timers` if they differ from the last snapshot.
+pub fn publish(timers: Vec<SystemTimer>) {
+    let tx = channel();
+    if *tx.borrow() != timers {
+        let _ = tx.send(timers);
+    }
+}
+
+/// Start the vnode watcher once. Safe to call from [`crate::init`].
+pub fn start_watcher() {
+    static STARTED: OnceLock<()> = OnceLock::new();
+    STARTED.get_or_init(|| {
+        publish(read_system_timers());
+        #[cfg(target_os = "macos")]
+        macos::spawn_vnode_watch();
+    });
+}
+
+/// Read Clock timers: CFPreferences/plist first, group-container sqlite second.
+pub fn read_system_timers() -> Vec<SystemTimer> {
+    let from_plist = read_plist_timers();
+    if !from_plist.is_empty() {
+        return collapse_timers(from_plist);
+    }
+    collapse_timers(read_sqlite_timers())
+}
+
+fn read_plist_timers() -> Vec<SystemTimer> {
+    #[cfg(target_os = "macos")]
+    macos::synchronize_prefs();
+    let Some(path) = prefs_plist_path() else {
+        return Vec::new();
+    };
+    match plist::Value::from_file(&path) {
+        Ok(value) => parse_mt_timers(&value),
+        Err(err) => {
+            if path.exists() {
+                log::debug!("mobiletimerd plist unreadable ({err})");
+            }
+            Vec::new()
+        }
+    }
+}
+
+fn read_sqlite_timers() -> Vec<SystemTimer> {
+    let Some(path) = sqlite_path() else {
+        return Vec::new();
+    };
+    if !path.exists() {
+        return Vec::new();
+    }
+    read_sqlite_file(&path)
+}
+
+pub fn prefs_plist_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join("Library/Preferences")
+            .join(format!("{PREFS_DOMAIN}.plist"))
+    })
+}
+
+pub fn sqlite_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| {
+        home.join("Library/Group Containers/group.com.apple.mobiletimerd/local.sqlite")
+    })
+}
+
+pub fn sqlite_wal_path() -> Option<PathBuf> {
+    sqlite_path().map(|p| {
+        let mut wal = p.into_os_string();
+        wal.push("-wal");
+        PathBuf::from(wal)
+    })
+}
+
+/// Parse an `MTTimers` array (or a domain dict that contains one).
+pub fn parse_mt_timers(value: &plist::Value) -> Vec<SystemTimer> {
+    match value {
+        plist::Value::Array(items) => items.iter().filter_map(parse_mt_timer).collect(),
+        plist::Value::Dictionary(dict) => {
+            if let Some(timers) = dict.get(PREFS_KEY_TIMERS) {
+                return parse_mt_timers(timers);
+            }
+            if let Some(data) = dict.get(PREFS_KEY_TIMERS).and_then(plist::Value::as_data) {
+                if let Some(decoded) = decode_keyed_archive(data) {
+                    return parse_mt_timers(&decoded);
+                }
+            }
+            // A single timer dict, or an NSKeyedArchiver envelope.
+            if dict.contains_key("$archiver") {
+                if let Some(root) = resolve_keyed_root(dict) {
+                    return parse_mt_timers(&root);
+                }
+            }
+            if dict.contains_key("MTTimerID") || dict.contains_key("MTTimerState") {
+                return parse_mt_timer(value).into_iter().collect();
+            }
+            Vec::new()
+        }
+        plist::Value::Data(bytes) => decode_keyed_archive(bytes)
+            .map(|inner| parse_mt_timers(&inner))
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn parse_mt_timer(value: &plist::Value) -> Option<SystemTimer> {
+    let dict = value.as_dictionary()?;
+    let id = dict_string(dict, "MTTimerID")
+        .or_else(|| dict_string(dict, "timerID"))
+        .filter(|s| !s.is_empty())?;
+    let title = dict_string(dict, "MTTimerTitle")
+        .or_else(|| dict_string(dict, "title"))
+        .unwrap_or_default();
+    let duration = dict_f64(dict, "MTTimerDuration")
+        .or_else(|| dict_f64(dict, "duration"))
+        .unwrap_or(0.0);
+    let state = MTTimerState::from_raw(
+        dict_i64(dict, "MTTimerState")
+            .or_else(|| dict_i64(dict, "state"))
+            .unwrap_or(0),
+    );
+    let dismissed = dict.get("MTTimerDismissedDate").and_then(plist_date_unix);
+    if dismissed.is_some() && !state.is_active() {
+        return None;
+    }
+    let fire = decode_fire_time(
+        dict.get("MTTimerFireTime")
+            .or_else(|| dict.get("MTTimerFireDate"))
+            .or_else(|| dict.get("fireTime")),
+    );
+    let fired = dict.get("MTTimerFiredDate").and_then(plist_date_unix);
+    let fire_date = match state {
+        MTTimerState::Running => fire.unix.or(fired),
+        MTTimerState::Fired => fired.or(fire.unix),
+        _ => fire.unix,
+    };
+    let remaining = match state {
+        MTTimerState::Running => None,
+        _ => fire.interval.or_else(|| {
+            fire_date.map(|fd| (fd - unix_now()).max(0.0)).or(Some(duration))
+        }),
+    };
+    Some(SystemTimer {
+        deep_link: format!("{CLOCK_TIMER_SCHEME}{id}"),
+        id,
+        title,
+        duration,
+        state,
+        fire_date,
+        remaining,
+    })
+}
+
+/// Decoded `MTTimerFireTime`: absolute Unix date and/or remaining interval.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct FireTime {
+    pub unix: Option<f64>,
+    pub interval: Option<f64>,
+}
+
+pub fn decode_fire_time(value: Option<&plist::Value>) -> FireTime {
+    let Some(value) = value else {
+        return FireTime::default();
+    };
+    match value {
+        plist::Value::Date(date) => FireTime {
+            unix: plist_date_unix(value).or_else(|| Some(system_time_unix(date.to_owned().into()))),
+            interval: None,
+        },
+        plist::Value::Real(n) => classify_number(*n),
+        plist::Value::Integer(n) => n.as_signed().map(|i| classify_number(i as f64)).unwrap_or_default(),
+        plist::Value::Data(bytes) => decode_keyed_archive(bytes)
+            .map(|inner| decode_fire_time(Some(&inner)))
+            .unwrap_or_default(),
+        plist::Value::Dictionary(dict) => decode_fire_dict(dict),
+        _ => FireTime::default(),
+    }
+}
+
+fn decode_fire_dict(dict: &plist::Dictionary) -> FireTime {
+    if dict.contains_key("$archiver") {
+        if let Some(root) = resolve_keyed_root(dict) {
+            return decode_fire_time(Some(&root));
+        }
+    }
+    if let Some(time) = dict_f64(dict, "NS.time") {
+        return FireTime {
+            unix: Some(apple_to_unix(time)),
+            interval: None,
+        };
+    }
+    for key in [
+        "MTTimerTimeInterval",
+        "timeInterval",
+        "interval",
+        "remaining",
+        "NS.number",
+        "seconds",
+        "value",
+    ] {
+        if let Some(n) = dict_f64(dict, key) {
+            return classify_number(n);
+        }
+    }
+    if let Some(class) = keyed_class_name(dict) {
+        if class.contains("Interval") {
+            if let Some(n) = dict.values().find_map(value_f64) {
+                return FireTime {
+                    unix: None,
+                    interval: Some(n.max(0.0)),
+                };
+            }
+        }
+        if class.contains("Date") {
+            if let Some(n) = dict.values().find_map(value_f64) {
+                return classify_number(n);
+            }
+        }
+    }
+    FireTime::default()
+}
+
+/// A raw number is an interval when it looks like a countdown, otherwise a date.
+pub fn classify_number(n: f64) -> FireTime {
+    if !n.is_finite() || n == 0.0 {
+        return FireTime::default();
+    }
+    // Remaining / duration: Clock timers are hours, not years.
+    if (0.0..86_400.0 * 7.0).contains(&n) {
+        return FireTime {
+            unix: None,
+            interval: Some(n),
+        };
+    }
+    // NSDate `NS.time` (Apple reference) after ~2004 sits around 1e8+.
+    if (1.0e8..1.0e10).contains(&n) && n < APPLE_EPOCH {
+        return FireTime {
+            unix: Some(apple_to_unix(n)),
+            interval: None,
+        };
+    }
+    if n > 1.0e12 {
+        return FireTime {
+            unix: Some(n / 1000.0),
+            interval: None,
+        };
+    }
+    if n > 1.0e9 {
+        return FireTime {
+            unix: Some(n),
+            interval: None,
+        };
+    }
+    FireTime {
+        unix: None,
+        interval: Some(n.max(0.0)),
+    }
+}
+
+fn decode_keyed_archive(bytes: &[u8]) -> Option<plist::Value> {
+    let value = plist::Value::from_reader(std::io::Cursor::new(bytes)).ok()?;
+    match &value {
+        plist::Value::Dictionary(dict) if dict.contains_key("$archiver") => resolve_keyed_root(dict),
+        _ => Some(value),
+    }
+}
+
+fn resolve_keyed_root(dict: &plist::Dictionary) -> Option<plist::Value> {
+    let objects = dict.get("$objects")?.as_array()?;
+    let top = dict.get("$top")?.as_dictionary()?;
+    let uid = top
+        .get("root")
+        .or_else(|| top.get("NS.objects"))
+        .or_else(|| top.values().next())?;
+    resolve_uid(objects, uid)
+}
+
+fn resolve_uid(objects: &[plist::Value], value: &plist::Value) -> Option<plist::Value> {
+    let idx = match value {
+        plist::Value::Uid(uid) => uid.get() as usize,
+        plist::Value::Integer(i) => i.as_unsigned()? as usize,
+        other => return Some(other.clone()),
+    };
+    objects.get(idx).cloned()
+}
+
+fn keyed_class_name(dict: &plist::Dictionary) -> Option<String> {
+    dict.get("$classname")
+        .and_then(plist::Value::as_string)
+        .map(|s| s.to_string())
+        .or_else(|| {
+            dict.get("$classes")
+                .and_then(plist::Value::as_array)
+                .and_then(|a| a.first())
+                .and_then(plist::Value::as_string)
+                .map(|s| s.to_string())
+        })
+}
+
+fn dict_string(dict: &plist::Dictionary, key: &str) -> Option<String> {
+    dict.get(key).and_then(|v| match v {
+        plist::Value::String(s) => Some(s.clone()),
+        plist::Value::Data(bytes) => String::from_utf8(bytes.clone()).ok(),
+        _ => None,
+    })
+}
+
+fn dict_f64(dict: &plist::Dictionary, key: &str) -> Option<f64> {
+    dict.get(key).and_then(value_f64)
+}
+
+fn dict_i64(dict: &plist::Dictionary, key: &str) -> Option<i64> {
+    dict.get(key).and_then(|v| match v {
+        plist::Value::Integer(i) => i.as_signed(),
+        plist::Value::Real(n) => Some(*n as i64),
+        plist::Value::String(s) => s.parse().ok(),
+        _ => None,
+    })
+}
+
+fn value_f64(value: &plist::Value) -> Option<f64> {
+    match value {
+        plist::Value::Real(n) => Some(*n),
+        plist::Value::Integer(i) => i.as_signed().map(|n| n as f64),
+        plist::Value::String(s) => s.parse().ok(),
+        plist::Value::Date(_) => plist_date_unix(value),
+        _ => None,
+    }
+}
+
+fn plist_date_unix(value: &plist::Value) -> Option<f64> {
+    match value {
+        plist::Value::Date(date) => Some(system_time_unix((*date).into())),
+        _ => None,
+    }
+}
+
+fn system_time_unix(time: SystemTime) -> f64 {
+    time.duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .or_else(|_| {
+            UNIX_EPOCH
+                .duration_since(time)
+                .map(|d| -(d.as_secs_f64()))
+        })
+        .unwrap_or(0.0)
+}
+
+/// mobiletimerd hoards every timer ever created. Keep one row per id, preferring
+/// the live state (running > paused > fired > rest).
+pub fn collapse_timers(timers: Vec<SystemTimer>) -> Vec<SystemTimer> {
+    let mut best: HashMap<String, SystemTimer> = HashMap::new();
+    for timer in timers {
+        if timer.id.is_empty() || !timer.state.is_active() {
+            continue;
+        }
+        best.entry(timer.id.clone())
+            .and_modify(|existing| {
+                if state_rank(timer.state) >= state_rank(existing.state) {
+                    *existing = timer.clone();
+                }
+            })
+            .or_insert(timer);
+    }
+    let mut out: Vec<SystemTimer> = best.into_values().collect();
+    out.sort_by(|a, b| {
+        state_rank(b.state)
+            .cmp(&state_rank(a.state))
+            .then_with(|| a.fire_date.partial_cmp(&b.fire_date).unwrap_or(std::cmp::Ordering::Equal))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+    out
+}
+
+fn state_rank(state: MTTimerState) -> u8 {
+    match state {
+        MTTimerState::Running => 4,
+        MTTimerState::Paused => 3,
+        MTTimerState::Fired => 2,
+        MTTimerState::Stopped => 1,
+        _ => 0,
+    }
+}
+
+fn read_sqlite_file(path: &Path) -> Vec<SystemTimer> {
+    let uri = format!("file:{}?mode=ro", path.display());
+    let conn = match rusqlite::Connection::open_with_flags(
+        &uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    ) {
+        Ok(conn) => conn,
+        Err(err) => {
+            log::debug!("mobiletimerd sqlite skipped ({err})");
+            return Vec::new();
+        }
+    };
+    let columns = sqlite_columns(&conn);
+    if columns.is_empty() {
+        return Vec::new();
+    }
+    let sql = format!(
+        "SELECT {} FROM ZMTCDTIMER",
+        columns.join(", ")
+    );
+    let mut stmt = match conn.prepare(&sql) {
+        Ok(stmt) => stmt,
+        Err(err) => {
+            log::debug!("mobiletimerd sqlite query skipped ({err})");
+            return Vec::new();
+        }
+    };
+    let names: Vec<String> = stmt.column_names().into_iter().map(|s| s.to_string()).collect();
+    let mut rows = match stmt.query([]) {
+        Ok(rows) => rows,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    while let Ok(Some(row)) = rows.next() {
+        if let Some(timer) = timer_from_sqlite_row(row, &names) {
+            out.push(timer);
+        }
+    }
+    out
+}
+
+fn sqlite_columns(conn: &rusqlite::Connection) -> Vec<&'static str> {
+    let info = conn.prepare("PRAGMA table_info(ZMTCDTIMER)");
+    let Ok(mut stmt) = info else {
+        return Vec::new();
+    };
+    let rows = stmt.query_map([], |row| row.get::<_, String>(1));
+    let Ok(rows) = rows else {
+        return Vec::new();
+    };
+    let present: Vec<String> = rows.filter_map(|r| r.ok()).collect();
+    const CANDIDATES: &[&str] = &[
+        "ZTIMERURL",
+        "ZTITLE",
+        "ZDURATION",
+        "ZSTATE",
+        "ZFIREDDATE",
+        "ZDISMISSEDDATE",
+        "ZFIRETIME",
+        "ZTIMERID",
+        "ZUUID",
+    ];
+    CANDIDATES
+        .iter()
+        .copied()
+        .filter(|name| present.iter().any(|p| p.eq_ignore_ascii_case(name)))
+        .collect()
+}
+
+fn timer_from_sqlite_row(row: &rusqlite::Row<'_>, names: &[String]) -> Option<SystemTimer> {
+    let get_str = |name: &str| -> Option<String> {
+        let idx = names.iter().position(|n| n.eq_ignore_ascii_case(name))?;
+        row.get::<_, Option<String>>(idx).ok().flatten()
+    };
+    let get_f64 = |name: &str| -> Option<f64> {
+        let idx = names.iter().position(|n| n.eq_ignore_ascii_case(name))?;
+        row.get::<_, Option<f64>>(idx)
+            .ok()
+            .flatten()
+            .or_else(|| row.get::<_, Option<i64>>(idx).ok().flatten().map(|n| n as f64))
+    };
+    let get_i64 = |name: &str| -> Option<i64> {
+        let idx = names.iter().position(|n| n.eq_ignore_ascii_case(name))?;
+        row.get::<_, Option<i64>>(idx)
+            .ok()
+            .flatten()
+            .or_else(|| row.get::<_, Option<f64>>(idx).ok().flatten().map(|n| n as i64))
+    };
+    let get_blob = |name: &str| -> Option<Vec<u8>> {
+        let idx = names.iter().position(|n| n.eq_ignore_ascii_case(name))?;
+        row.get::<_, Option<Vec<u8>>>(idx).ok().flatten()
+    };
+
+    let url = get_str("ZTIMERURL").unwrap_or_default();
+    let id = url_timer_id(&url)
+        .or_else(|| get_str("ZTIMERID"))
+        .or_else(|| get_str("ZUUID"))
+        .filter(|s| !s.is_empty())?;
+    let state = MTTimerState::from_raw(get_i64("ZSTATE").unwrap_or(0));
+    if get_f64("ZDISMISSEDDATE").is_some() && !state.is_active() {
+        return None;
+    }
+    let duration = get_f64("ZDURATION").unwrap_or(0.0);
+    let fire = get_blob("ZFIRETIME")
+        .and_then(|bytes| Some(decode_fire_time(Some(&plist::Value::Data(bytes)))))
+        .unwrap_or_default();
+    let fired = get_f64("ZFIREDDATE").map(normalize_store_date);
+    let fire_date = match state {
+        MTTimerState::Running => fire.unix.or(fired),
+        MTTimerState::Fired => fired.or(fire.unix),
+        _ => fire.unix,
+    };
+    Some(SystemTimer {
+        title: get_str("ZTITLE").unwrap_or_default(),
+        duration,
+        state,
+        fire_date,
+        remaining: match state {
+            MTTimerState::Running => None,
+            _ => fire.interval,
+        },
+        deep_link: if url.starts_with("x-apple-clock:") {
+            url
+        } else {
+            format!("{CLOCK_TIMER_SCHEME}{id}")
+        },
+        id,
+    })
+}
+
+fn url_timer_id(url: &str) -> Option<String> {
+    let idx = url.find("id=")?;
+    let rest = &url[idx + 3..];
+    let end = rest.find('&').unwrap_or(rest.len());
+    let id = rest[..end].trim();
+    (!id.is_empty()).then(|| id.to_string())
+}
+
+fn normalize_store_date(n: f64) -> f64 {
+    if n > 1.0e12 {
+        n / 1000.0
+    } else if n < APPLE_EPOCH && n > 1.0e7 {
+        apple_to_unix(n)
+    } else {
+        n
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::fd::RawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::io::AsRawFd;
+    use std::thread;
+    use std::time::Duration;
+
+    pub fn synchronize_prefs() {
+        unsafe {
+            let name = CFStringCreateWithCString(
+                std::ptr::null(),
+                c"com.apple.mobiletimerd".as_ptr(),
+                kCFStringEncodingUTF8,
+            );
+            if !name.is_null() {
+                let _ = CFPreferencesAppSynchronize(name);
+                CFRelease(name);
+            }
+        }
+    }
+
+    pub fn spawn_vnode_watch() {
+        thread::Builder::new()
+            .name("nook-clock-timers".into())
+            .spawn(watch_loop)
+            .ok();
+    }
+
+    fn watch_loop() {
+        let kq = unsafe { libc::kqueue() };
+        if kq < 0 {
+            log::warn!("kqueue for Clock timers failed");
+            return;
+        }
+        let mut watched: Vec<Watched> = Vec::new();
+        loop {
+            refresh_watches(kq, &mut watched);
+            let mut ev = libc::kevent {
+                ident: 0,
+                filter: 0,
+                flags: 0,
+                fflags: 0,
+                data: 0,
+                udata: std::ptr::null_mut(),
+            };
+            let timeout = libc::timespec {
+                tv_sec: 30,
+                tv_nsec: 0,
+            };
+            let n = unsafe { libc::kevent(kq, std::ptr::null(), 0, &mut ev, 1, &timeout) };
+            if n < 0 {
+                thread::sleep(Duration::from_millis(250));
+                continue;
+            }
+            if n > 0 {
+                // cfprefsd writes via rename; give the new file a moment.
+                thread::sleep(Duration::from_millis(40));
+                refresh_watches(kq, &mut watched);
+            }
+            publish(read_system_timers());
+        }
+    }
+
+    struct Watched {
+        path: PathBuf,
+        file: Option<std::fs::File>,
+        #[allow(dead_code)]
+        ident: usize,
+    }
+
+    impl Drop for Watched {
+        fn drop(&mut self) {
+            self.file.take();
+        }
+    }
+
+    fn watch_targets() -> Vec<PathBuf> {
+        let mut paths = Vec::new();
+        if let Some(plist) = prefs_plist_path() {
+            if let Some(parent) = plist.parent() {
+                paths.push(parent.to_path_buf());
+            }
+            paths.push(plist);
+        }
+        if let Some(db) = sqlite_path() {
+            paths.push(db);
+        }
+        if let Some(wal) = sqlite_wal_path() {
+            paths.push(wal);
+        }
+        paths
+    }
+
+    fn refresh_watches(kq: RawFd, watched: &mut Vec<Watched>) {
+        let targets = watch_targets();
+        watched.retain(|w| targets.iter().any(|p| p == &w.path));
+        for path in targets {
+            if watched.iter().any(|w| w.path == path) {
+                // Re-open if the vnode vanished (atomic rename).
+                if let Some(slot) = watched.iter_mut().find(|w| w.path == path) {
+                    if slot.file.is_none() || !path.exists() {
+                        if let Some(next) = open_watch(kq, &path) {
+                            *slot = next;
+                        }
+                    }
+                }
+                continue;
+            }
+            if let Some(item) = open_watch(kq, &path) {
+                watched.push(item);
+            }
+        }
+    }
+
+    fn open_watch(kq: RawFd, path: &Path) -> Option<Watched> {
+        if !path.exists() {
+            return None;
+        }
+        let file = std::fs::File::open(path).ok()?;
+        let fd = file.as_raw_fd();
+        let flags = (libc::NOTE_DELETE
+            | libc::NOTE_WRITE
+            | libc::NOTE_EXTEND
+            | libc::NOTE_RENAME
+            | libc::NOTE_REVOKE
+            | libc::NOTE_ATTRIB) as u32;
+        let ev = libc::kevent {
+            ident: fd as usize,
+            filter: libc::EVFILT_VNODE,
+            flags: (libc::EV_ADD | libc::EV_ENABLE | libc::EV_CLEAR) as u16,
+            fflags: flags,
+            data: 0,
+            udata: std::ptr::null_mut(),
+        };
+        let rc = unsafe { libc::kevent(kq, &ev, 1, std::ptr::null_mut(), 0, std::ptr::null()) };
+        if rc < 0 {
+            // Directory may not accept every NOTE_*; still keep the fd if add failed
+            // only because the file disappeared mid-open.
+            log::debug!("vnode watch add failed for {}", path.display());
+        }
+        let _ = CString::new(path.as_os_str().as_bytes());
+        Some(Watched {
+            path: path.to_path_buf(),
+            file: Some(file),
+            ident: fd as usize, // kqueue ident; kept so the File outlives the watch
+        })
+    }
+
+    const kCFStringEncodingUTF8: u32 = 0x0800_0100;
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFPreferencesAppSynchronize(applicationID: *const std::ffi::c_void) -> u8;
+        fn CFStringCreateWithCString(
+            alloc: *const std::ffi::c_void,
+            cStr: *const i8,
+            encoding: u32,
+        ) -> *mut std::ffi::c_void;
+        fn CFRelease(cf: *const std::ffi::c_void);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn timer(
+        id: &str,
+        state: MTTimerState,
+        duration: f64,
+        fire_date: Option<f64>,
+        remaining: Option<f64>,
+    ) -> SystemTimer {
+        SystemTimer {
+            id: id.into(),
+            title: id.into(),
+            duration,
+            state,
+            fire_date,
+            remaining,
+            deep_link: format!("{CLOCK_TIMER_SCHEME}{id}"),
+        }
+    }
+
+    #[test]
+    fn mt_timer_state_maps_mobiletimer_enum() {
+        assert_eq!(MTTimerState::from_raw(0), MTTimerState::Invalid);
+        assert_eq!(MTTimerState::from_raw(1), MTTimerState::Stopped);
+        assert_eq!(MTTimerState::from_raw(2), MTTimerState::Running);
+        assert_eq!(MTTimerState::from_raw(3), MTTimerState::Paused);
+        assert_eq!(MTTimerState::from_raw(4), MTTimerState::Fired);
+        assert_eq!(MTTimerState::from_raw(5), MTTimerState::Dismissed);
+        assert_eq!(MTTimerState::from_raw(99), MTTimerState::Invalid);
+        assert!(MTTimerState::Running.is_active());
+        assert!(MTTimerState::Paused.is_active());
+        assert!(MTTimerState::Fired.is_active());
+        assert!(!MTTimerState::Stopped.is_active());
+        assert!(!MTTimerState::Dismissed.is_active());
+        assert!(MTTimerState::Running.is_running());
+        assert!(MTTimerState::Running.is_counting());
+        assert!(!MTTimerState::Paused.is_counting());
+    }
+
+    #[test]
+    fn remaining_from_absolute_fire_date() {
+        let now = 1_700_000_000.0;
+        assert_eq!(
+            remaining_secs(MTTimerState::Running, Some(now + 90.2), None, 300.0, now),
+            91
+        );
+        assert_eq!(
+            remaining_secs(MTTimerState::Running, Some(now - 5.0), None, 300.0, now),
+            0
+        );
+        assert_eq!(
+            remaining_secs(MTTimerState::Fired, Some(now - 1.0), None, 300.0, now),
+            0
+        );
+    }
+
+    #[test]
+    fn remaining_from_paused_interval() {
+        let now = 1_700_000_000.0;
+        assert_eq!(
+            remaining_secs(MTTimerState::Paused, None, Some(45.1), 300.0, now),
+            46
+        );
+        assert_eq!(
+            remaining_secs(MTTimerState::Stopped, None, None, 120.4, now),
+            121
+        );
+        assert_eq!(
+            remaining_secs(MTTimerState::Dismissed, None, Some(10.0), 300.0, now),
+            0
+        );
+    }
+
+    #[test]
+    fn apple_epoch_round_trip() {
+        let unix = 1_700_000_000.0;
+        assert!((apple_to_unix(unix_to_apple(unix)) - unix).abs() < f64::EPSILON);
+        assert!((apple_to_unix(0.0) - APPLE_EPOCH).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn classify_number_splits_interval_and_date() {
+        let interval = classify_number(300.0);
+        assert_eq!(interval.interval, Some(300.0));
+        assert!(interval.unix.is_none());
+
+        let apple = classify_number(700_000_000.0);
+        assert!(apple.unix.is_some());
+        assert!((apple.unix.unwrap() - apple_to_unix(700_000_000.0)).abs() < 0.001);
+
+        let unix = classify_number(1_700_000_000.0);
+        assert_eq!(unix.unix, Some(1_700_000_000.0));
+    }
+
+    #[test]
+    fn decode_ns_time_fire_date() {
+        let mut dict = plist::Dictionary::new();
+        dict.insert("NS.time".into(), plist::Value::Real(700_000_000.0));
+        let fire = decode_fire_time(Some(&plist::Value::Dictionary(dict)));
+        assert!((fire.unix.unwrap() - apple_to_unix(700_000_000.0)).abs() < 0.001);
+    }
+
+    #[test]
+    fn decode_interval_keyed_object() {
+        let mut dict = plist::Dictionary::new();
+        dict.insert("$classname".into(), plist::Value::String("MTTimerTimeInterval".into()));
+        dict.insert("timeInterval".into(), plist::Value::Real(90.0));
+        let fire = decode_fire_time(Some(&plist::Value::Dictionary(dict)));
+        assert_eq!(fire.interval, Some(90.0));
+    }
+
+    #[test]
+    fn parse_mt_timers_array_and_filter_dismissed() {
+        let xml = r#"
+        <dict>
+            <key>MTTimers</key>
+            <array>
+                <dict>
+                    <key>MTTimerID</key><string>AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA</string>
+                    <key>MTTimerTitle</key><string>Pasta</string>
+                    <key>MTTimerDuration</key><real>600</real>
+                    <key>MTTimerState</key><integer>2</integer>
+                    <key>MTTimerFireTime</key><real>1700000120</real>
+                </dict>
+                <dict>
+                    <key>MTTimerID</key><string>BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB</string>
+                    <key>MTTimerTitle</key><string>Old</string>
+                    <key>MTTimerDuration</key><real>60</real>
+                    <key>MTTimerState</key><integer>5</integer>
+                    <key>MTTimerDismissedDate</key><real>1700000000</real>
+                </dict>
+                <dict>
+                    <key>MTTimerID</key><string>CCCCCCCC-CCCC-CCCC-CCCC-CCCCCCCCCCCC</string>
+                    <key>MTTimerTitle</key><string>Hold</string>
+                    <key>MTTimerDuration</key><real>120</real>
+                    <key>MTTimerState</key><integer>3</integer>
+                    <key>MTTimerFireTime</key><real>44</real>
+                </dict>
+            </array>
+        </dict>
+        "#;
+        let value = plist::Value::from_reader_xml(std::io::Cursor::new(xml)).unwrap();
+        let parsed = collapse_timers(parse_mt_timers(&value));
+        assert_eq!(parsed.len(), 2);
+        let pasta = parsed.iter().find(|t| t.title == "Pasta").unwrap();
+        assert_eq!(pasta.state, MTTimerState::Running);
+        assert_eq!(pasta.fire_date, Some(1_700_000_120.0));
+        assert_eq!(
+            pasta.deep_link,
+            "x-apple-clock:timer?id=AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA"
+        );
+        assert_eq!(pasta.remaining_secs(1_700_000_000.0), 120);
+        let hold = parsed.iter().find(|t| t.title == "Hold").unwrap();
+        assert_eq!(hold.state, MTTimerState::Paused);
+        assert_eq!(hold.remaining_secs(1_700_000_000.0), 44);
+    }
+
+    #[test]
+    fn collapse_prefers_running_duplicate() {
+        let timers = vec![
+            timer("same", MTTimerState::Dismissed, 60.0, None, None),
+            timer("same", MTTimerState::Paused, 60.0, None, Some(10.0)),
+            timer("same", MTTimerState::Running, 60.0, Some(9_999.0), None),
+        ];
+        let out = collapse_timers(timers);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].state, MTTimerState::Running);
+        assert_eq!(out[0].fire_date, Some(9_999.0));
+    }
+
+    #[test]
+    fn url_timer_id_extracts_uuid() {
+        assert_eq!(
+            url_timer_id("x-apple-clock:timer?id=ABC-123&x=1").as_deref(),
+            Some("ABC-123")
+        );
+        assert!(url_timer_id("clock-timer://").is_none());
+    }
+}

--- a/crates/nook/Cargo.toml
+++ b/crates/nook/Cargo.toml
@@ -25,4 +25,13 @@ pulldown-cmark.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = "0.6"
+objc2-foundation = "0.3"
+objc2-user-notifications = { version = "0.3", features = [
+    "UNUserNotificationCenter",
+    "UNNotificationRequest",
+    "UNNotificationContent",
+    "UNNotificationTrigger",
+    "UNNotificationSound",
+    "block2",
+] }
 block2 = "0.6"

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -143,7 +143,7 @@ impl Island {
                     &mut kids,
                     cell_pane(
                         self.settings.cells_for(module),
-                        timer_card(&self.timers, self.timer_composer, cx),
+                        timer_card(self, cx),
                     ),
                 ),
                 WidgetModule::Notes if self.settings.show_notes => add(

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -493,7 +493,6 @@ impl Island {
                             dirty = true;
                         }
                     }
-                    }
                     let levels = nook_core::audio::get_audio_levels();
                     if this.now_playing.audio_levels.as_deref() != Some(levels.as_slice()) {
                         this.now_playing.audio_levels = Some(levels);

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -27,6 +27,7 @@ use nook_core::models::NowPlayingData;
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
+use nook_core::system_timers::{self, SystemTimer};
 use settings::SettingsView;
 use std::time::{Duration, Instant};
 
@@ -47,6 +48,14 @@ pub enum Tab {
     Files,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) enum ClockTimerAction {
+    Pause,
+    Resume,
+    Cancel,
+    Open(String),
+}
+
 #[derive(Clone)]
 pub struct Timer {
     pub id: u64,
@@ -55,6 +64,22 @@ pub struct Timer {
     pub remaining: u32,
     pub total: u32,
     pub running: bool,
+}
+
+/// Compact-face view of a local island timer or a Clock.app timer.
+#[derive(Clone, Debug)]
+pub struct FaceTimer {
+    pub remaining: u32,
+    pub total: u32,
+    pub running: bool,
+    pub name: String,
+    pub source: FaceTimerSource,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum FaceTimerSource {
+    Local(u64),
+    Clock(String),
 }
 
 pub struct Island {
@@ -78,6 +103,7 @@ pub struct Island {
     pub(crate) notes_editing: bool,
     notes_sub: Option<Subscription>,
     pub timers: Vec<Timer>,
+    pub system_timers: Vec<SystemTimer>,
     pub next_timer_id: u64,
     /// Index into the 7-day week strip (today − 3 … today + 3). 3 is today.
     pub calendar_day: u8,
@@ -207,6 +233,7 @@ impl Island {
             notes_editing: false,
             notes_sub: None,
             timers: Vec::new(),
+            system_timers: Vec::new(),
             next_timer_id: 1,
             calendar_day: 3,
             timer_composer: false,
@@ -454,6 +481,7 @@ impl Island {
                                 dirty = true;
                                 if t.remaining == 0 {
                                     t.running = false;
+                                    crate::notify::cancel_island_timer(t.id);
                                     nook_core::haptics::trigger(Some(nook_core::haptics::HapticConfig {
                                         pattern: nook_core::haptics::HapticPattern::Success,
                                         intensity: 1.0,
@@ -461,6 +489,10 @@ impl Island {
                                 }
                             }
                         }
+                        if this.clock_timer_visible() {
+                            dirty = true;
+                        }
+                    }
                     }
                     let levels = nook_core::audio::get_audio_levels();
                     if this.now_playing.audio_levels.as_deref() != Some(levels.as_slice()) {
@@ -690,6 +722,50 @@ impl Island {
                 .await;
         })
         .detach();
+
+        cx.spawn(async move |this, cx| {
+            let mut rx = system_timers::subscribe();
+            loop {
+                let timers = rx.borrow().clone();
+                if this
+                    .update(cx, |this, cx| {
+                        if this.system_timers == timers {
+                            return;
+                        }
+                        let was_running = this
+                            .system_timers
+                            .iter()
+                            .any(|t| t.state.is_running());
+                        let now_running = timers.iter().any(|t| t.state.is_running());
+                        let now_fired = timers.iter().any(|t| t.state == system_timers::MTTimerState::Fired);
+                        let was_fired = this
+                            .system_timers
+                            .iter()
+                            .any(|t| t.state == system_timers::MTTimerState::Fired);
+                        this.system_timers = timers;
+                        if this.settings.show_timers && this.settings.sync_clock_timers {
+                            if !was_running && now_running {
+                                this.preferred = Some(CompactMode::Timer);
+                            }
+                            if !was_fired && now_fired {
+                                nook_core::haptics::trigger(Some(nook_core::haptics::HapticConfig {
+                                    pattern: nook_core::haptics::HapticPattern::Success,
+                                    intensity: 1.0,
+                                }));
+                            }
+                        }
+                        cx.notify();
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+                if rx.changed().await.is_err() {
+                    break;
+                }
+            }
+        })
+        .detach();
     }
 
     /// Merge a fresh poll into the island: extend the local sample history and
@@ -737,26 +813,118 @@ impl Island {
         self.timers.iter().find(|t| t.running)
     }
 
-    /// Compact face: a finished timer first so the ring turns red, else running, else first.
-    pub(crate) fn face_timer(&self) -> Option<&Timer> {
-        self.timers
+    fn clock_timers(&self) -> impl Iterator<Item = &SystemTimer> {
+        self.system_timers.iter().filter(|t| t.state.is_active())
+    }
+
+    fn clock_timer_visible(&self) -> bool {
+        self.settings.show_timers
+            && self.settings.sync_clock_timers
+            && self.clock_timers().any(|t| t.state.is_counting())
+    }
+
+    fn has_live_timer(&self) -> bool {
+        self.running_timer().is_some()
+            || (self.settings.sync_clock_timers
+                && self.clock_timers().any(|t| t.state.is_running() || t.state.is_counting()))
+    }
+
+    fn clock_face(timer: &SystemTimer, now: f64) -> FaceTimer {
+        FaceTimer {
+            remaining: timer.remaining_secs(now),
+            total: timer.total_secs().max(1),
+            running: timer.state.is_running(),
+            name: if timer.title.is_empty() {
+                "Clock".into()
+            } else {
+                timer.title.clone()
+            },
+            source: FaceTimerSource::Clock(timer.id.clone()),
+        }
+    }
+
+    fn local_face(timer: &Timer) -> FaceTimer {
+        FaceTimer {
+            remaining: timer.remaining,
+            total: timer.total.max(1),
+            running: timer.running,
+            name: timer.name.clone(),
+            source: FaceTimerSource::Local(timer.id),
+        }
+    }
+
+    /// Compact face: a finished timer first so the ring turns red, else the
+    /// soonest running countdown (island or Clock), else the first local.
+    pub(crate) fn face_timer(&self) -> Option<FaceTimer> {
+        if !self.settings.show_timers {
+            return None;
+        }
+        let now = system_timers::unix_now();
+        let mut faces: Vec<FaceTimer> = self.timers.iter().map(Self::local_face).collect();
+        if self.settings.sync_clock_timers {
+            faces.extend(self.clock_timers().map(|t| Self::clock_face(t, now)));
+        }
+        faces
             .iter()
             .find(|t| t.remaining == 0 && t.total > 0)
-            .or_else(|| self.running_timer())
-            .or_else(|| self.timers.first())
+            .cloned()
+            .or_else(|| {
+                faces
+                    .iter()
+                    .filter(|t| t.running)
+                    .min_by_key(|t| t.remaining)
+                    .cloned()
+            })
+            .or_else(|| faces.into_iter().next())
+    }
+
+    pub(crate) fn toggle_face_timer(&mut self) {
+        match self.face_timer().map(|t| t.source) {
+            Some(FaceTimerSource::Local(id)) => self.toggle_local_timer(id),
+            Some(FaceTimerSource::Clock(_)) => {
+                if self.clock_timers().any(|t| t.state.is_running()) {
+                    nook_core::shortcuts::pause_timer();
+                } else {
+                    nook_core::shortcuts::resume_timer();
+                }
+            }
+            None => {}
+        }
+    }
+
+    pub(crate) fn toggle_local_timer(&mut self, id: u64) {
+        if let Some(t) = self.timers.iter_mut().find(|t| t.id == id) {
+            t.running = !t.running;
+            if t.running && t.remaining > 0 {
+                crate::notify::schedule_island_timer(t.id, t.remaining, &t.name);
+            } else {
+                crate::notify::cancel_island_timer(t.id);
+            }
+        }
     }
 
     pub(crate) fn reset_timer(&mut self, id: u64) {
         if let Some(t) = self.timers.iter_mut().find(|t| t.id == id) {
             t.remaining = t.total;
             t.running = false;
+            crate::notify::cancel_island_timer(t.id);
         }
     }
 
     pub(crate) fn remove_timer(&mut self, id: u64) {
+        crate::notify::cancel_island_timer(id);
         self.timers.retain(|t| t.id != id);
         if self.timers.is_empty() {
             self.timer_composer = false;
+        }
+    }
+
+    pub(crate) fn control_clock_timer(&self, action: ClockTimerAction) {
+        match action {
+            ClockTimerAction::Pause => nook_core::shortcuts::pause_timer(),
+            ClockTimerAction::Resume => nook_core::shortcuts::resume_timer(),
+            ClockTimerAction::Cancel => nook_core::shortcuts::cancel_timer(),
+            ClockTimerAction::Open(id) => nook_core::shortcuts::open_timer(&id),
         }
     }
 
@@ -871,7 +1039,7 @@ impl Island {
         if self.has_agents() {
             modes.push(CompactMode::Agents);
         }
-        if self.settings.show_timers && self.running_timer().is_some() {
+        if self.settings.show_timers && self.has_live_timer() {
             modes.push(CompactMode::Timer);
         }
         if self.settings.show_files && !self.files.is_empty() {
@@ -1325,8 +1493,9 @@ impl Island {
     }
 
     pub(crate) fn add_timer(&mut self, seconds: u32) {
+        let id = self.next_timer_id;
         self.timers.push(Timer {
-            id: self.next_timer_id,
+            id,
             name: String::new(),
             remaining: seconds,
             total: seconds,
@@ -1335,6 +1504,7 @@ impl Island {
         self.next_timer_id += 1;
         self.timer_composer = false;
         self.preferred = Some(CompactMode::Timer);
+        crate::notify::schedule_island_timer(id, seconds, "");
     }
 
     pub(crate) fn arm_file_drag(&mut self, path: String) {
@@ -1446,6 +1616,7 @@ mod tests {
             notes_editing: false,
             notes_sub: None,
             timers: Vec::new(),
+            system_timers: Vec::new(),
             next_timer_id: 1,
             calendar_day: 3,
             timer_composer: false,
@@ -1673,6 +1844,54 @@ mod tests {
         island.settings.show_files = false;
         island.settings.show_timers = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn face_timer_lets_a_running_clock_timer_take_the_compact_face() {
+        let mut island = test_island();
+        island.settings.sync_clock_timers = true;
+        island.system_timers.push(nook_core::system_timers::SystemTimer {
+            id: "clock-1".into(),
+            title: "Pasta".into(),
+            duration: 600.0,
+            state: nook_core::system_timers::MTTimerState::Running,
+            fire_date: Some(nook_core::system_timers::unix_now() + 120.0),
+            remaining: None,
+            deep_link: "x-apple-clock:timer?id=clock-1".into(),
+        });
+        assert!(island.available_modes().contains(&CompactMode::Timer));
+        let face = island.face_timer().expect("clock timer on the face");
+        assert!(matches!(face.source, FaceTimerSource::Clock(_)));
+        assert!(face.running);
+        assert!(face.remaining <= 120);
+        assert_eq!(face.name, "Pasta");
+        island.settings.sync_clock_timers = false;
+        assert!(island.face_timer().is_none());
+        assert!(!island.available_modes().contains(&CompactMode::Timer));
+    }
+
+    #[test]
+    fn face_timer_prefers_a_finished_local_timer_over_a_running_clock() {
+        let mut island = test_island();
+        island.timers.push(Timer {
+            id: 1,
+            name: "Local".into(),
+            remaining: 0,
+            total: 60,
+            running: false,
+        });
+        island.system_timers.push(nook_core::system_timers::SystemTimer {
+            id: "clock-1".into(),
+            title: "Pasta".into(),
+            duration: 600.0,
+            state: nook_core::system_timers::MTTimerState::Running,
+            fire_date: Some(nook_core::system_timers::unix_now() + 30.0),
+            remaining: None,
+            deep_link: "x-apple-clock:timer?id=clock-1".into(),
+        });
+        let face = island.face_timer().expect("finished local wins");
+        assert!(matches!(face.source, FaceTimerSource::Local(1)));
+        assert_eq!(face.remaining, 0);
     }
 
     #[test]

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -156,7 +156,13 @@ impl WidgetModuleExt for WidgetModule {
             Self::Files => "Tray tab".into(),
             Self::Notes => "Scratchpad".into(),
             Self::Observe => observe_subtitle(settings.observe.metrics.len()),
-            Self::Timers => "Countdown".into(),
+            Self::Timers => {
+                if settings.sync_clock_timers {
+                    "Island + Clock".into()
+                } else {
+                    "Countdown".into()
+                }
+            }
             Self::Reminders => "EventKit".into(),
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
@@ -998,6 +1004,31 @@ impl SettingsView {
                     .into_any_element(),
                 );
             }
+            WidgetModule::Timers => {
+                rows.push(
+                    toggle_row(
+                        "Apple Clock timers",
+                        settings.sync_clock_timers,
+                        cx,
+                        |s| s.sync_clock_timers = !s.sync_clock_timers,
+                    )
+                    .into_any_element(),
+                );
+                rows.push(
+                    action_row(
+                        "clock-shortcuts",
+                        "Clock shortcuts",
+                        "Install…",
+                        cx,
+                        |_, _, _| {
+                            if let Err(err) = nook_core::shortcuts::import_bundled_shortcuts() {
+                                log::info!("clock shortcuts: {err}");
+                            }
+                        },
+                    )
+                    .into_any_element(),
+                );
+            }
             _ => {}
         }
 
@@ -1349,7 +1380,9 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Now Playing from MediaRemote on macOS, with an AppleScript fallback.".into()
         }
         WidgetModule::Files => "Drop zone and tray live on the Tray tab of the expanded island.".into(),
-        WidgetModule::Timers => "Countdown presets and a compact ring while a timer is running.".into(),
+        WidgetModule::Timers => {
+            "Island countdowns plus Apple Clock timers (read from mobiletimerd). Import the bundled Nook Clock shortcuts once to pause, resume, or cancel from the island.".into()
+        }
         WidgetModule::Reminders => "Incomplete reminders from EventKit, same store as Calendar.".into(),
         WidgetModule::Speed => "Cloudflare (then OVH) download probe. Runs from the island card.".into(),
         WidgetModule::Agents => {
@@ -1701,6 +1734,20 @@ mod tests {
         assert_eq!(
             WidgetModule::Calendar.subtitle(&settings).as_ref(),
             "7 days"
+        );
+    }
+
+    #[test]
+    fn timers_subtitle_mentions_clock_when_sync_is_on() {
+        let mut settings = AppSettings::default();
+        assert_eq!(
+            WidgetModule::Timers.subtitle(&settings).as_ref(),
+            "Island + Clock"
+        );
+        settings.sync_clock_timers = false;
+        assert_eq!(
+            WidgetModule::Timers.subtitle(&settings).as_ref(),
+            "Countdown"
         );
     }
 

--- a/crates/nook/src/main.rs
+++ b/crates/nook/src/main.rs
@@ -2,6 +2,7 @@ mod dotmatrix;
 mod icons;
 mod island;
 mod motion;
+mod notify;
 mod platform;
 mod theme;
 mod widgets;

--- a/crates/nook/src/notify.rs
+++ b/crates/nook/src/notify.rs
@@ -1,0 +1,119 @@
+//! Mirror island-local timers into Notification Center.
+//!
+//! `UNUserNotificationCenter` + `UNTimeIntervalNotificationTrigger`: usernoted
+//! delivers the alert even if the overlay is occluded or the process exits.
+
+pub fn request_authorization() {
+    #[cfg(target_os = "macos")]
+    macos::request_authorization();
+}
+
+pub fn schedule_island_timer(id: u64, remaining: u32, title: &str) {
+    if remaining == 0 {
+        cancel_island_timer(id);
+        return;
+    }
+    request_authorization();
+    #[cfg(target_os = "macos")]
+    macos::schedule(id, remaining, title);
+    #[cfg(not(target_os = "macos"))]
+    let _ = title;
+}
+
+pub fn cancel_island_timer(id: u64) {
+    #[cfg(target_os = "macos")]
+    macos::cancel(id);
+}
+
+pub fn identifier(id: u64) -> String {
+    format!("nook.island.timer.{id}")
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::identifier;
+    use block2::RcBlock;
+    use objc2_foundation::{NSArray, NSError, NSString};
+    use objc2_user_notifications::{
+        UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
+        UNNotificationSound, UNTimeIntervalNotificationTrigger, UNUserNotificationCenter,
+    };
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    static ASKED: AtomicBool = AtomicBool::new(false);
+
+    pub fn request_authorization() {
+        if ASKED.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let center = UNUserNotificationCenter::currentNotificationCenter();
+        let options = UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound;
+        let handler = RcBlock::new(move |granted: bool, error: *mut NSError| {
+            if !error.is_null() {
+                let err = unsafe { &*error };
+                log::debug!("notification auth error: {err:?}");
+            } else {
+                log::debug!("notification auth granted={granted}");
+            }
+        });
+        unsafe {
+            center.requestAuthorizationWithOptions_completionHandler(options, &handler);
+        }
+    }
+
+    pub fn schedule(id: u64, remaining: u32, title: &str) {
+        let ident = identifier(id);
+        cancel(id);
+        let center = UNUserNotificationCenter::currentNotificationCenter();
+        let content = UNMutableNotificationContent::new();
+        let heading = if title.trim().is_empty() {
+            "Timer".to_string()
+        } else {
+            title.to_string()
+        };
+        unsafe {
+            content.setTitle(&NSString::from_str(&heading));
+            content.setBody(&NSString::from_str("Time is up"));
+            content.setSound(Some(&UNNotificationSound::defaultSound()));
+        }
+        let trigger = unsafe {
+            UNTimeIntervalNotificationTrigger::triggerWithTimeInterval_repeats(
+                remaining.max(1) as f64,
+                false,
+            )
+        };
+        let request = UNNotificationRequest::requestWithIdentifier_content_trigger(
+            &NSString::from_str(&ident),
+            &content,
+            Some(&trigger),
+        );
+        let handler = RcBlock::new(move |error: *mut NSError| {
+            if !error.is_null() {
+                let err = unsafe { &*error };
+                log::debug!("schedule timer notification: {err:?}");
+            }
+        });
+        unsafe {
+            center.addNotificationRequest_withCompletionHandler(&request, Some(&handler));
+        }
+    }
+
+    pub fn cancel(id: u64) {
+        let ident = identifier(id);
+        let center = UNUserNotificationCenter::currentNotificationCenter();
+        let ids = NSArray::from_slice(&[NSString::from_str(&ident).as_ref()]);
+        center.removePendingNotificationRequestsWithIdentifiers(&ids);
+        center.removeDeliveredNotificationsWithIdentifiers(&ids);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identifier_is_stable_per_timer() {
+        assert_eq!(identifier(3), "nook.island.timer.3");
+        assert_ne!(identifier(1), identifier(2));
+    }
+}

--- a/crates/nook/src/notify.rs
+++ b/crates/nook/src/notify.rs
@@ -33,6 +33,7 @@ pub fn identifier(id: u64) -> String {
 mod macos {
     use super::identifier;
     use block2::RcBlock;
+    use objc2::runtime::Bool;
     use objc2_foundation::{NSArray, NSError, NSString};
     use objc2_user_notifications::{
         UNAuthorizationOptions, UNMutableNotificationContent, UNNotificationRequest,
@@ -48,12 +49,12 @@ mod macos {
         }
         let center = UNUserNotificationCenter::currentNotificationCenter();
         let options = UNAuthorizationOptions::Alert | UNAuthorizationOptions::Sound;
-        let handler = RcBlock::new(move |granted: bool, error: *mut NSError| {
+        let handler = RcBlock::new(move |granted: Bool, error: *mut NSError| {
             if !error.is_null() {
                 let err = unsafe { &*error };
                 log::debug!("notification auth error: {err:?}");
             } else {
-                log::debug!("notification auth granted={granted}");
+                log::debug!("notification auth granted={}", granted.as_bool());
             }
         });
         unsafe {

--- a/crates/nook/src/widgets/timers.rs
+++ b/crates/nook/src/widgets/timers.rs
@@ -1,9 +1,10 @@
-//! Compact timer ring + expanded timers Nook pane.
+//! Compact timer ring + expanded timers Nook pane (island + Apple Clock).
 
 use crate::icons::{lucide, lucide_color};
 use crate::island::ui::{format_timer, nook_display, nook_empty, nook_icon_btn, nook_pane};
-use crate::island::{Island, Timer};
+use crate::island::{ClockTimerAction, Island, Timer};
 use crate::theme;
+use nook_core::system_timers::{self, MTTimerState, SystemTimer};
 use gpui::{
     canvas, div, point, prelude::*, px, rgb, rgba, AnyElement, Context, FontWeight, MouseButton,
     MouseDownEvent, PathBuilder, Rgba, SharedString,
@@ -26,7 +27,6 @@ pub(crate) fn compact_left(island: &Island, cx: &mut Context<Island>) -> AnyElem
     let total = timer.total.max(1);
     let progress = 1.0 - timer.remaining as f32 / total as f32;
     let done = timer.remaining == 0;
-    let id = timer.id;
     div()
         .id("timer-ring")
         .size(px(COMPACT_RING))
@@ -38,9 +38,7 @@ pub(crate) fn compact_left(island: &Island, cx: &mut Context<Island>) -> AnyElem
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                if let Some(t) = this.timers.iter_mut().find(|t| t.id == id) {
-                    t.running = !t.running;
-                }
+                this.toggle_face_timer();
                 cx.notify();
             }),
         )
@@ -105,23 +103,37 @@ pub(crate) fn timer_ring(
     .h(px(size))
 }
 
-pub(crate) fn timer_card(
-    timers: &[Timer],
-    _composer: bool,
-    cx: &mut Context<Island>,
-) -> impl IntoElement {
+pub(crate) fn timer_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let timers = &island.timers;
+    let clock: Vec<&SystemTimer> = if island.settings.sync_clock_timers {
+        island
+            .system_timers
+            .iter()
+            .filter(|t| t.state.is_active())
+            .collect()
+    } else {
+        Vec::new()
+    };
+
     let mut week = div().flex().items_end().gap(px(10.));
     for (id, unit, num, seconds) in PRESETS {
         week = week.child(preset_col(id, unit, num, seconds, cx));
     }
 
-    let remaining = timers.first().map(|t| format_timer(t.remaining));
-    let body = if timers.is_empty() {
+    let remaining = island
+        .face_timer()
+        .map(|t| format_timer(t.remaining))
+        .or_else(|| timers.first().map(|t| format_timer(t.remaining)));
+    let empty = timers.is_empty() && clock.is_empty();
+    let body = if empty {
         nook_empty("clock", "No timers").into_any_element()
     } else {
-        let mut col = div().flex().flex_col().flex_1().min_w(px(0.));
+        let mut col = div().flex().flex_col().flex_1().min_w(px(0.)).gap(px(8.));
         if let Some(first) = timers.first() {
             col = col.child(featured_timer(first, cx));
+        }
+        if !clock.is_empty() {
+            col = col.child(clock_section(&clock, cx));
         }
         col.into_any_element()
     };
@@ -138,6 +150,134 @@ pub(crate) fn timer_card(
                 .child(week),
         )
         .child(body)
+}
+
+fn clock_section(timers: &[&SystemTimer], cx: &mut Context<Island>) -> impl IntoElement {
+    let can_control = nook_core::shortcuts::cached_shortcuts().can_control();
+    let now = system_timers::unix_now();
+    let mut list = div().flex().flex_col().gap(px(4.));
+    list = list.child(
+        div()
+            .flex()
+            .items_center()
+            .gap(px(6.))
+            .child(
+                div()
+                    .px(px(5.))
+                    .py(px(1.))
+                    .rounded(px(4.))
+                    .bg(rgba(0xffffff18))
+                    .text_size(px(9.))
+                    .line_height(px(12.))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(theme::accent())
+                    .child("Clock"),
+            )
+            .child(
+                div()
+                    .text_size(px(11.))
+                    .text_color(theme::SECONDARY_LABEL)
+                    .child(if can_control {
+                        "Shortcuts"
+                    } else {
+                        "Open Clock to control"
+                    }),
+            ),
+    );
+    for timer in timers.iter().take(3) {
+        list = list.child(clock_row(timer, now, can_control, cx));
+    }
+    list
+}
+
+fn clock_row(
+    timer: &SystemTimer,
+    now: f64,
+    can_control: bool,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let id = timer.id.clone();
+    let running = timer.state.is_running();
+    let remaining = timer.remaining_secs(now);
+    let done = timer.state == MTTimerState::Fired || remaining == 0;
+    let title = if timer.title.is_empty() {
+        match timer.state {
+            MTTimerState::Running => "Running",
+            MTTimerState::Paused => "Paused",
+            MTTimerState::Fired => "Done",
+            _ => "Timer",
+        }
+        .to_string()
+    } else {
+        timer.title.clone()
+    };
+    let play_icon = if running { "pause-fill" } else { "play-fill" };
+    div()
+        .id(SharedString::from(format!("clock-timer-{id}")))
+        .flex()
+        .items_center()
+        .gap(px(8.))
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.))
+                .flex()
+                .flex_col()
+                .child(
+                    div()
+                        .text_size(px(13.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme::LABEL)
+                        .child(title),
+                )
+                .child(
+                    div()
+                        .text_size(px(12.))
+                        .text_color(if done {
+                            theme::DESTRUCTIVE
+                        } else {
+                            theme::SECONDARY_LABEL
+                        })
+                        .child(format_timer(remaining)),
+                ),
+        )
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(4.))
+                .child(nook_icon_btn(
+                    if can_control { play_icon } else { "clock" },
+                    format!("clock-toggle-{id}"),
+                    cx,
+                    {
+                        let id = id.clone();
+                        move |this, _, _, cx| {
+                            if can_control {
+                                this.control_clock_timer(if running {
+                                    ClockTimerAction::Pause
+                                } else {
+                                    ClockTimerAction::Resume
+                                });
+                            } else {
+                                this.control_clock_timer(ClockTimerAction::Open(id.clone()));
+                            }
+                            cx.notify();
+                        }
+                    },
+                ))
+                .when(can_control, |d| {
+                    d.child(nook_icon_btn(
+                        "x",
+                        format!("clock-cancel-{id}"),
+                        cx,
+                        move |this, _, _, cx| {
+                            this.control_clock_timer(ClockTimerAction::Cancel);
+                            cx.notify();
+                        },
+                    ))
+                }),
+        )
 }
 
 fn preset_col(
@@ -296,9 +436,7 @@ fn timer_face(
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                if let Some(t) = this.timers.iter_mut().find(|t| t.id == id) {
-                    t.running = !t.running;
-                }
+                this.toggle_local_timer(id);
                 cx.notify();
             }),
         )

--- a/resources/shortcuts/README.md
+++ b/resources/shortcuts/README.md
@@ -1,0 +1,17 @@
+# Nook Clock shortcuts
+
+Clock.app has no public write API for a dev-signed Mac app. Control goes through
+Shortcuts App Intents. Create four shortcuts with **exactly** these names, then
+tap **Install…** in Settings → Widgets → Timers (or open the `.shortcut` files
+in this folder after signing them on a Mac with `shortcuts sign`).
+
+| Name | Action |
+|------|--------|
+| `Nook Start Timer` | Start Timer (Clock). Optional text input: duration in seconds. |
+| `Nook Pause Timer` | Pause Timer |
+| `Nook Resume Timer` | Resume Timer |
+| `Nook Cancel Timer` | Cancel Timer |
+
+`shortcuts list` must show those names. Until they are imported, the island
+still **reads** Clock timers and the Clock section falls back to **Open Clock**
+(`x-apple-clock:timer?id=`).

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -45,6 +45,12 @@ else
   echo "warning: MediaRemote adapter not bundled; Now Playing will use AppleScript" >&2
 fi
 
+# Clock App Intent shortcuts (user imports once from Settings).
+if [[ -d "$ROOT/resources/shortcuts" ]]; then
+  mkdir -p "$APP/Contents/Resources/shortcuts"
+  cp -R "$ROOT/resources/shortcuts/." "$APP/Contents/Resources/shortcuts/"
+fi
+
 # Ad-hoc sign so the .app launches without "damaged" on this machine.
 # A Developer ID identity, if present, is used instead.
 if security find-identity -v -p codesigning 2>/dev/null | grep -q "Developer ID Application"; then


### PR DESCRIPTION
## WP25 — Apple Clock timer sync

Read Clock.app timers in the notch island, control them via imported Shortcuts, and mirror island-local countdowns into Notification Center.

### What landed
- **Read (event-driven):** `nook-core::system_timers` reads the `com.apple.mobiletimerd` CFPreferences plist (group-container sqlite fallback), maps `MTTimerState`, decodes `MTTimerFireTime`, and publishes snapshots from a kqueue vnode watch on the plist / sqlite-wal only — no new poll loop.
- **Control:** `nook-core::shortcuts` runs `Nook Pause/Resume/Cancel/Start Timer` via `/usr/bin/shortcuts`. Missing shortcuts degrade to Open Clock (`x-apple-clock:timer?id=`).
- **Notification mirror:** `nook::notify` schedules `UNTimeIntervalNotificationTrigger` on island timer start and cancels on pause/reset/finish.
- **UI:** Timers widget Clock section with badge + remaining from `fire_date`; compact face lets a running Clock timer compete. Settings → Widgets → Timers has **Apple Clock timers** (default on) and **Install…** for bundled shortcut import.

### Tests
`cargo test -p nook -p nook-core` green (Linux CI host).
- State mapping + remaining calc (running fire date, paused interval, fired = 0)
- Plist parse / dismissed filter / duplicate collapse
- Compact-face competition (Clock vs finished local)

### Honest blockers
- Direct `MTTimerManager` XPC needs `com.apple.private.mobiletimerd` — not possible for a dev-signed app.
- AlarmKit is Catalyst-only on macOS 26.
- Bundled `.shortcut` files cannot be `shortcuts sign`'d in this Linux environment; user creates/imports the four named shortcuts (see `resources/shortcuts/README.md`). Until then, control is read-only + Open Clock.
- `MTTimerState` / fire-time encoding calibrated from MobileTimer headers + synthetic plists, not a live Clock start/pause diff on this machine.
- Group-container sqlite may raise the macOS 15+ “access data from other apps” prompt; plist path is preferred and needs no TCC.
