### PR TITLE
WP02: Volume & brightness HUDs

### DIFF
--- a/crates/nook-core/src/brightness.rs
+++ b/crates/nook-core/src/brightness.rs
@@ -3,7 +3,7 @@
 //! External DDC/CI displays are out of scope. If the private symbols vanish
 //! on a future macOS, [`available`] stays false and the brightness HUD hides.
 
-use crate::sysvol::{self, HudKind};
+use crate::sysvol;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// True when get/set symbols resolved and the internal panel answered.
@@ -51,7 +51,7 @@ pub const CORE_SET_SYMBOL: &str = "CoreDisplay_Display_SetUserBrightness";
 #[cfg(target_os = "macos")]
 mod macos {
     use super::*;
-    use crate::sysvol::clamp_unit;
+    use crate::sysvol::{clamp_unit, HudKind};
     use std::ffi::{c_char, c_void, CString};
     use std::sync::Once;
 

--- a/crates/nook-core/src/brightness.rs
+++ b/crates/nook-core/src/brightness.rs
@@ -1,0 +1,236 @@
+//! Built-in panel brightness via private DisplayServices (dlopen / dlsym).
+//!
+//! External DDC/CI displays are out of scope. If the private symbols vanish
+//! on a future macOS, [`available`] stays false and the brightness HUD hides.
+
+use crate::sysvol::{self, HudKind};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// True when get/set symbols resolved and the internal panel answered.
+pub fn available() -> bool {
+    AVAILABLE.load(Ordering::Relaxed)
+}
+
+pub fn brightness() -> Option<f32> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::read()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+pub fn set_brightness(value: f32) {
+    let value = sysvol::clamp_unit(value);
+    #[cfg(target_os = "macos")]
+    macos::write(value);
+    let _ = value;
+}
+
+/// Probe private frameworks and subscribe to brightness-change notifications.
+pub fn start() {
+    #[cfg(target_os = "macos")]
+    macos::start();
+}
+
+static AVAILABLE: AtomicBool = AtomicBool::new(false);
+
+/// DisplayServices / CoreDisplay symbol names we probe at startup.
+pub const DISPLAY_SERVICES_PATH: &str =
+    "/System/Library/PrivateFrameworks/DisplayServices.framework/DisplayServices";
+pub const CORE_DISPLAY_PATH: &str = "/System/Library/Frameworks/CoreDisplay.framework/CoreDisplay";
+pub const GET_BRIGHTNESS_SYMBOL: &str = "DisplayServicesGetBrightness";
+pub const SET_BRIGHTNESS_SYMBOL: &str = "DisplayServicesSetBrightness";
+pub const REGISTER_BRIGHTNESS_SYMBOL: &str =
+    "DisplayServicesRegisterForBrightnessChangeNotifications";
+pub const CORE_GET_SYMBOL: &str = "CoreDisplay_Display_GetUserBrightness";
+pub const CORE_SET_SYMBOL: &str = "CoreDisplay_Display_SetUserBrightness";
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use crate::sysvol::clamp_unit;
+    use std::ffi::{c_char, c_void, CString};
+    use std::sync::Once;
+
+    const RTLD_LAZY: i32 = 1;
+    const OBSERVER_ID: u32 = 0x4e4f4b31; // "NOK1"
+
+    type GetBrightnessFn = unsafe extern "C" fn(u32, *mut f32) -> i32;
+    type SetBrightnessFn = unsafe extern "C" fn(u32, f32) -> i32;
+    type RegisterFn = unsafe extern "C" fn(u32, u32, BrightnessCallback) -> i32;
+    type BrightnessCallback =
+        unsafe extern "C" fn(*mut c_void, u32, *mut c_void, *const c_void, *const c_void);
+    type CoreGetFn = unsafe extern "C" fn(u32) -> f64;
+    type CoreSetFn = unsafe extern "C" fn(u32, f64);
+
+    struct Api {
+        get: Option<GetBrightnessFn>,
+        set: Option<SetBrightnessFn>,
+        register: Option<RegisterFn>,
+        core_get: Option<CoreGetFn>,
+        core_set: Option<CoreSetFn>,
+    }
+
+    static STARTED: Once = Once::new();
+    static API: std::sync::OnceLock<Api> = std::sync::OnceLock::new();
+
+    unsafe extern "C" {
+        fn dlopen(path: *const c_char, mode: i32) -> *mut c_void;
+        fn dlsym(handle: *mut c_void, symbol: *const c_char) -> *mut c_void;
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    unsafe extern "C" {
+        fn CGMainDisplayID() -> u32;
+    }
+
+    fn load_sym<T>(handle: *mut c_void, name: &str) -> Option<T> {
+        if handle.is_null() {
+            return None;
+        }
+        let c_name = CString::new(name).ok()?;
+        let ptr = unsafe { dlsym(handle, c_name.as_ptr()) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { std::mem::transmute_copy(&ptr) })
+        }
+    }
+
+    fn open(path: &str) -> *mut c_void {
+        let c_path = match CString::new(path) {
+            Ok(p) => p,
+            Err(_) => return std::ptr::null_mut(),
+        };
+        unsafe { dlopen(c_path.as_ptr(), RTLD_LAZY) }
+    }
+
+    fn probe() -> Api {
+        let ds = open(super::DISPLAY_SERVICES_PATH);
+        let cd = open(super::CORE_DISPLAY_PATH);
+        let api = Api {
+            get: load_sym(ds, super::GET_BRIGHTNESS_SYMBOL),
+            set: load_sym(ds, super::SET_BRIGHTNESS_SYMBOL),
+            register: load_sym(ds, super::REGISTER_BRIGHTNESS_SYMBOL),
+            core_get: load_sym(cd, super::CORE_GET_SYMBOL),
+            core_set: load_sym(cd, super::CORE_SET_SYMBOL),
+        };
+        if api.get.is_none() && api.core_get.is_none() {
+            log::warn!(
+                "DisplayServices/CoreDisplay brightness symbols missing; brightness HUD hidden"
+            );
+        }
+        api
+    }
+
+    fn api() -> &'static Api {
+        API.get_or_init(probe)
+    }
+
+    fn display_id() -> u32 {
+        unsafe { CGMainDisplayID() }
+    }
+
+    pub(super) fn read() -> Option<f32> {
+        let api = api();
+        let id = display_id();
+        if let Some(get) = api.get {
+            let mut value = 0.0f32;
+            let status = unsafe { get(id, &mut value) };
+            if status == 0 && value.is_finite() {
+                return Some(clamp_unit(value));
+            }
+        }
+        if let Some(get) = api.core_get {
+            let value = unsafe { get(id) } as f32;
+            if value.is_finite() {
+                return Some(clamp_unit(value));
+            }
+        }
+        None
+    }
+
+    pub(super) fn write(value: f32) {
+        let api = api();
+        let id = display_id();
+        let mut ok = false;
+        if let Some(set) = api.set {
+            ok = unsafe { set(id, value) } == 0;
+        }
+        if !ok {
+            if let Some(set) = api.core_set {
+                unsafe { set(id, value as f64) };
+            }
+        }
+    }
+
+    unsafe extern "C" fn on_brightness_changed(
+        _passthrough: *mut c_void,
+        _display: u32,
+        _name: *mut c_void,
+        _sender: *const c_void,
+        _info: *const c_void,
+    ) {
+        if let Some(value) = read() {
+            sysvol::publish(HudKind::Brightness, value);
+        }
+    }
+
+    pub(super) fn start() {
+        STARTED.call_once(|| {
+            let api = api();
+            match read() {
+                Some(_) => {
+                    AVAILABLE.store(true, Ordering::Relaxed);
+                    log::info!("brightness HUD available (DisplayServices/CoreDisplay)");
+                }
+                None => {
+                    AVAILABLE.store(false, Ordering::Relaxed);
+                    log::warn!("internal panel brightness unread; brightness HUD hidden");
+                    return;
+                }
+            }
+            if let Some(register) = api.register {
+                let status = unsafe { register(display_id(), OBSERVER_ID, on_brightness_changed) };
+                if status != 0 {
+                    log::warn!(
+                        "DisplayServicesRegisterForBrightnessChangeNotifications failed ({status}); brightness HUD will only update from the island slider"
+                    );
+                }
+            } else {
+                log::warn!("brightness-change notifications unavailable; no brightness HUD from the keys");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn private_symbol_names_match_monitorcontrol() {
+        assert!(DISPLAY_SERVICES_PATH.contains("DisplayServices.framework"));
+        assert_eq!(GET_BRIGHTNESS_SYMBOL, "DisplayServicesGetBrightness");
+        assert_eq!(SET_BRIGHTNESS_SYMBOL, "DisplayServicesSetBrightness");
+        assert_eq!(
+            REGISTER_BRIGHTNESS_SYMBOL,
+            "DisplayServicesRegisterForBrightnessChangeNotifications"
+        );
+        assert_eq!(CORE_GET_SYMBOL, "CoreDisplay_Display_GetUserBrightness");
+        assert_eq!(CORE_SET_SYMBOL, "CoreDisplay_Display_SetUserBrightness");
+    }
+
+    #[test]
+    fn setters_are_safe_off_macos() {
+        set_brightness(0.3);
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(!available());
+            assert_eq!(brightness(), None);
+        }
+    }
+}

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod agents;
 pub mod audio;
+pub mod brightness;
 pub mod browser_media;
 pub mod calendar;
 pub mod database;
@@ -18,7 +19,9 @@ pub mod notch;
 pub mod notes;
 pub mod observe;
 pub mod occupancy;
+pub mod osd;
 pub mod settings;
+pub mod sysvol;
 pub mod utils;
 pub mod widgets;
 
@@ -63,5 +66,8 @@ pub fn init() {
         audio::init_audio_state();
         audio::setup_audio_monitoring();
         mouse::start_polling();
+        sysvol::start();
+        brightness::start();
+        osd::install();
     });
 }

--- a/crates/nook-core/src/osd.rs
+++ b/crates/nook-core/src/osd.rs
@@ -1,0 +1,260 @@
+//! SlimHUD-style suppression of the system bezel renderer (`OSDUIHelper`).
+//!
+//! Default is off — Settings must opt in. Startup always SIGCONTs a leftover
+//! stopped helper so a previous crash cannot leave the user without bezels.
+//! SIGTERM/SIGINT only send SIGCONT (async-signal-safe); `atexit` and [`Drop`]
+//! run the full launchctl restore.
+
+use crate::settings;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::Once;
+
+pub const HELPER_LABEL: &str = "com.apple.OSDUIHelper";
+pub const HELPER_PROCESS: &str = "OSDUIHelper";
+pub const LAUNCHCTL: &str = "/bin/launchctl";
+pub const PKILL: &str = "/usr/bin/pkill";
+pub const PGREP: &str = "/usr/bin/pgrep";
+
+/// `launchctl kickstart` arguments for the per-user OSDUIHelper service.
+pub fn kickstart_args(uid: u32, kill: bool) -> Vec<String> {
+    let mut args = vec!["kickstart".to_string()];
+    if kill {
+        args.push("-k".into());
+    }
+    args.push(format!("gui/{uid}/{HELPER_LABEL}"));
+    args
+}
+
+pub fn pgrep_args() -> [&'static str; 2] {
+    ["-x", HELPER_PROCESS]
+}
+
+pub fn is_suppressed() -> bool {
+    SUPPRESSED.load(Ordering::Relaxed)
+}
+
+/// True when we last saw the helper process (so we can claim suppression).
+pub fn helper_present() -> bool {
+    HELPER_SEEN.load(Ordering::Relaxed)
+}
+
+/// Crash-safe restore, then apply the current Settings value.
+pub fn install() {
+    STARTED.call_once(|| {
+        restore();
+        apply_from_settings();
+        #[cfg(target_os = "macos")]
+        macos::install_exit_hooks();
+        let _ = GUARD.set(OsdGuard);
+    });
+}
+
+pub fn apply_from_settings() {
+    apply(settings::get_app_settings().replace_system_hud);
+}
+
+pub fn apply(replace: bool) {
+    if replace {
+        let _ = suppress();
+    } else {
+        restore();
+    }
+}
+
+/// Stop the helper so it stays "alive" to launchd but cannot draw. Returns
+/// whether a process was actually stopped.
+pub fn suppress() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::suppress()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        HELPER_SEEN.store(false, Ordering::Relaxed);
+        SUPPRESSED.store(false, Ordering::Relaxed);
+        false
+    }
+}
+
+pub fn restore() {
+    #[cfg(target_os = "macos")]
+    macos::restore();
+    #[cfg(not(target_os = "macos"))]
+    {
+        SUPPRESSED.store(false, Ordering::Relaxed);
+    }
+}
+
+/// Parse `pgrep -x OSDUIHelper` stdout into pids.
+pub fn parse_pgrep_stdout(stdout: &str) -> Vec<i32> {
+    stdout
+        .split_whitespace()
+        .filter_map(|token| token.parse::<i32>().ok())
+        .filter(|pid| *pid > 1)
+        .collect()
+}
+
+static STARTED: Once = Once::new();
+static SUPPRESSED: AtomicBool = AtomicBool::new(false);
+static HELPER_SEEN: AtomicBool = AtomicBool::new(false);
+static CACHED_PID: AtomicI32 = AtomicI32::new(0);
+static GUARD: std::sync::OnceLock<OsdGuard> = std::sync::OnceLock::new();
+
+struct OsdGuard;
+
+impl Drop for OsdGuard {
+    fn drop(&mut self) {
+        restore();
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use std::process::Command;
+
+    // Darwin signal numbers (async-signal-safe restore uses these only).
+    const SIGINT: i32 = 2;
+    const SIGTERM: i32 = 15;
+    const SIGSTOP: i32 = 17;
+    const SIGCONT: i32 = 19;
+
+    unsafe extern "C" {
+        fn getuid() -> u32;
+        fn kill(pid: i32, sig: i32) -> i32;
+        fn atexit(cb: extern "C" fn()) -> i32;
+        fn signal(sig: i32, handler: extern "C" fn(i32)) -> *mut std::ffi::c_void;
+    }
+
+    fn uid() -> u32 {
+        unsafe { getuid() }
+    }
+
+    fn helper_pids() -> Vec<i32> {
+        let output = Command::new(PGREP).args(pgrep_args()).output();
+        match output {
+            Ok(out) => {
+                let text = String::from_utf8_lossy(&out.stdout);
+                super::parse_pgrep_stdout(&text)
+            }
+            Err(err) => {
+                log::debug!("pgrep OSDUIHelper: {err}");
+                Vec::new()
+            }
+        }
+    }
+
+    fn kickstart(kill: bool) {
+        let args = kickstart_args(uid(), kill);
+        if let Err(err) = Command::new(LAUNCHCTL).args(&args).status() {
+            log::debug!("launchctl {}: {err}", args.join(" "));
+        }
+    }
+
+    pub(super) fn suppress() -> bool {
+        kickstart(false);
+        let pids = helper_pids();
+        if pids.is_empty() {
+            log::warn!("OSDUIHelper not running; island HUD will show beside the system bezel");
+            HELPER_SEEN.store(false, Ordering::Relaxed);
+            SUPPRESSED.store(false, Ordering::Relaxed);
+            CACHED_PID.store(0, Ordering::Relaxed);
+            return false;
+        }
+        HELPER_SEEN.store(true, Ordering::Relaxed);
+        CACHED_PID.store(pids[0], Ordering::Relaxed);
+        for pid in pids {
+            unsafe {
+                let _ = kill(pid, SIGSTOP);
+            }
+        }
+        SUPPRESSED.store(true, Ordering::Relaxed);
+        true
+    }
+
+    pub(super) fn restore() {
+        let cached = CACHED_PID.swap(0, Ordering::Relaxed);
+        if cached > 1 {
+            unsafe {
+                let _ = kill(cached, SIGCONT);
+            }
+        }
+        for pid in helper_pids() {
+            unsafe {
+                let _ = kill(pid, SIGCONT);
+            }
+        }
+        kickstart(true);
+        SUPPRESSED.store(false, Ordering::Relaxed);
+    }
+
+    extern "C" fn restore_on_exit() {
+        let pid = CACHED_PID.load(Ordering::Relaxed);
+        if pid > 1 {
+            unsafe {
+                let _ = kill(pid, SIGCONT);
+            }
+        }
+    }
+
+    extern "C" fn restore_on_signal(_sig: i32) {
+        restore_on_exit();
+    }
+
+    pub(super) fn install_exit_hooks() {
+        unsafe {
+            let _ = atexit(restore_on_exit);
+            let _ = signal(SIGTERM, restore_on_signal);
+            let _ = signal(SIGINT, restore_on_signal);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kickstart_args_target_the_gui_domain() {
+        assert_eq!(
+            kickstart_args(501, false),
+            vec![
+                "kickstart".to_string(),
+                "gui/501/com.apple.OSDUIHelper".into()
+            ]
+        );
+        assert_eq!(
+            kickstart_args(501, true),
+            vec![
+                "kickstart".to_string(),
+                "-k".into(),
+                "gui/501/com.apple.OSDUIHelper".into()
+            ]
+        );
+    }
+
+    #[test]
+    fn pgrep_is_exact_process_name() {
+        assert_eq!(pgrep_args(), ["-x", "OSDUIHelper"]);
+        assert_eq!(HELPER_LABEL, "com.apple.OSDUIHelper");
+    }
+
+    #[test]
+    fn parse_pgrep_stdout_ignores_noise() {
+        assert_eq!(parse_pgrep_stdout(""), Vec::<i32>::new());
+        assert_eq!(parse_pgrep_stdout("0\n1\n"), Vec::<i32>::new());
+        assert_eq!(parse_pgrep_stdout("4321\n4400\n"), vec![4321, 4400]);
+        assert_eq!(parse_pgrep_stdout("not-a-pid"), Vec::<i32>::new());
+    }
+
+    #[test]
+    fn suppress_is_a_no_op_off_macos() {
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(!suppress());
+            assert!(!is_suppressed());
+            assert!(!helper_present());
+            restore();
+        }
+    }
+}

--- a/crates/nook-core/src/osd.rs
+++ b/crates/nook-core/src/osd.rs
@@ -97,6 +97,7 @@ pub fn parse_pgrep_stdout(stdout: &str) -> Vec<i32> {
 static STARTED: Once = Once::new();
 static SUPPRESSED: AtomicBool = AtomicBool::new(false);
 static HELPER_SEEN: AtomicBool = AtomicBool::new(false);
+#[allow(dead_code)]
 static CACHED_PID: AtomicI32 = AtomicI32::new(0);
 static GUARD: std::sync::OnceLock<OsdGuard> = std::sync::OnceLock::new();
 

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -160,6 +160,13 @@ pub struct AppSettings {
     /// the display.
     #[serde(default)]
     pub hide_when_maximized: bool,
+    /// Transient volume/brightness HUD on the compact island face.
+    #[serde(default = "default_true")]
+    pub show_volume_brightness_hud: bool,
+    /// SIGSTOP `OSDUIHelper` so the system bezel does not draw on top.
+    /// Default off — suppression also hides caps-lock and keyboard-backlight bezels.
+    #[serde(default)]
+    pub replace_system_hud: bool,
     /// Island fill as `0xRRGGBB`. `None` uses the default black Live Activity
     /// fill.
     #[serde(default)]
@@ -237,6 +244,8 @@ impl Default for AppSettings {
             island_x: default_island_x(),
             island_y: 0.0,
             hide_when_maximized: false,
+            show_volume_brightness_hud: true,
+            replace_system_hud: false,
             island_color: None,
             widget_widths: Vec::new(),
             window: WindowSettings::default(),
@@ -616,6 +625,8 @@ mod tests {
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
         assert_eq!(parsed.island_y, 0.0);
         assert!(!parsed.hide_when_maximized);
+        assert!(parsed.show_volume_brightness_hud);
+        assert!(!parsed.replace_system_hud);
         assert_eq!(parsed.island_color, None);
     }
 

--- a/crates/nook-core/src/sysvol.rs
+++ b/crates/nook-core/src/sysvol.rs
@@ -466,7 +466,7 @@ mod tests {
     #[test]
     fn clamp_unit_rejects_nan_and_inf() {
         assert_eq!(clamp_unit(f32::NAN), 0.0);
-        assert_eq!(clamp_unit(f32::INFINITY), 1.0);
+        assert_eq!(clamp_unit(f32::INFINITY), 0.0);
         assert_eq!(clamp_unit(-2.0), 0.0);
         assert_eq!(clamp_unit(0.25), 0.25);
     }

--- a/crates/nook-core/src/sysvol.rs
+++ b/crates/nook-core/src/sysvol.rs
@@ -143,10 +143,9 @@ static AVAILABLE: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 mod macos {
     use super::{clamp_unit, publish, HudKind, AVAILABLE};
-    use block2::{Block, RcBlock};
     use std::ffi::c_void;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::{Mutex, Once};
+    use std::sync::Once;
 
     type AudioObjectId = u32;
     type OsStatus = i32;
@@ -187,11 +186,16 @@ mod macos {
             data_size: u32,
             data: *const c_void,
         ) -> OsStatus;
-        fn AudioObjectAddPropertyListenerBlock(
+        fn AudioObjectAddPropertyListener(
             object: AudioObjectId,
             address: *const PropertyAddress,
-            queue: *mut c_void,
-            listener: *mut Block<dyn Fn(u32, *const PropertyAddress)>,
+            listener: unsafe extern "C" fn(
+                AudioObjectId,
+                u32,
+                *const PropertyAddress,
+                *mut c_void,
+            ) -> OsStatus,
+            client: *mut c_void,
         ) -> OsStatus;
     }
 
@@ -199,8 +203,6 @@ mod macos {
     static DEVICE: AtomicU32 = AtomicU32::new(0);
     static LAST_VOLUME: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
     static LAST_MUTE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-    static BLOCKS: Mutex<Vec<RcBlock<dyn Fn(u32, *const PropertyAddress)>>> =
-        Mutex::new(Vec::new());
 
     fn addr(selector: u32, scope: u32, element: u32) -> PropertyAddress {
         PropertyAddress {
@@ -354,23 +356,28 @@ mod macos {
         );
     }
 
+    /// CoreAudio HAL thread. `client` is a leaked `fn()` from [`listen`].
+    unsafe extern "C" fn on_property(
+        _object: AudioObjectId,
+        _n: u32,
+        _addrs: *const PropertyAddress,
+        client: *mut c_void,
+    ) -> OsStatus {
+        if !client.is_null() {
+            // SAFETY: `client` is `Box::leak` of a `fn()`; listeners are
+            // registered once and never removed or sent across threads.
+            let callback = unsafe { *(client as *const fn()) };
+            callback();
+        }
+        0
+    }
+
     fn listen(object: AudioObjectId, address: PropertyAddress, on_change: fn()) {
-        let block = RcBlock::new(move |_n: u32, _addrs: *const PropertyAddress| {
-            on_change();
-        });
-        let status = unsafe {
-            let block_ref = &*block;
-            let block_ptr = block_ref as *const Block<dyn Fn(u32, *const PropertyAddress)>
-                as *mut Block<dyn Fn(u32, *const PropertyAddress)>;
-            AudioObjectAddPropertyListenerBlock(object, &address, std::ptr::null_mut(), block_ptr)
-        };
-        if status == 0 {
-            if let Ok(mut guard) = BLOCKS.lock() {
-                guard.push(block);
-            } else {
-                std::mem::forget(block);
-            }
-        } else {
+        // Process-lifetime: keep the callback pointer alive for CoreAudio.
+        let client = Box::leak(Box::new(on_change)) as *mut fn() as *mut c_void;
+        let status =
+            unsafe { AudioObjectAddPropertyListener(object, &address, on_property, client) };
+        if status != 0 {
             log::warn!("CoreAudio listener failed ({status:#x})");
         }
     }

--- a/crates/nook-core/src/sysvol.rs
+++ b/crates/nook-core/src/sysvol.rs
@@ -366,7 +366,9 @@ mod macos {
         if !client.is_null() {
             // SAFETY: `client` is `Box::leak` of a `fn()`; listeners are
             // registered once and never removed or sent across threads.
-            let callback = unsafe { *(client as *const fn()) };
+            // The enclosing `unsafe fn` body is already an unsafe block
+            // (edition 2021).
+            let callback = *(client as *const fn());
             callback();
         }
         0

--- a/crates/nook-core/src/sysvol.rs
+++ b/crates/nook-core/src/sysvol.rs
@@ -1,0 +1,535 @@
+//! System output volume and mute, observed through CoreAudio property listeners.
+//!
+//! Also owns the shared HUD event bus that [`crate::brightness`] publishes into.
+//! Idle cost is zero: nothing runs until CoreAudio (or a brightness callback)
+//! fires, and there is no sampling loop.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::watch;
+
+/// How long the island keeps a volume/brightness HUD up after the last change.
+pub const HUD_TTL: Duration = Duration::from_millis(1500);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HudKind {
+    Volume,
+    Mute,
+    Brightness,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HudEvent {
+    pub kind: HudKind,
+    pub value: f32,
+    pub seq: u64,
+}
+
+impl HudEvent {
+    pub const INITIAL: Self = Self {
+        kind: HudKind::Volume,
+        value: 0.0,
+        seq: 0,
+    };
+
+    pub fn is_initial(self) -> bool {
+        self.seq == 0
+    }
+
+    /// Slider fill: mute is drawn empty even when the device still has a level.
+    pub fn display_value(self) -> f32 {
+        match self.kind {
+            HudKind::Mute => 0.0,
+            HudKind::Volume | HudKind::Brightness => clamp_unit(self.value),
+        }
+    }
+}
+
+/// Clamp a hardware reading or slider gesture into `0..=1`.
+pub fn clamp_unit(value: f32) -> f32 {
+    if !value.is_finite() {
+        return 0.0;
+    }
+    value.clamp(0.0, 1.0)
+}
+
+/// Mean of the channel scalars that actually exist on a device.
+pub fn average_channel_scalars(channels: &[f32]) -> Option<f32> {
+    let mut sum = 0.0f32;
+    let mut n = 0u32;
+    for value in channels {
+        if value.is_finite() {
+            sum += clamp_unit(*value);
+            n += 1;
+        }
+    }
+    (n > 0).then_some(sum / n as f32)
+}
+
+/// True after the CoreAudio listeners installed successfully.
+pub fn available() -> bool {
+    AVAILABLE.load(Ordering::Relaxed)
+}
+
+pub fn volume() -> Option<f32> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_volume()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+pub fn muted() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_mute().unwrap_or(false)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn set_volume(value: f32) {
+    let value = clamp_unit(value);
+    #[cfg(target_os = "macos")]
+    macos::write_volume(value);
+    let _ = value;
+}
+
+pub fn set_muted(muted: bool) {
+    #[cfg(target_os = "macos")]
+    macos::write_mute(muted);
+    let _ = muted;
+}
+
+/// Subscribe to volume, mute, and brightness HUD events.
+pub fn subscribe() -> watch::Receiver<HudEvent> {
+    bus().subscribe()
+}
+
+pub(crate) fn publish(kind: HudKind, value: f32) {
+    let value = clamp_unit(value);
+    let tx = bus();
+    let current = *tx.borrow();
+    if current.seq > 0 && current.kind == kind && (current.value - value).abs() < 0.002 {
+        return;
+    }
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed) + 1;
+    let _ = tx.send(HudEvent { kind, value, seq });
+}
+
+/// Install CoreAudio listeners. Safe to call more than once.
+pub fn start() {
+    #[cfg(target_os = "macos")]
+    macos::start();
+}
+
+fn bus() -> &'static watch::Sender<HudEvent> {
+    TX.get_or_init(|| {
+        let (tx, _rx) = watch::channel(HudEvent::INITIAL);
+        tx
+    })
+}
+
+static TX: OnceLock<watch::Sender<HudEvent>> = OnceLock::new();
+static SEQ: AtomicU64 = AtomicU64::new(0);
+static AVAILABLE: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::{clamp_unit, publish, HudKind, AVAILABLE};
+    use block2::{Block, RcBlock};
+    use std::ffi::c_void;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::{Mutex, Once};
+
+    type AudioObjectId = u32;
+    type OsStatus = i32;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct PropertyAddress {
+        selector: u32,
+        scope: u32,
+        element: u32,
+    }
+
+    const SYSTEM_OBJECT: AudioObjectId = 1;
+    const ELEMENT_MAIN: u32 = 0;
+    const SCOPE_GLOBAL: u32 = u32::from_be_bytes(*b"glob");
+    const SCOPE_OUTPUT: u32 = u32::from_be_bytes(*b"outp");
+    const DEFAULT_OUTPUT: u32 = u32::from_be_bytes(*b"dOut");
+    const VIRTUAL_MAIN_VOLUME: u32 = u32::from_be_bytes(*b"vmvc");
+    const VOLUME_SCALAR: u32 = u32::from_be_bytes(*b"volm");
+    const MUTE: u32 = u32::from_be_bytes(*b"mute");
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    unsafe extern "C" {
+        fn AudioObjectHasProperty(object: AudioObjectId, address: *const PropertyAddress) -> u8;
+        fn AudioObjectGetPropertyData(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            data_size: *mut u32,
+            data: *mut c_void,
+        ) -> OsStatus;
+        fn AudioObjectSetPropertyData(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            data_size: u32,
+            data: *const c_void,
+        ) -> OsStatus;
+        fn AudioObjectAddPropertyListenerBlock(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            queue: *mut c_void,
+            listener: *mut Block<dyn Fn(u32, *const PropertyAddress)>,
+        ) -> OsStatus;
+    }
+
+    static STARTED: Once = Once::new();
+    static DEVICE: AtomicU32 = AtomicU32::new(0);
+    static LAST_VOLUME: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+    static LAST_MUTE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+    static BLOCKS: Mutex<Vec<RcBlock<dyn Fn(u32, *const PropertyAddress)>>> =
+        Mutex::new(Vec::new());
+
+    fn addr(selector: u32, scope: u32, element: u32) -> PropertyAddress {
+        PropertyAddress {
+            selector,
+            scope,
+            element,
+        }
+    }
+
+    fn has_property(object: AudioObjectId, address: PropertyAddress) -> bool {
+        unsafe { AudioObjectHasProperty(object, &address) != 0 }
+    }
+
+    fn get_f32(object: AudioObjectId, address: PropertyAddress) -> Option<f32> {
+        if !has_property(object, address) {
+            return None;
+        }
+        let mut value = 0.0f32;
+        let mut size = std::mem::size_of::<f32>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                &mut value as *mut f32 as *mut c_void,
+            )
+        };
+        (status == 0 && value.is_finite()).then_some(value)
+    }
+
+    fn get_u32(object: AudioObjectId, address: PropertyAddress) -> Option<u32> {
+        if !has_property(object, address) {
+            return None;
+        }
+        let mut value = 0u32;
+        let mut size = std::mem::size_of::<u32>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                &mut value as *mut u32 as *mut c_void,
+            )
+        };
+        (status == 0).then_some(value)
+    }
+
+    fn set_f32(object: AudioObjectId, address: PropertyAddress, value: f32) -> bool {
+        if !has_property(object, address) {
+            return false;
+        }
+        let status = unsafe {
+            AudioObjectSetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                std::mem::size_of::<f32>() as u32,
+                &value as *const f32 as *const c_void,
+            )
+        };
+        status == 0
+    }
+
+    fn set_u32(object: AudioObjectId, address: PropertyAddress, value: u32) -> bool {
+        if !has_property(object, address) {
+            return false;
+        }
+        let status = unsafe {
+            AudioObjectSetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                std::mem::size_of::<u32>() as u32,
+                &value as *const u32 as *const c_void,
+            )
+        };
+        status == 0
+    }
+
+    fn default_output() -> Option<AudioObjectId> {
+        let id = get_u32(
+            SYSTEM_OBJECT,
+            addr(DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
+        )?;
+        (id != 0).then_some(id)
+    }
+
+    fn volume_on(device: AudioObjectId) -> Option<f32> {
+        let virtual_main = addr(VIRTUAL_MAIN_VOLUME, SCOPE_OUTPUT, ELEMENT_MAIN);
+        if let Some(value) = get_f32(device, virtual_main) {
+            return Some(clamp_unit(value));
+        }
+        let master = addr(VOLUME_SCALAR, SCOPE_OUTPUT, ELEMENT_MAIN);
+        if let Some(value) = get_f32(device, master) {
+            return Some(clamp_unit(value));
+        }
+        let mut channels = Vec::new();
+        for element in 1u32..=8 {
+            if let Some(value) = get_f32(device, addr(VOLUME_SCALAR, SCOPE_OUTPUT, element)) {
+                channels.push(value);
+            }
+        }
+        super::average_channel_scalars(&channels)
+    }
+
+    fn mute_on(device: AudioObjectId) -> Option<bool> {
+        get_u32(device, addr(MUTE, SCOPE_OUTPUT, ELEMENT_MAIN)).map(|v| v != 0)
+    }
+
+    pub(super) fn read_volume() -> Option<f32> {
+        volume_on(default_output()?)
+    }
+
+    pub(super) fn read_mute() -> Option<bool> {
+        mute_on(default_output()?)
+    }
+
+    pub(super) fn write_volume(value: f32) {
+        let Some(device) = default_output() else {
+            return;
+        };
+        let virtual_main = addr(VIRTUAL_MAIN_VOLUME, SCOPE_OUTPUT, ELEMENT_MAIN);
+        if set_f32(device, virtual_main, value) {
+            let _ = set_u32(device, addr(MUTE, SCOPE_OUTPUT, ELEMENT_MAIN), 0);
+            return;
+        }
+        let master = addr(VOLUME_SCALAR, SCOPE_OUTPUT, ELEMENT_MAIN);
+        let mut wrote = set_f32(device, master, value);
+        for element in 1u32..=8 {
+            wrote |= set_f32(device, addr(VOLUME_SCALAR, SCOPE_OUTPUT, element), value);
+        }
+        if wrote {
+            let _ = set_u32(device, addr(MUTE, SCOPE_OUTPUT, ELEMENT_MAIN), 0);
+        }
+    }
+
+    pub(super) fn write_mute(muted: bool) {
+        let Some(device) = default_output() else {
+            return;
+        };
+        let _ = set_u32(
+            device,
+            addr(MUTE, SCOPE_OUTPUT, ELEMENT_MAIN),
+            u32::from(muted),
+        );
+    }
+
+    fn listen(object: AudioObjectId, address: PropertyAddress, on_change: fn()) {
+        let block = RcBlock::new(move |_n: u32, _addrs: *const PropertyAddress| {
+            on_change();
+        });
+        let status = unsafe {
+            let block_ref = &*block;
+            let block_ptr = block_ref as *const Block<dyn Fn(u32, *const PropertyAddress)>
+                as *mut Block<dyn Fn(u32, *const PropertyAddress)>;
+            AudioObjectAddPropertyListenerBlock(object, &address, std::ptr::null_mut(), block_ptr)
+        };
+        if status == 0 {
+            if let Ok(mut guard) = BLOCKS.lock() {
+                guard.push(block);
+            } else {
+                std::mem::forget(block);
+            }
+        } else {
+            log::warn!("CoreAudio listener failed ({status:#x})");
+        }
+    }
+
+    fn publish_device_state() {
+        let Some(device) = default_output() else {
+            return;
+        };
+        let muted = mute_on(device).unwrap_or(false);
+        let volume = volume_on(device).unwrap_or(0.0);
+        let bits = volume.to_bits();
+        let mute_changed = LAST_MUTE.swap(muted, Ordering::Relaxed) != muted;
+        let vol_changed = LAST_VOLUME.swap(bits, Ordering::Relaxed) != bits;
+        if mute_changed && muted {
+            publish(HudKind::Mute, volume);
+        } else if mute_changed || vol_changed {
+            publish(
+                if muted {
+                    HudKind::Mute
+                } else {
+                    HudKind::Volume
+                },
+                volume,
+            );
+        }
+    }
+
+    fn attach_device() {
+        let Some(device) = default_output() else {
+            AVAILABLE.store(false, Ordering::Relaxed);
+            return;
+        };
+        let previous = DEVICE.swap(device, Ordering::Relaxed);
+        if previous == device && AVAILABLE.load(Ordering::Relaxed) {
+            return;
+        }
+        listen(
+            device,
+            addr(VIRTUAL_MAIN_VOLUME, SCOPE_OUTPUT, ELEMENT_MAIN),
+            publish_device_state,
+        );
+        listen(
+            device,
+            addr(VOLUME_SCALAR, SCOPE_OUTPUT, ELEMENT_MAIN),
+            publish_device_state,
+        );
+        for element in 1u32..=2 {
+            listen(
+                device,
+                addr(VOLUME_SCALAR, SCOPE_OUTPUT, element),
+                publish_device_state,
+            );
+        }
+        listen(
+            device,
+            addr(MUTE, SCOPE_OUTPUT, ELEMENT_MAIN),
+            publish_device_state,
+        );
+        AVAILABLE.store(true, Ordering::Relaxed);
+        if let Some(volume) = volume_on(device) {
+            LAST_VOLUME.store(volume.to_bits(), Ordering::Relaxed);
+        }
+        LAST_MUTE.store(mute_on(device).unwrap_or(false), Ordering::Relaxed);
+    }
+
+    fn on_default_device() {
+        attach_device();
+        publish_device_state();
+    }
+
+    pub(super) fn start() {
+        STARTED.call_once(|| {
+            let _ = super::bus();
+            listen(
+                SYSTEM_OBJECT,
+                addr(DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
+                on_default_device,
+            );
+            attach_device();
+            if AVAILABLE.load(Ordering::Relaxed) {
+                log::info!("CoreAudio volume HUD listeners installed");
+            } else {
+                log::warn!("no default output device; volume HUD disabled");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_unit_rejects_nan_and_inf() {
+        assert_eq!(clamp_unit(f32::NAN), 0.0);
+        assert_eq!(clamp_unit(f32::INFINITY), 1.0);
+        assert_eq!(clamp_unit(-2.0), 0.0);
+        assert_eq!(clamp_unit(0.25), 0.25);
+    }
+
+    #[test]
+    fn average_channel_scalars_skips_empty_and_non_finite() {
+        assert_eq!(average_channel_scalars(&[]), None);
+        assert_eq!(average_channel_scalars(&[f32::NAN]), None);
+        assert_eq!(average_channel_scalars(&[0.2, 0.4]), Some(0.3));
+        assert_eq!(average_channel_scalars(&[1.5, -1.0]), Some(0.5));
+    }
+
+    #[test]
+    fn hud_event_display_value_empties_mute() {
+        let mute = HudEvent {
+            kind: HudKind::Mute,
+            value: 0.8,
+            seq: 1,
+        };
+        assert_eq!(mute.display_value(), 0.0);
+        let volume = HudEvent {
+            kind: HudKind::Volume,
+            value: 1.4,
+            seq: 2,
+        };
+        assert_eq!(volume.display_value(), 1.0);
+        assert!(HudEvent::INITIAL.is_initial());
+        assert!(!volume.is_initial());
+    }
+
+    #[test]
+    fn publish_skips_duplicate_values_and_bumps_seq() {
+        let mut rx = subscribe();
+        publish(HudKind::Volume, 0.4);
+        assert!(rx.has_changed().unwrap());
+        let first = *rx.borrow_and_update();
+        assert_eq!(first.kind, HudKind::Volume);
+        assert!((first.value - 0.4).abs() < f32::EPSILON);
+        assert!(first.seq >= 1);
+
+        publish(HudKind::Volume, 0.4);
+        assert!(!rx.has_changed().unwrap());
+
+        publish(HudKind::Mute, 0.4);
+        let second = *rx.borrow_and_update();
+        assert_eq!(second.kind, HudKind::Mute);
+        assert!(second.seq > first.seq);
+    }
+
+    #[test]
+    fn hud_ttl_is_brief() {
+        assert_eq!(HUD_TTL, Duration::from_millis(1500));
+    }
+
+    #[test]
+    fn volume_setters_are_safe_off_macos() {
+        set_volume(0.5);
+        set_muted(true);
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(!available());
+            assert_eq!(volume(), None);
+            assert!(!muted());
+        }
+    }
+}

--- a/crates/nook/src/assets/icons/sun.svg
+++ b/crates/nook/src/assets/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<circle cx="12" cy="12" r="4"/>
+<path d="M12 2v2"/>
+<path d="M12 20v2"/>
+<path d="m4.93 4.93 1.41 1.41"/>
+<path d="m17.66 17.66 1.41 1.41"/>
+<path d="M2 12h2"/>
+<path d="M20 12h2"/>
+<path d="m6.34 17.66-1.41 1.41"/>
+<path d="m19.07 4.93-1.41 1.41"/>
+</svg>

--- a/crates/nook/src/assets/icons/volume-2.svg
+++ b/crates/nook/src/assets/icons/volume-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z"/>
+<path d="M16 9a5 5 0 0 1 0 6"/>
+<path d="M19.364 18.364a9 9 0 0 0 0-12.728"/>
+</svg>

--- a/crates/nook/src/assets/icons/volume-x.svg
+++ b/crates/nook/src/assets/icons/volume-x.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z"/>
+<line x1="22" x2="16" y1="9" y2="15"/>
+<line x1="16" x2="22" y1="9" y2="15"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -7,9 +7,10 @@ use crate::icons::lucide;
 use crate::theme;
 use crate::widgets;
 use gpui::{
-    div, prelude::*, px, AnyElement, Context, CursorStyle, MouseButton, MouseDownEvent,
-    SharedString,
+    div, prelude::*, px, relative, rgb, rgba, AnyElement, Context, CursorStyle, MouseButton,
+    MouseDownEvent, MouseMoveEvent, MouseUpEvent, SharedString,
 };
+use nook_core::sysvol::HudKind;
 
 impl Island {
     pub(super) fn render_compact(
@@ -53,6 +54,10 @@ impl Island {
     }
 
     fn compact_left(&self, mode: CompactMode, cx: &mut Context<Self>) -> AnyElement {
+        if self.hud_active() {
+            return lucide(hud_icon(self.hud.unwrap().kind), theme::COMPACT_FACE)
+                .into_any_element();
+        }
         match mode {
             CompactMode::Media => {
                 album_chip(&self.now_playing, self.overlay_fade.value, cx).into_any_element()
@@ -74,6 +79,9 @@ impl Island {
         hovered: bool,
         cx: &mut Context<Self>,
     ) -> AnyElement {
+        if self.hud_active() {
+            return self.hud_slider(cx);
+        }
         match mode {
             CompactMode::Media => visualizer(
                 self.now_playing
@@ -123,7 +131,73 @@ impl Island {
         }
     }
 
+    fn hud_slider(&self, cx: &mut Context<Self>) -> AnyElement {
+        const SEGMENTS: u32 = 20;
+        let fill = self.hud_fill.value.clamp(0.0, 1.0);
+        let mut hits = div()
+            .absolute()
+            .inset_0()
+            .flex()
+            .cursor(CursorStyle::PointingHand);
+        for i in 0..SEGMENTS {
+            let ratio = (i as f32 + 0.5) / SEGMENTS as f32;
+            hits = hits.child(
+                div()
+                    .id(SharedString::from(format!("hud-seg-{i}")))
+                    .flex_1()
+                    .h_full()
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                            cx.stop_propagation();
+                            this.apply_hud_slider(ratio, cx);
+                        }),
+                    )
+                    .on_mouse_move(cx.listener(move |this, _: &MouseMoveEvent, _, cx| {
+                        if this.hud_dragging {
+                            cx.stop_propagation();
+                            this.apply_hud_slider(ratio, cx);
+                        }
+                    })),
+            );
+        }
+        div()
+            .id("hud-slider")
+            .w_full()
+            .max_w(px(72.))
+            .h(px(theme::HIT_MIN.min(18.0)))
+            .flex()
+            .items_center()
+            .on_mouse_up(
+                MouseButton::Left,
+                cx.listener(|this, _: &MouseUpEvent, _, cx| {
+                    this.end_hud_drag();
+                    cx.notify();
+                }),
+            )
+            .child(
+                div()
+                    .relative()
+                    .w_full()
+                    .h(px(4.))
+                    .rounded(px(2.))
+                    .bg(rgba(0xffffff26))
+                    .child(
+                        div()
+                            .h_full()
+                            .w(relative(fill))
+                            .rounded(px(2.))
+                            .bg(rgb(0xffffff)),
+                    )
+                    .child(hits),
+            )
+            .into_any_element()
+    }
+
     pub(super) fn mode_dots(&self, cx: &mut Context<Self>) -> impl IntoElement {
+        if self.hud_active() {
+            return div().into_any_element();
+        }
         let modes = self.available_modes();
         let current = self.mode();
         if modes.len() <= 1 {
@@ -181,5 +255,26 @@ impl Island {
             );
         }
         row.into_any_element()
+    }
+}
+
+fn hud_icon(kind: HudKind) -> &'static str {
+    match kind {
+        HudKind::Volume => "volume-2",
+        HudKind::Mute => "volume-x",
+        HudKind::Brightness => "sun",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::hud_icon;
+    use nook_core::sysvol::HudKind;
+
+    #[test]
+    fn hud_icons_match_kind() {
+        assert_eq!(hud_icon(HudKind::Volume), "volume-2");
+        assert_eq!(hud_icon(HudKind::Mute), "volume-x");
+        assert_eq!(hud_icon(HudKind::Brightness), "sun");
     }
 }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -1852,13 +1852,25 @@ mod tests {
         island.hud_fill.set(event.display_value());
         assert!(island.hud_active());
         let live = island.target_size();
-        assert!(live.0 > idle.0, "HUD should widen the idle sliver");
-        assert!(live.1 > idle.1, "HUD should grow the idle sliver");
+        assert!(live.0 > idle.0, "HUD should widen the idle sliver, {live:?} vs {idle:?}");
+        assert_eq!(live.1, 32.0 + theme::COMPACT_HEIGHT_OVERFLOW);
         assert!((island.hud.unwrap().display_value() - 0.6).abs() < f32::EPSILON);
+
+        island.settings.non_notch_mode = true;
+        island.hud = None;
+        let collapsed = island.target_size();
+        island.hud = Some(HudState {
+            kind: event.kind,
+            value: event.value,
+            shown_at: Instant::now(),
+            gen: 1,
+        });
+        let raised = island.target_size();
+        assert!(raised.1 > collapsed.1, "HUD should lift the 1px non-notch sliver");
 
         island.settings.show_volume_brightness_hud = false;
         assert!(!island.hud_active());
-        assert_eq!(island.target_size(), idle);
+        assert_eq!(island.target_size(), collapsed);
     }
 
     #[test]

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -742,28 +742,12 @@ impl Island {
                 if event.is_initial() {
                     continue;
                 }
-                let Ok(gen) = this.update(cx, |this, cx| this.apply_hud_event(event, cx)) else {
+                if this
+                    .update(cx, |this, cx| this.apply_hud_event(event, cx))
+                    .is_err()
+                {
                     break;
-                };
-                if gen == 0 {
-                    continue;
                 }
-                let this2 = this.clone();
-                cx.spawn(async move |_, cx| {
-                    cx.background_executor().timer(HUD_TTL).await;
-                    this2
-                        .update(cx, |this, cx| {
-                            if this
-                                .hud
-                                .is_some_and(|hud| hud.gen == gen && !this.hud_dragging)
-                            {
-                                this.hud = None;
-                                cx.notify();
-                            }
-                        })
-                        .ok();
-                })
-                .detach();
             }
         })
         .detach();

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -27,8 +27,30 @@ use nook_core::models::NowPlayingData;
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
+use nook_core::sysvol::{self, HudEvent, HudKind, HUD_TTL};
 use settings::SettingsView;
 use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) struct HudState {
+    pub kind: HudKind,
+    pub value: f32,
+    pub shown_at: Instant,
+    pub gen: u64,
+}
+
+impl HudState {
+    pub fn display_value(self) -> f32 {
+        match self.kind {
+            HudKind::Mute => 0.0,
+            HudKind::Volume | HudKind::Brightness => sysvol::clamp_unit(self.value),
+        }
+    }
+
+    pub fn expired(self, now: Instant, dragging: bool) -> bool {
+        !dragging && now.duration_since(self.shown_at) >= HUD_TTL
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompactMode {
@@ -158,6 +180,9 @@ pub struct Island {
     pub(crate) mirror_on: bool,
     mirror_gen: u64,
     pub(crate) mirror_frame: Option<std::sync::Arc<gpui::RenderImage>>,
+    pub(super) hud: Option<HudState>,
+    hud_fill: SpringValue,
+    hud_dragging: bool,
 }
 
 struct PendingFileDrag {
@@ -256,6 +281,9 @@ impl Island {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            hud: None,
+            hud_fill: SpringValue::at(0.0),
+            hud_dragging: false,
         };
         // Start at the compact idle size so the first paint isn't a jump.
         let (w, h) = this.target_size();
@@ -263,6 +291,7 @@ impl Island {
         this.anim_h.set(h);
 
         platform::install_media_observers();
+        platform::install_osd_wake_observer();
         nook_core::runtime().spawn(async {
             let _ = nook_core::calendar::request_calendar_access().await;
         });
@@ -328,6 +357,11 @@ impl Island {
                             this.settings.island_y = y;
                         } else {
                             this.settings = settings;
+                        }
+                        nook_core::osd::apply_from_settings();
+                        if !this.settings.show_volume_brightness_hud {
+                            this.hud = None;
+                            this.hud_dragging = false;
                         }
                         dirty = true;
                     }
@@ -490,6 +524,12 @@ impl Island {
                             }
                         }
                     }
+                    if let Some(hud) = this.hud {
+                        if hud.expired(now, this.hud_dragging) {
+                            this.hud = None;
+                            dirty = true;
+                        }
+                    }
                     if dirty {
                         cx.notify();
                     }
@@ -501,7 +541,8 @@ impl Island {
                         || this.pending_file_drag.is_some()
                         || this.mirror_on
                         || this.settings_open
-                        || any_working;
+                        || any_working
+                        || this.hud_active();
                     // Media playing promotes itself through `dirty` (the
                     // visualizer levels change every frame), so it needs no
                     // term of its own here.
@@ -688,6 +729,42 @@ impl Island {
             cx.background_executor()
                 .timer(Duration::from_secs(wait))
                 .await;
+        })
+        .detach();
+
+        cx.spawn(async move |this, cx| {
+            let mut rx = nook_core::sysvol::subscribe();
+            loop {
+                if rx.changed().await.is_err() {
+                    break;
+                }
+                let event = *rx.borrow_and_update();
+                if event.is_initial() {
+                    continue;
+                }
+                let Ok(gen) = this.update(cx, |this, cx| this.apply_hud_event(event, cx)) else {
+                    break;
+                };
+                if gen == 0 {
+                    continue;
+                }
+                let this2 = this.clone();
+                cx.spawn(async move |_, cx| {
+                    cx.background_executor().timer(HUD_TTL).await;
+                    this2
+                        .update(cx, |this, cx| {
+                            if this
+                                .hud
+                                .is_some_and(|hud| hud.gen == gen && !this.hud_dragging)
+                            {
+                                this.hud = None;
+                                cx.notify();
+                            }
+                        })
+                        .ok();
+                })
+                .detach();
+            }
         })
         .detach();
     }
@@ -884,6 +961,75 @@ impl Island {
         modes
     }
 
+    pub(super) fn hud_enabled(&self) -> bool {
+        self.settings.show_volume_brightness_hud
+    }
+
+    pub(super) fn hud_active(&self) -> bool {
+        self.hud_enabled() && self.hud.is_some()
+    }
+
+    fn apply_hud_event(&mut self, event: HudEvent, cx: &mut Context<Self>) -> u64 {
+        if !self.hud_enabled() {
+            return 0;
+        }
+        let first = self.hud.is_none();
+        let gen = self.hud.map(|h| h.gen.saturating_add(1)).unwrap_or(1);
+        self.hud = Some(HudState {
+            kind: event.kind,
+            value: event.value,
+            shown_at: Instant::now(),
+            gen,
+        });
+        if first {
+            if self.reduce_motion {
+                self.hud_fill.set(event.display_value());
+            }
+            nook_core::haptics::trigger(None);
+        }
+        cx.notify();
+        gen
+    }
+
+    pub(super) fn apply_hud_slider(&mut self, ratio: f32, cx: &mut Context<Self>) {
+        let Some(kind) = self.hud.map(|h| h.kind) else {
+            return;
+        };
+        let value = sysvol::clamp_unit(ratio);
+        self.hud_dragging = true;
+        match kind {
+            HudKind::Volume | HudKind::Mute => {
+                sysvol::set_volume(value);
+                self.hud = Some(HudState {
+                    kind: HudKind::Volume,
+                    value,
+                    shown_at: Instant::now(),
+                    gen: self.hud.map(|h| h.gen.saturating_add(1)).unwrap_or(1),
+                });
+            }
+            HudKind::Brightness => {
+                nook_core::brightness::set_brightness(value);
+                self.hud = Some(HudState {
+                    kind: HudKind::Brightness,
+                    value,
+                    shown_at: Instant::now(),
+                    gen: self.hud.map(|h| h.gen.saturating_add(1)).unwrap_or(1),
+                });
+            }
+        }
+        cx.notify();
+    }
+
+    pub(super) fn end_hud_drag(&mut self) {
+        if !self.hud_dragging {
+            return;
+        }
+        self.hud_dragging = false;
+        if let Some(hud) = &mut self.hud {
+            hud.shown_at = Instant::now();
+        }
+    }
+
     fn target_size(&self) -> (f32, f32) {
         let base_w = self.notch_width.max(180.0);
         let base_h = self.notch_height.max(32.0);
@@ -900,6 +1046,9 @@ impl Island {
         }
         if self.hovered {
             return (base_w + 125.0, base_h + 15.0);
+        }
+        if self.hud_active() {
+            return (base_w + 120.0, base_h + theme::COMPACT_HEIGHT_OVERFLOW);
         }
         if self.mode() == CompactMode::Idle {
             let h = if self.settings.non_notch_mode {
@@ -1019,6 +1168,18 @@ impl Island {
         moving |= self
             .overlay_fade
             .step(motion::REVEAL, overlay, dt, motion::REST_ALPHA);
+        let hud_target = self
+            .hud
+            .filter(|_| self.hud_enabled())
+            .map(|h| h.display_value())
+            .unwrap_or(0.0);
+        if self.reduce_motion {
+            self.hud_fill.set(hud_target);
+        } else {
+            moving |= self
+                .hud_fill
+                .step(motion::REVEAL, hud_target, dt, motion::REST_ALPHA);
+        }
 
         if self.reduce_motion {
             self.blur = 0.0;
@@ -1494,6 +1655,9 @@ mod tests {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            hud: None,
+            hud_fill: SpringValue::at(0.0),
+            hud_dragging: false,
         }
     }
 
@@ -1683,6 +1847,53 @@ mod tests {
         let (w, h) = island.target_size();
         assert!(w >= 180.0);
         assert!(h >= 1.0);
+    }
+
+    #[test]
+    fn hud_takeover_expands_idle_island_and_respects_the_toggle() {
+        let mut island = test_island();
+        let idle = island.target_size();
+        let event = HudEvent {
+            kind: HudKind::Volume,
+            value: 0.6,
+            seq: 1,
+        };
+        // apply_hud_event needs a Context; drive the same fields the spawn path sets.
+        island.hud = Some(HudState {
+            kind: event.kind,
+            value: event.value,
+            shown_at: Instant::now(),
+            gen: 1,
+        });
+        island.hud_fill.set(event.display_value());
+        assert!(island.hud_active());
+        let live = island.target_size();
+        assert!(live.0 > idle.0, "HUD should widen the idle sliver");
+        assert!(live.1 > idle.1, "HUD should grow the idle sliver");
+        assert!((island.hud.unwrap().display_value() - 0.6).abs() < f32::EPSILON);
+
+        island.settings.show_volume_brightness_hud = false;
+        assert!(!island.hud_active());
+        assert_eq!(island.target_size(), idle);
+    }
+
+    #[test]
+    fn hud_expires_after_ttl_unless_dragging() {
+        let mut island = test_island();
+        island.hud = Some(HudState {
+            kind: HudKind::Brightness,
+            value: 0.2,
+            shown_at: Instant::now() - HUD_TTL - Duration::from_millis(10),
+            gen: 3,
+        });
+        assert!(island.hud.unwrap().expired(Instant::now(), false));
+        assert!(!island.hud.unwrap().expired(Instant::now(), true));
+        island.hud_dragging = true;
+        island.end_hud_drag();
+        assert!(!island.hud_dragging);
+        assert!(
+            Instant::now().duration_since(island.hud.unwrap().shown_at) < Duration::from_millis(50)
+        );
     }
 
     #[test]

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -569,6 +569,31 @@ impl SettingsView {
                         .into_any_element(),
                     ]),
                     Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
+                ))
+                .child(section(
+                    "HUD",
+                    settings_group(vec![
+                        toggle_row(
+                            "Show volume & brightness HUD",
+                            settings.show_volume_brightness_hud,
+                            cx,
+                            |s| {
+                                s.show_volume_brightness_hud = !s.show_volume_brightness_hud;
+                            },
+                        )
+                        .into_any_element(),
+                        toggle_row(
+                            "Replace system volume/brightness HUD",
+                            settings.replace_system_hud,
+                            cx,
+                            |s| {
+                                s.replace_system_hud = !s.replace_system_hud;
+                                nook_core::osd::apply(s.replace_system_hud);
+                            },
+                        )
+                        .into_any_element(),
+                    ]),
+                    Some(hud_caption(settings)),
                 )),
         )
     }
@@ -1336,6 +1361,14 @@ impl SettingsView {
     }
 }
 
+fn hud_caption(settings: &AppSettings) -> SharedString {
+    if settings.replace_system_hud {
+        "Hides the system volume, brightness, caps-lock, and keyboard-backlight bezels while openNook is running. If OSDUIHelper is missing, the island HUD still appears beside the system bezel.".into()
+    } else {
+        "Volume and brightness keys still show the system bezel. Turn on replacement to hide it — that also hides caps-lock and keyboard-backlight bezels.".into()
+    }
+}
+
 fn module_blurb(module: WidgetModule) -> SharedString {
     match module {
         WidgetModule::Calendar => {
@@ -1741,6 +1774,16 @@ mod tests {
         assert_eq!(SettingsCategory::from_u8(99), SettingsCategory::General);
         assert_eq!(WidgetModule::from_u8(0), WidgetModule::Calendar);
         assert_eq!(WidgetModule::from_u8(99), WidgetModule::Calendar);
+    }
+
+    #[test]
+    fn hud_caption_explains_bezel_suppression() {
+        let off = AppSettings::default();
+        assert!(!off.replace_system_hud);
+        assert!(hud_caption(&off).as_ref().contains("system bezel"));
+        let mut on = AppSettings::default();
+        on.replace_system_hud = true;
+        assert!(hud_caption(&on).as_ref().contains("caps-lock"));
     }
 
     #[test]

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -1433,6 +1433,44 @@ pub fn install_media_observers() {
     }
 }
 
+/// Re-assert OSDUIHelper suppression after sleep — launchd can respawn it.
+pub fn install_osd_wake_observer() {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use block2::RcBlock;
+        use objc2::runtime::AnyObject;
+        use objc2::*;
+
+        static INSTALLED: Once = Once::new();
+        INSTALLED.call_once(|| {
+            let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+            if workspace.is_null() {
+                return;
+            }
+            let center: *mut AnyObject = msg_send![workspace, notificationCenter];
+            if center.is_null() {
+                return;
+            }
+            let name: *mut AnyObject = msg_send![
+                class!(NSString),
+                stringWithUTF8String: c"NSWorkspaceDidWakeNotification".as_ptr()
+            ];
+            let block = RcBlock::new(move |_note: *mut AnyObject| {
+                nook_core::osd::apply_from_settings();
+            });
+            let token: *mut AnyObject = msg_send![
+                center,
+                addObserverForName: name,
+                object: std::ptr::null_mut::<AnyObject>(),
+                queue: std::ptr::null_mut::<AnyObject>(),
+                usingBlock: &*block
+            ];
+            std::mem::forget(block);
+            let _ = token;
+        });
+    }
+}
+
 /// GPUI-space island rect (origin top-left) for the native glass underlay.
 #[derive(Clone, Copy, Debug)]
 pub struct IslandGlass {


### PR DESCRIPTION
## Summary

Island volume and brightness HUDs (WP02 only).

- **Observe (no TCC):** CoreAudio property listeners for default-output volume/mute (`sysvol.rs`) and DisplayServices/CoreDisplay brightness via dlopen (`brightness.rs`). Changes publish on a shared `tokio::sync::watch` bus — no new idle polls.
- **Compact-face HUD:** transient icon + slider takeover (~1.5s), slider drag writes volume/brightness, fill animates on `motion::REVEAL`.
- **Bezel suppression (default off):** Settings → HUD → “Replace system volume/brightness HUD” uses the SlimHUD `OSDUIHelper` SIGSTOP trick, with crash-safe SIGCONT on start, `atexit`/signal restore, and re-assert on `NSWorkspaceDidWakeNotification`.
- **Graceful degrade:** missing CoreAudio device, vanished DisplayServices symbols, or missing OSDUIHelper hide/disable that layer and keep the island HUD (or show it beside the system bezel).

Does not implement other WPs. Branched from `origin/main` (W0 perf work intact).

## Settings

- **Show volume & brightness HUD** — default on
- **Replace system volume/brightness HUD** — default off, with explainer that suppression also hides caps-lock and keyboard-backlight bezels

## Tests

`cargo test -p nook -p nook-core` — 85 + 88 passed (Linux CI; macOS listeners/dlopen are `cfg`-gated).

## Notes / blockers

- OSDUIHelper as the Tahoe/26 bezel renderer is unverified on this Linux agent — suppression degrades if the process is missing.
- DisplayServices is private; symbols are probed at startup.
- External-display DDC/CI is out of scope.
- No `window.resize` in `render`.