### PR TITLE
WP12: Per-app volume mixer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,6 +3835,9 @@ dependencies = [
  "futures-util",
  "log",
  "objc2",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
  "objc2-event-kit",
  "objc2-foundation",
  "open",
@@ -4058,13 +4061,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1eebcea8b0dbff5f7c8504f3107c68fc061a3eb44932051c8cf8a68d969c3b2"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-audio-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a89f2ec274a0cf4a32642b2991e8b351a404d290da87bb6a9a9d8632490bd1c"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
  "dispatch2",
+ "libc",
  "objc2",
 ]
 

--- a/Info.plist
+++ b/Info.plist
@@ -30,5 +30,7 @@
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
+	<key>NSAudioCaptureUsageDescription</key>
+	<string>openNook adjusts each app's volume by tapping its audio output. It does not save or send what you hear — it only scales the sound in real time. macOS shows a recording indicator while any per-app slider is below 100%.</string>
 </dict>
 </plist>

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -22,6 +22,9 @@ sysinfo = "0.37"
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-event-kit = { version = "0.3", features = ["EKEventStore", "EKEvent", "EKReminder", "EKCalendar"] }
+objc2-core-audio = { version = "0.3.2", features = ["AudioHardware", "objc2", "objc2-foundation", "block2"] }
+objc2-core-audio-types = "0.3.2"
+objc2-core-foundation = { version = "0.3.2", features = ["CFDictionary", "CFString"] }
 block2 = "0.6"
 security-framework = "3.7"
 

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod files;
 pub mod haptics;
 #[cfg(target_os = "macos")]
 mod mediaremote;
+pub mod mixer;
 pub mod models;
 pub mod mouse;
 pub mod notch;
@@ -62,6 +63,7 @@ pub fn init() {
         }
         audio::init_audio_state();
         audio::setup_audio_monitoring();
+        mixer::init();
         mouse::start_polling();
     });
 }

--- a/crates/nook-core/src/mixer.rs
+++ b/crates/nook-core/src/mixer.rs
@@ -677,6 +677,10 @@ mod macos {
     const SYSTEM_OBJECT: AudioObjectID = kAudioObjectSystemObject as AudioObjectID;
 
     /// Same layout as Foundation's `NSOperatingSystemVersion` (`NSInteger` triple).
+    ///
+    /// Encoded as an anonymous struct (`{?=qqq}`). Apple's runtime type for
+    /// `isOperatingSystemAtLeastVersion:` / `operatingSystemVersion` uses `?`,
+    /// not the typedef name — a named encoding panics in objc2's checker.
     #[repr(C)]
     struct NsVer {
         major: isize,
@@ -686,7 +690,7 @@ mod macos {
 
     unsafe impl Encode for NsVer {
         const ENCODING: Encoding = Encoding::Struct(
-            "NSOperatingSystemVersion",
+            "?",
             &[isize::ENCODING, isize::ENCODING, isize::ENCODING],
         );
     }
@@ -1504,6 +1508,11 @@ mod tests {
         assert!(version_at_least(14, 5, 1, 14, 4, 0));
         assert!(!version_at_least(14, 3, 9, 14, 4, 0));
         assert!(!version_at_least(13, 6, 0, 14, 4, 0));
+    }
+
+    #[test]
+    fn is_available_does_not_panic() {
+        let _ = is_available();
     }
 
     #[test]

--- a/crates/nook-core/src/mixer.rs
+++ b/crates/nook-core/src/mixer.rs
@@ -1,0 +1,1501 @@
+//! Per-app volume mixer.
+//!
+//! Listing apps that are producing sound is prompt-free. Changing a slider
+//! creates a Core Audio process tap (macOS 14.4+), which is a capture object
+//! and triggers the system-audio-recording consent prompt. With every gain at
+//! unity there are no taps, no aggregate device, and no IOProc.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+/// Explanatory copy shown before the first slider move (and in Settings).
+pub const TCC_PREPROMPT: &str = "Per-app volume uses macOS system-audio recording. openNook does not save or send your audio — it only scales it in real time so each app can have its own level. macOS will ask for permission the first time you move a slider, and Control Center shows a recording indicator while any slider is below 100%.";
+
+pub const UNITY: f32 = 1.0;
+pub const GAIN_MIN: f32 = 0.0;
+pub const GAIN_MAX: f32 = 1.5;
+const UNITY_EPS: f32 = 0.001;
+const MUTE_EPS: f32 = 0.001;
+
+const GAINS_KEY: &str = "mixer_gains";
+const ACK_KEY: &str = "mixer_capture_ack";
+
+/// One row in the mixer card: a playing app (helpers already grouped).
+#[derive(Clone, Debug, PartialEq)]
+pub struct MixerApp {
+    pub bundle_id: String,
+    pub name: String,
+    pub pids: Vec<i32>,
+    pub object_ids: Vec<u32>,
+    pub gain: f32,
+    pub muted: bool,
+    pub level: f32,
+}
+
+/// Privacy / pipeline state shown in Settings and the card.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CaptureStatus {
+    Unavailable,
+    Idle,
+    NeedsConsent,
+    Denied,
+    Active,
+}
+
+/// Persisted / in-memory gain table keyed by canonical bundle id.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct GainMap {
+    gains: BTreeMap<String, f32>,
+    restore: BTreeMap<String, f32>,
+}
+
+impl GainMap {
+    pub fn get(&self, id: &str) -> f32 {
+        self.gains
+            .get(id)
+            .copied()
+            .filter(|g| g.is_finite())
+            .unwrap_or(UNITY)
+    }
+
+    pub fn set(&mut self, id: &str, gain: f32) {
+        let id = id.trim();
+        if id.is_empty() {
+            return;
+        }
+        let gain = sanitize_gain(gain);
+        if is_unity(gain) {
+            self.gains.remove(id);
+            self.restore.remove(id);
+            return;
+        }
+        if gain > MUTE_EPS {
+            self.restore.insert(id.to_string(), gain);
+        }
+        self.gains.insert(id.to_string(), gain);
+    }
+
+    pub fn is_muted(&self, id: &str) -> bool {
+        self.get(id) <= MUTE_EPS
+    }
+
+    pub fn toggle_mute(&mut self, id: &str) {
+        if self.is_muted(id) {
+            let restore = self.restore.get(id).copied().unwrap_or(UNITY);
+            self.set(id, if restore <= MUTE_EPS { UNITY } else { restore });
+        } else {
+            let current = self.get(id);
+            if current > MUTE_EPS {
+                self.restore.insert(id.to_string(), current);
+            }
+            self.gains.insert(id.to_string(), 0.0);
+        }
+    }
+
+    pub fn reset(&mut self, id: &str) {
+        self.gains.remove(id);
+        self.restore.remove(id);
+    }
+
+    pub fn reset_all(&mut self) {
+        self.gains.clear();
+        self.restore.clear();
+    }
+
+    pub fn has_active(&self) -> bool {
+        self.gains.values().any(|g| !is_unity(*g))
+    }
+
+    pub fn active_ids(&self) -> Vec<String> {
+        self.gains
+            .iter()
+            .filter(|(_, g)| !is_unity(**g))
+            .map(|(k, _)| k.clone())
+            .collect()
+    }
+
+    pub fn to_persist(&self) -> BTreeMap<String, f32> {
+        self.gains
+            .iter()
+            .filter(|(_, g)| !is_unity(**g))
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
+    }
+
+    pub fn from_persist(map: BTreeMap<String, f32>) -> Self {
+        let mut this = Self::default();
+        for (key, gain) in map {
+            this.set(&key, gain);
+        }
+        this
+    }
+}
+
+/// A Core Audio process object as enumerated from the HAL.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RawProcess {
+    pub pid: i32,
+    pub object_id: u32,
+    pub bundle_id: String,
+    pub name: String,
+    pub running_output: bool,
+    pub responsible_bundle: Option<String>,
+}
+
+pub fn is_unity(gain: f32) -> bool {
+    (gain - UNITY).abs() < UNITY_EPS
+}
+
+pub fn sanitize_gain(gain: f32) -> f32 {
+    if gain.is_finite() {
+        gain.clamp(GAIN_MIN, GAIN_MAX)
+    } else {
+        UNITY
+    }
+}
+
+/// Realtime-safe sample scale. Boosts (`gain > 1`) go through tanh.
+pub fn scale_sample(sample: f32, gain: f32) -> f32 {
+    if !sample.is_finite() {
+        return 0.0;
+    }
+    let g = sanitize_gain(gain);
+    let x = sample * g;
+    if g <= UNITY {
+        x.clamp(-1.0, 1.0)
+    } else {
+        x.tanh()
+    }
+}
+
+const HELPER_TOKENS: &[&str] = &[
+    "helper",
+    "gpu",
+    "webcontent",
+    "networking",
+    "renderer",
+    "plugin",
+    "gpuhelper",
+    "rendererhelper",
+    "pluginhelper",
+    "broker",
+];
+
+/// Last bundle-id component looks like a helper / GPU / renderer process.
+pub fn is_helper_bundle(bundle_id: &str) -> bool {
+    let last = bundle_id.rsplit('.').next().unwrap_or("");
+    let lower = last.to_ascii_lowercase();
+    HELPER_TOKENS.contains(&lower.as_str())
+        || lower.contains("helper")
+        || bundle_id.contains(".helper")
+        || bundle_id.contains(".Helper")
+}
+
+fn strip_helper_suffix(bundle_id: &str) -> String {
+    let mut parts: Vec<&str> = bundle_id.split('.').collect();
+    while parts.len() > 2 {
+        let last = parts.last().copied().unwrap_or("").to_ascii_lowercase();
+        if HELPER_TOKENS.contains(&last.as_str()) || last.contains("helper") {
+            parts.pop();
+        } else {
+            break;
+        }
+    }
+    parts.join(".")
+}
+
+/// Map a process bundle id onto the app the user thinks is playing.
+pub fn canonical_bundle_id(bundle_id: &str) -> String {
+    match bundle_id {
+        "com.apple.WebKit.GPU"
+        | "com.apple.WebKit.WebContent"
+        | "com.apple.WebKit.Networking"
+        | "com.apple.WebKit.GPU.Development"
+        | "com.apple.WebKit.WebContent.Development" => "com.apple.Safari".into(),
+        other => strip_helper_suffix(other),
+    }
+}
+
+/// Group a helper under its responsible parent when we know one.
+pub fn group_key(bundle_id: &str, responsible_bundle: Option<&str>) -> String {
+    if let Some(resp) = responsible_bundle {
+        if is_helper_bundle(bundle_id) && !is_helper_bundle(resp) {
+            return canonical_bundle_id(resp);
+        }
+    }
+    canonical_bundle_id(bundle_id)
+}
+
+fn title_case_token(token: &str) -> String {
+    let mut chars = token.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+        None => String::new(),
+    }
+}
+
+fn humanize_bundle(bundle_id: &str) -> String {
+    let mut parts: Vec<&str> = bundle_id.split('.').collect();
+    while let Some(last) = parts.last().copied() {
+        if last.eq_ignore_ascii_case("client")
+            || last.eq_ignore_ascii_case("mac")
+            || last.eq_ignore_ascii_case("macos")
+            || last.eq_ignore_ascii_case("desktop")
+        {
+            parts.pop();
+        } else {
+            break;
+        }
+    }
+    title_case_token(parts.last().copied().unwrap_or(bundle_id))
+}
+
+pub fn display_name_for_bundle(bundle_id: &str) -> String {
+    match bundle_id {
+        "com.apple.Safari" => "Safari".into(),
+        "com.apple.Music" => "Music".into(),
+        "com.apple.TV" => "TV".into(),
+        "com.apple.quicktimeplayer" => "QuickTime".into(),
+        "com.apple.FaceTime" => "FaceTime".into(),
+        "com.spotify.client" => "Spotify".into(),
+        "com.google.Chrome" => "Chrome".into(),
+        "com.google.Chrome.canary" => "Chrome Canary".into(),
+        "com.microsoft.edgemac" => "Edge".into(),
+        "org.mozilla.firefox" => "Firefox".into(),
+        "org.videolan.vlc" => "VLC".into(),
+        "com.hnc.Discord" => "Discord".into(),
+        "com.tinyspeck.slackmacgap" => "Slack".into(),
+        "us.zoom.xos" => "Zoom".into(),
+        other => humanize_bundle(other),
+    }
+}
+
+/// Collapse helper processes that share a canonical bundle into one row.
+pub fn group_playing_apps(procs: &[RawProcess], gains: &GainMap) -> Vec<MixerApp> {
+    let mut groups: BTreeMap<String, MixerApp> = BTreeMap::new();
+    for proc in procs.iter().filter(|proc| proc.running_output) {
+        let key = group_key(&proc.bundle_id, proc.responsible_bundle.as_deref());
+        if key.is_empty() {
+            continue;
+        }
+        let entry = groups.entry(key.clone()).or_insert_with(|| MixerApp {
+            name: if !proc.name.is_empty() && !is_helper_bundle(&proc.bundle_id) {
+                proc.name.clone()
+            } else {
+                display_name_for_bundle(&key)
+            },
+            bundle_id: key.clone(),
+            pids: Vec::new(),
+            object_ids: Vec::new(),
+            gain: gains.get(&key),
+            muted: gains.is_muted(&key),
+            level: 0.0,
+        });
+        if !entry.pids.contains(&proc.pid) {
+            entry.pids.push(proc.pid);
+        }
+        if proc.object_id != 0 && !entry.object_ids.contains(&proc.object_id) {
+            entry.object_ids.push(proc.object_id);
+        }
+        if !proc.name.is_empty() && !is_helper_bundle(&proc.bundle_id) {
+            entry.name = proc.name.clone();
+        }
+        entry.gain = gains.get(&key);
+        entry.muted = gains.is_muted(&key);
+    }
+    let mut apps: Vec<_> = groups.into_values().collect();
+    apps.sort_by(|a, b| {
+        a.name
+            .to_lowercase()
+            .cmp(&b.name.to_lowercase())
+            .then_with(|| a.bundle_id.cmp(&b.bundle_id))
+    });
+    apps
+}
+
+pub fn version_at_least(
+    major: i64,
+    minor: i64,
+    patch: i64,
+    need_maj: i64,
+    need_min: i64,
+    need_pat: i64,
+) -> bool {
+    (major, minor, patch) >= (need_maj, need_min, need_pat)
+}
+
+pub fn capture_status_label(status: CaptureStatus) -> &'static str {
+    match status {
+        CaptureStatus::Unavailable => "Requires macOS 14.4 or later",
+        CaptureStatus::Idle => "Idle — no recording while every slider is at 100%",
+        CaptureStatus::NeedsConsent => "Permission asked on the first slider move",
+        CaptureStatus::Denied => {
+            "Denied — enable Screen & System Audio Recording in Privacy & Security"
+        }
+        CaptureStatus::Active => "Recording indicator on — a slider is below 100%",
+    }
+}
+
+struct MixerState {
+    gains: GainMap,
+    apps: Vec<MixerApp>,
+    ack: bool,
+    denied: bool,
+    card_visible: bool,
+    enabled: bool,
+    #[cfg(target_os = "macos")]
+    inner: macos::Engine,
+}
+
+impl Default for MixerState {
+    fn default() -> Self {
+        Self {
+            gains: GainMap::default(),
+            apps: Vec::new(),
+            ack: false,
+            denied: false,
+            card_visible: false,
+            enabled: true,
+            #[cfg(target_os = "macos")]
+            inner: macos::Engine::default(),
+        }
+    }
+}
+
+static STATE: OnceLock<Mutex<MixerState>> = OnceLock::new();
+static GEN: AtomicU64 = AtomicU64::new(1);
+static DIRTY: AtomicBool = AtomicBool::new(false);
+
+fn lock_state() -> MutexGuard<'static, MixerState> {
+    STATE
+        .get_or_init(|| Mutex::new(MixerState::default()))
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+}
+
+fn bump() {
+    GEN.fetch_add(1, Ordering::Relaxed);
+}
+
+fn persist_gains(map: &GainMap) {
+    match serde_json::to_string(&map.to_persist()) {
+        Ok(json) => {
+            if let Err(err) = crate::database::set_setting(GAINS_KEY, &json) {
+                log::debug!("mixer persist gains: {err}");
+            }
+        }
+        Err(err) => log::debug!("mixer serialize gains: {err}"),
+    }
+}
+
+fn persist_ack(ack: bool) {
+    if let Err(err) = crate::database::set_setting(ACK_KEY, if ack { "1" } else { "0" }) {
+        log::debug!("mixer persist ack: {err}");
+    }
+}
+
+fn load_persisted(state: &mut MixerState) {
+    if let Some(json) = crate::database::get_setting(GAINS_KEY) {
+        if let Ok(map) = serde_json::from_str::<BTreeMap<String, f32>>(&json) {
+            state.gains = GainMap::from_persist(map);
+        }
+    }
+    if let Some(flag) = crate::database::get_setting(ACK_KEY) {
+        state.ack = flag == "1" || flag.eq_ignore_ascii_case("true");
+    }
+}
+
+/// Load saved gains and, on macOS 14.4+, clean leftover private aggregates.
+pub fn init() {
+    let mut state = lock_state();
+    load_persisted(&mut state);
+    #[cfg(target_os = "macos")]
+    {
+        macos::cleanup_orphans();
+        if is_available() && state.enabled && state.gains.has_active() {
+            state.inner.ensure_watchers();
+            DIRTY.store(true, Ordering::Relaxed);
+        }
+    }
+    bump();
+}
+
+pub fn generation() -> u64 {
+    GEN.load(Ordering::Relaxed)
+}
+
+pub fn is_available() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::process_taps_supported()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn snapshot() -> Vec<MixerApp> {
+    lock_state().apps.clone()
+}
+
+pub fn capture_acknowledged() -> bool {
+    lock_state().ack
+}
+
+pub fn acknowledge_capture() {
+    let mut state = lock_state();
+    if state.ack {
+        return;
+    }
+    state.ack = true;
+    persist_ack(true);
+    bump();
+}
+
+pub fn capture_status() -> CaptureStatus {
+    if !is_available() {
+        return CaptureStatus::Unavailable;
+    }
+    let state = lock_state();
+    if state.denied {
+        return CaptureStatus::Denied;
+    }
+    if state.gains.has_active() && state.ack {
+        return CaptureStatus::Active;
+    }
+    if !state.ack {
+        return CaptureStatus::NeedsConsent;
+    }
+    CaptureStatus::Idle
+}
+
+pub fn set_card_visible(visible: bool) {
+    let mut state = lock_state();
+    if state.card_visible == visible {
+        return;
+    }
+    state.card_visible = visible;
+    DIRTY.store(true, Ordering::Relaxed);
+}
+
+pub fn set_enabled(enabled: bool) {
+    let mut state = lock_state();
+    if state.enabled == enabled {
+        return;
+    }
+    state.enabled = enabled;
+    if !enabled {
+        state.card_visible = false;
+        #[cfg(target_os = "macos")]
+        {
+            state.inner.teardown_pipeline();
+            state.inner.stop_watchers();
+        }
+    } else {
+        DIRTY.store(true, Ordering::Relaxed);
+    }
+    bump();
+}
+
+pub fn set_gain(bundle_id: &str, gain: f32) {
+    let mut state = lock_state();
+    if !state.ack && !is_unity(sanitize_gain(gain)) {
+        return;
+    }
+    let key = canonical_bundle_id(bundle_id);
+    state.gains.set(&key, gain);
+    persist_gains(&state.gains);
+    refresh_app_gains(&mut state);
+    DIRTY.store(true, Ordering::Relaxed);
+    bump();
+}
+
+pub fn toggle_mute(bundle_id: &str) {
+    let mut state = lock_state();
+    if !state.ack {
+        return;
+    }
+    let key = canonical_bundle_id(bundle_id);
+    state.gains.toggle_mute(&key);
+    persist_gains(&state.gains);
+    refresh_app_gains(&mut state);
+    DIRTY.store(true, Ordering::Relaxed);
+    bump();
+}
+
+pub fn reset_all() {
+    let mut state = lock_state();
+    state.gains.reset_all();
+    persist_gains(&state.gains);
+    refresh_app_gains(&mut state);
+    #[cfg(target_os = "macos")]
+    {
+        state.inner.teardown_pipeline();
+        if !state.card_visible {
+            state.inner.stop_watchers();
+        }
+    }
+    DIRTY.store(true, Ordering::Relaxed);
+    bump();
+}
+
+pub fn mark_denied() {
+    let mut state = lock_state();
+    if !state.denied {
+        state.denied = true;
+        bump();
+    }
+}
+
+fn refresh_app_gains(state: &mut MixerState) {
+    for app in &mut state.apps {
+        app.gain = state.gains.get(&app.bundle_id);
+        app.muted = state.gains.is_muted(&app.bundle_id);
+    }
+}
+
+/// Apply event-driven HAL updates. Cheap when nothing is dirty.
+pub fn pump() {
+    if !DIRTY.swap(false, Ordering::AcqRel) {
+        return;
+    }
+    let mut state = lock_state();
+    if !is_available() || !state.enabled {
+        state.apps.clear();
+        #[cfg(target_os = "macos")]
+        {
+            state.inner.teardown_pipeline();
+            state.inner.stop_watchers();
+        }
+        return;
+    }
+    let want_watchers = state.card_visible || state.gains.has_active();
+    #[cfg(target_os = "macos")]
+    {
+        if want_watchers {
+            state.inner.ensure_watchers();
+            let procs = state.inner.refresh_processes();
+            state.apps = group_playing_apps(&procs, &state.gains);
+            let running_keys: Vec<String> = state.apps.iter().map(|a| a.bundle_id.clone()).collect();
+            if state.ack {
+                if let Err(err) = state.inner.sync_pipeline(&state.gains, &state.apps) {
+                    log::warn!("mixer pipeline: {err}");
+                    if err.contains("denied") || err.contains("permission") || err.contains("-54") {
+                        state.denied = true;
+                    }
+                }
+            }
+            if !state.gains.has_active()
+                && !running_keys
+                    .iter()
+                    .any(|id| !is_unity(state.gains.get(id)))
+            {
+                state.inner.teardown_pipeline();
+            }
+            if !state.card_visible && !state.gains.has_active() {
+                state.inner.stop_watchers();
+            }
+        } else {
+            state.apps.clear();
+            state.inner.teardown_pipeline();
+            state.inner.stop_watchers();
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = want_watchers;
+        state.apps.clear();
+    }
+    bump();
+}
+
+/// Copy IOProc peaks into the UI snapshot. Call only while the card is open.
+pub fn copy_levels(apps: &mut [MixerApp]) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::copy_levels(apps)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = apps;
+        false
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use objc2::runtime::AnyObject;
+    use objc2::{class, msg_send};
+    use objc2_core_audio::{
+        kAudioAggregateDeviceIsPrivateKey, kAudioAggregateDeviceNameKey,
+        kAudioAggregateDeviceSubDeviceListKey, kAudioAggregateDeviceTapAutoStartKey,
+        kAudioAggregateDeviceTapListKey, kAudioAggregateDeviceUIDKey,
+        kAudioDevicePropertyBufferFrameSize, kAudioDevicePropertyDeviceUID,
+        kAudioHardwarePropertyDefaultOutputDevice, kAudioHardwarePropertyDevices,
+        kAudioHardwarePropertyProcessObjectList, kAudioObjectPropertyElementMain,
+        kAudioObjectPropertyName, kAudioObjectPropertyScopeGlobal, kAudioObjectSystemObject,
+        kAudioProcessPropertyBundleID, kAudioProcessPropertyIsRunningOutput,
+        kAudioProcessPropertyPID, kAudioSubDeviceUIDKey, kAudioSubTapDriftCompensationKey,
+        kAudioSubTapUIDKey, kAudioTapPropertyUID, AudioDeviceCreateIOProcID,
+        AudioDeviceDestroyIOProcID, AudioDeviceIOProcID, AudioDeviceStart, AudioDeviceStop,
+        AudioHardwareCreateAggregateDevice, AudioHardwareCreateProcessTap,
+        AudioHardwareDestroyAggregateDevice, AudioHardwareDestroyProcessTap,
+        AudioObjectAddPropertyListener, AudioObjectGetPropertyData,
+        AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
+        AudioObjectPropertyListenerProc, AudioObjectRemovePropertyListener,
+        AudioObjectSetPropertyData, CATapDescription, CATapMuteBehavior,
+    };
+    use objc2_core_audio_types::{AudioBufferList, AudioTimeStamp};
+    use objc2_core_foundation::{CFDictionary, CFRetained, CFString};
+    use objc2_foundation::{NSArray, NSDictionary, NSNumber, NSString, NSUUID};
+    use std::ffi::{c_void, CStr};
+    use std::ptr::NonNull;
+    use std::sync::atomic::AtomicU32;
+
+    const MAX_TAPS: usize = 16;
+    const AGG_PREFIX: &str = "openNook Mixer";
+    const BUFFER_FRAMES: u32 = 512;
+
+    static TAP_GAINS: [AtomicU32; MAX_TAPS] = [const { AtomicU32::new(0) }; MAX_TAPS];
+    static TAP_PEAKS: [AtomicU32; MAX_TAPS] = [const { AtomicU32::new(0) }; MAX_TAPS];
+    static TAP_COUNT: AtomicU32 = AtomicU32::new(0);
+    static TAP_KEYS: Mutex<Vec<String>> = Mutex::new(Vec::new());
+
+    pub struct Engine {
+        watching: bool,
+        pipeline: Option<Pipeline>,
+        processes: Vec<RawProcess>,
+        running_listeners: Vec<AudioObjectID>,
+    }
+
+    impl Default for Engine {
+        fn default() -> Self {
+            Self {
+                watching: false,
+                pipeline: None,
+                processes: Vec::new(),
+                running_listeners: Vec::new(),
+            }
+        }
+    }
+
+    struct Pipeline {
+        taps: Vec<AudioObjectID>,
+        agg: AudioObjectID,
+        proc_id: AudioDeviceIOProcID,
+        started: bool,
+    }
+
+    impl Drop for Pipeline {
+        fn drop(&mut self) {
+            unsafe { teardown(self) }
+        }
+    }
+
+    pub fn process_taps_supported() -> bool {
+        unsafe {
+            let info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+            if info.is_null() {
+                return false;
+            }
+            #[repr(C)]
+            struct NsVer {
+                major: isize,
+                minor: isize,
+                patch: isize,
+            }
+            let ver = NsVer {
+                major: 14,
+                minor: 4,
+                patch: 0,
+            };
+            let ok: bool = msg_send![info, isOperatingSystemAtLeastVersion: ver];
+            ok
+        }
+    }
+
+    pub fn cleanup_orphans() {
+        let devices = property_ids(kAudioObjectSystemObject, kAudioHardwarePropertyDevices);
+        for id in devices {
+            if let Some(name) = read_cf_string(id, kAudioObjectPropertyName) {
+                if name.starts_with(AGG_PREFIX) {
+                    log::info!("mixer: destroying orphaned aggregate {name}");
+                    unsafe {
+                        AudioHardwareDestroyAggregateDevice(id);
+                    }
+                }
+            }
+        }
+    }
+
+    impl Engine {
+        pub fn ensure_watchers(&mut self) {
+            if self.watching || !process_taps_supported() {
+                return;
+            }
+            add_listener(kAudioObjectSystemObject, kAudioHardwarePropertyProcessObjectList);
+            add_listener(
+                kAudioObjectSystemObject,
+                kAudioHardwarePropertyDefaultOutputDevice,
+            );
+            self.watching = true;
+        }
+
+        pub fn stop_watchers(&mut self) {
+            if !self.watching {
+                return;
+            }
+            remove_listener(kAudioObjectSystemObject, kAudioHardwarePropertyProcessObjectList);
+            remove_listener(
+                kAudioObjectSystemObject,
+                kAudioHardwarePropertyDefaultOutputDevice,
+            );
+            for id in self.running_listeners.drain(..) {
+                remove_listener(id, kAudioProcessPropertyIsRunningOutput);
+            }
+            self.watching = false;
+        }
+
+        pub fn refresh_processes(&mut self) -> Vec<RawProcess> {
+            let ids = property_ids(kAudioObjectSystemObject, kAudioHardwarePropertyProcessObjectList);
+            let mut next_listeners = Vec::new();
+            let mut procs = Vec::new();
+            for object_id in ids {
+                if !self.running_listeners.contains(&object_id) {
+                    add_listener(object_id, kAudioProcessPropertyIsRunningOutput);
+                }
+                next_listeners.push(object_id);
+                let pid = read_i32(object_id, kAudioProcessPropertyPID).unwrap_or(0);
+                let bundle = read_cf_string(object_id, kAudioProcessPropertyBundleID).unwrap_or_default();
+                let running = read_u32(object_id, kAudioProcessPropertyIsRunningOutput).unwrap_or(0) != 0;
+                let (name, responsible) = identity_for_pid(pid, &bundle);
+                procs.push(RawProcess {
+                    pid,
+                    object_id,
+                    bundle_id: bundle,
+                    name,
+                    running_output: running,
+                    responsible_bundle: responsible,
+                });
+            }
+            for old in &self.running_listeners {
+                if !next_listeners.contains(old) {
+                    remove_listener(*old, kAudioProcessPropertyIsRunningOutput);
+                }
+            }
+            self.running_listeners = next_listeners;
+            self.processes = procs.clone();
+            procs
+        }
+
+        pub fn teardown_pipeline(&mut self) {
+            self.pipeline = None;
+            TAP_COUNT.store(0, Ordering::Relaxed);
+            if let Ok(mut keys) = TAP_KEYS.lock() {
+                keys.clear();
+            }
+        }
+
+        pub fn sync_pipeline(&mut self, gains: &GainMap, apps: &[MixerApp]) -> Result<(), String> {
+            let needed: Vec<&MixerApp> = apps
+                .iter()
+                .filter(|app| !is_unity(gains.get(&app.bundle_id)) && !app.object_ids.is_empty())
+                .collect();
+            if needed.is_empty() {
+                self.teardown_pipeline();
+                return Ok(());
+            }
+            if needed.len() > MAX_TAPS {
+                return Err("too many tapped apps".into());
+            }
+            // Rebuild whenever the set of tapped apps or the default device changes.
+            self.teardown_pipeline();
+            self.pipeline = Some(build_pipeline(&needed, gains)?);
+            Ok(())
+        }
+    }
+
+    fn build_pipeline(apps: &[&MixerApp], gains: &GainMap) -> Result<Pipeline, String> {
+        let default_out = default_output_device().ok_or("no default output")?;
+        let device_uid = read_cf_string(default_out, kAudioDevicePropertyDeviceUID)
+            .ok_or("default output has no uid")?;
+
+        let mut taps = Vec::new();
+        let mut tap_uids = Vec::new();
+        let mut keys = Vec::new();
+        for (i, app) in apps.iter().enumerate() {
+            let tap = create_tap(app).map_err(|err| {
+                if err.contains("-54") || err.to_lowercase().contains("denied") {
+                    format!("permission denied: {err}")
+                } else {
+                    err
+                }
+            })?;
+            let uid = read_cf_string(tap, kAudioTapPropertyUID).unwrap_or_default();
+            if uid.is_empty() {
+                unsafe {
+                    AudioHardwareDestroyProcessTap(tap);
+                }
+                return Err("tap has no uid".into());
+            }
+            TAP_GAINS[i].store(gains.get(&app.bundle_id).to_bits(), Ordering::Relaxed);
+            TAP_PEAKS[i].store(0, Ordering::Relaxed);
+            keys.push(app.bundle_id.clone());
+            taps.push(tap);
+            tap_uids.push(uid);
+        }
+        TAP_COUNT.store(taps.len() as u32, Ordering::Relaxed);
+        if let Ok(mut slot) = TAP_KEYS.lock() {
+            *slot = keys;
+        }
+
+        let dict = aggregate_description(&device_uid, &tap_uids);
+        let cf_dict: &CFDictionary =
+            unsafe { &*(objc2::rc::Retained::as_ptr(&dict) as *const CFDictionary) };
+        let mut agg: AudioObjectID = 0;
+        let status =
+            unsafe { AudioHardwareCreateAggregateDevice(cf_dict, NonNull::from(&mut agg)) };
+        if status != 0 || agg == 0 {
+            for tap in taps {
+                unsafe {
+                    AudioHardwareDestroyProcessTap(tap);
+                }
+            }
+            return Err(format!("create aggregate failed ({status})"));
+        }
+        set_buffer_frames(agg, BUFFER_FRAMES);
+
+        let mut proc_id: AudioDeviceIOProcID = None;
+        let status = unsafe {
+            AudioDeviceCreateIOProcID(agg, Some(io_proc), std::ptr::null_mut(), &mut proc_id)
+        };
+        if status != 0 || proc_id.is_none() {
+            unsafe {
+                AudioHardwareDestroyAggregateDevice(agg);
+            }
+            for tap in taps {
+                unsafe {
+                    AudioHardwareDestroyProcessTap(tap);
+                }
+            }
+            return Err(format!("create IOProc failed ({status})"));
+        }
+        let status = unsafe { AudioDeviceStart(agg, proc_id) };
+        if status != 0 {
+            unsafe {
+                AudioDeviceDestroyIOProcID(agg, proc_id);
+                AudioHardwareDestroyAggregateDevice(agg);
+            }
+            for tap in taps {
+                unsafe {
+                    AudioHardwareDestroyProcessTap(tap);
+                }
+            }
+            return Err(format!("start IOProc failed ({status})"));
+        }
+
+        Ok(Pipeline {
+            taps,
+            agg,
+            proc_id,
+            started: true,
+        })
+    }
+
+    fn create_tap(app: &MixerApp) -> Result<AudioObjectID, String> {
+        let nums: Vec<objc2::rc::Retained<NSNumber>> = app
+            .object_ids
+            .iter()
+            .map(|id| NSNumber::new_u32(*id))
+            .collect();
+        let refs: Vec<&NSNumber> = nums.iter().map(|n| n.as_ref()).collect();
+        let array = NSArray::from_slice(&refs);
+        let desc = unsafe {
+            CATapDescription::initStereoMixdownOfProcesses(CATapDescription::alloc(), &array)
+        };
+        unsafe {
+            desc.setName(&NSString::from_str(&format!("{AGG_PREFIX} {}", app.bundle_id)));
+            desc.setPrivate(true);
+            desc.setMuteBehavior(CATapMuteBehavior::MutedWhenTapped);
+        }
+        let mut tap: AudioObjectID = 0;
+        let status = unsafe { AudioHardwareCreateProcessTap(Some(&desc), &mut tap) };
+        if status != 0 || tap == 0 {
+            return Err(format!("create tap failed ({status})"));
+        }
+        Ok(tap)
+    }
+
+    fn aggregate_description(
+        device_uid: &str,
+        tap_uids: &[String],
+    ) -> objc2::rc::Retained<NSDictionary<NSString, AnyObject>> {
+        let device = NSString::from_str(device_uid);
+        let sub = NSDictionary::<NSString, AnyObject>::from_slices(
+            &[&*ns(kAudioSubDeviceUIDKey)],
+            &[&device],
+        );
+        let sub_list = NSArray::from_retained_slice(&[sub]);
+
+        let drift = NSNumber::new_i32(1);
+        let mut tap_dicts = Vec::new();
+        for uid in tap_uids {
+            let uid_ns = NSString::from_str(uid);
+            let dict = NSDictionary::<NSString, AnyObject>::from_slices(
+                &[
+                    &*ns(kAudioSubTapUIDKey),
+                    &*ns(kAudioSubTapDriftCompensationKey),
+                ],
+                &[&uid_ns, &drift],
+            );
+            tap_dicts.push(dict);
+        }
+        let tap_list = NSArray::from_retained_slice(&tap_dicts);
+
+        let name = NSString::from_str(&format!("{AGG_PREFIX} {}", random_uid()));
+        let uid = NSString::from_str(&random_uid());
+        let yes = NSNumber::new_i32(1);
+        NSDictionary::<NSString, AnyObject>::from_slices(
+            &[
+                &*ns(kAudioAggregateDeviceNameKey),
+                &*ns(kAudioAggregateDeviceUIDKey),
+                &*ns(kAudioAggregateDeviceIsPrivateKey),
+                &*ns(kAudioAggregateDeviceTapAutoStartKey),
+                &*ns(kAudioAggregateDeviceSubDeviceListKey),
+                &*ns(kAudioAggregateDeviceTapListKey),
+            ],
+            &[&name, &uid, &yes, &yes, &sub_list, &tap_list],
+        )
+    }
+
+    fn ns(key: &CStr) -> objc2::rc::Retained<NSString> {
+        NSString::from_str(key.to_str().unwrap_or_default())
+    }
+
+    fn random_uid() -> String {
+        NSUUID::new().UUIDString().to_string()
+    }
+
+    fn default_output_device() -> Option<AudioObjectID> {
+        read_u32(
+            kAudioObjectSystemObject,
+            kAudioHardwarePropertyDefaultOutputDevice,
+        )
+    }
+
+    fn set_buffer_frames(device: AudioObjectID, frames: u32) {
+        let address = address(kAudioDevicePropertyBufferFrameSize);
+        let mut frames = frames;
+        let size = std::mem::size_of::<u32>() as u32;
+        unsafe {
+            AudioObjectSetPropertyData(
+                device,
+                NonNull::from(&address),
+                0,
+                std::ptr::null(),
+                size,
+                NonNull::from(&mut frames).cast::<c_void>(),
+            );
+        }
+    }
+
+    unsafe fn teardown(pipeline: &mut Pipeline) {
+        if pipeline.started {
+            AudioDeviceStop(pipeline.agg, pipeline.proc_id);
+            pipeline.started = false;
+        }
+        if pipeline.proc_id.is_some() {
+            AudioDeviceDestroyIOProcID(pipeline.agg, pipeline.proc_id);
+            pipeline.proc_id = None;
+        }
+        if pipeline.agg != 0 {
+            AudioHardwareDestroyAggregateDevice(pipeline.agg);
+            pipeline.agg = 0;
+        }
+        for tap in pipeline.taps.drain(..) {
+            if tap != 0 {
+                AudioHardwareDestroyProcessTap(tap);
+            }
+        }
+    }
+
+    unsafe extern "C-unwind" fn io_proc(
+        _device: AudioObjectID,
+        _now: NonNull<AudioTimeStamp>,
+        in_data: NonNull<AudioBufferList>,
+        _in_time: NonNull<AudioTimeStamp>,
+        out_data: NonNull<AudioBufferList>,
+        _out_time: NonNull<AudioTimeStamp>,
+        _client: *mut c_void,
+    ) -> i32 {
+        let _ = std::panic::catch_unwind(|| mix_buffers(in_data, out_data));
+        0
+    }
+
+    fn mix_buffers(in_data: NonNull<AudioBufferList>, out_data: NonNull<AudioBufferList>) {
+        unsafe {
+            let output = out_data.as_ref();
+            let out_bufs = std::slice::from_raw_parts_mut(
+                output.mBuffers.as_ptr() as *mut objc2_core_audio_types::AudioBuffer,
+                output.mNumberBuffers as usize,
+            );
+            for buf in out_bufs.iter_mut() {
+                if buf.mData.is_null() {
+                    continue;
+                }
+                std::ptr::write_bytes(buf.mData, 0, buf.mDataByteSize as usize);
+            }
+            let input = in_data.as_ref();
+            let in_bufs = std::slice::from_raw_parts(
+                input.mBuffers.as_ptr(),
+                input.mNumberBuffers as usize,
+            );
+            let n = TAP_COUNT.load(Ordering::Relaxed) as usize;
+            for (i, buf) in in_bufs.iter().enumerate() {
+                if buf.mData.is_null() {
+                    continue;
+                }
+                let gain = f32::from_bits(TAP_GAINS[i.min(n.saturating_sub(1).min(MAX_TAPS - 1))].load(Ordering::Relaxed));
+                let count = buf.mDataByteSize as usize / std::mem::size_of::<f32>();
+                let samples = std::slice::from_raw_parts(buf.mData as *const f32, count);
+                let mut peak = 0.0f32;
+                if let Some(out) = out_bufs.first_mut() {
+                    if !out.mData.is_null() {
+                        let out_count = out.mDataByteSize as usize / std::mem::size_of::<f32>();
+                        let dest = std::slice::from_raw_parts_mut(out.mData as *mut f32, out_count);
+                        let n = count.min(out_count);
+                        for j in 0..n {
+                            let s = scale_sample(samples[j], gain);
+                            let a = s.abs();
+                            if a > peak {
+                                peak = a;
+                            }
+                            dest[j] = (dest[j] + s).clamp(-1.0, 1.0);
+                        }
+                    }
+                }
+                if i < MAX_TAPS {
+                    TAP_PEAKS[i].store(peak.to_bits(), Ordering::Relaxed);
+                }
+            }
+        }
+    }
+
+    pub fn copy_levels(apps: &mut [MixerApp]) -> bool {
+        let keys = TAP_KEYS.lock().unwrap_or_else(|e| e.into_inner());
+        let mut changed = false;
+        for app in apps.iter_mut() {
+            let peak = keys
+                .iter()
+                .position(|k| k == &app.bundle_id)
+                .and_then(|i| TAP_PEAKS.get(i))
+                .map(|a| f32::from_bits(a.load(Ordering::Relaxed)))
+                .unwrap_or(0.0);
+            let next = (app.level * 0.72 + peak * 0.28).clamp(0.0, 1.0);
+            if (next - app.level).abs() > 0.012 {
+                app.level = next;
+                changed = true;
+            }
+        }
+        changed
+    }
+
+    fn identity_for_pid(pid: i32, bundle: &str) -> (String, Option<String>) {
+        let name = running_app_name(pid).unwrap_or_else(|| display_name_for_bundle(bundle));
+        let responsible = responsible_pid(pid)
+            .filter(|r| *r != pid)
+            .and_then(running_app_bundle);
+        (name, responsible)
+    }
+
+    fn running_app_name(pid: i32) -> Option<String> {
+        unsafe {
+            let app: *mut AnyObject = msg_send![
+                class!(NSRunningApplication),
+                runningApplicationWithProcessIdentifier: pid
+            ];
+            if app.is_null() {
+                return None;
+            }
+            let name: *mut AnyObject = msg_send![app, localizedName];
+            nsstring_to_rust(name)
+        }
+    }
+
+    fn running_app_bundle(pid: i32) -> Option<String> {
+        unsafe {
+            let app: *mut AnyObject = msg_send![
+                class!(NSRunningApplication),
+                runningApplicationWithProcessIdentifier: pid
+            ];
+            if app.is_null() {
+                return None;
+            }
+            let ident: *mut AnyObject = msg_send![app, bundleIdentifier];
+            nsstring_to_rust(ident)
+        }
+    }
+
+    fn nsstring_to_rust(s: *mut AnyObject) -> Option<String> {
+        if s.is_null() {
+            return None;
+        }
+        unsafe {
+            let ptr: *const i8 = msg_send![s, UTF8String];
+            if ptr.is_null() {
+                return None;
+            }
+            CStr::from_ptr(ptr).to_str().ok().map(|s| s.to_string())
+        }
+    }
+
+    fn responsible_pid(pid: i32) -> Option<i32> {
+        unsafe {
+            extern "C" {
+                fn dlsym(handle: *mut c_void, name: *const i8) -> *mut c_void;
+            }
+            const RTLD_DEFAULT: *mut c_void = -2isize as *mut c_void;
+            let sym = dlsym(
+                RTLD_DEFAULT,
+                b"responsibility_get_pid_responsible_for_pid\0".as_ptr() as *const i8,
+            );
+            if sym.is_null() {
+                return None;
+            }
+            let f: unsafe extern "C" fn(i32) -> i32 = std::mem::transmute(sym);
+            let parent = f(pid);
+            if parent > 0 {
+                Some(parent)
+            } else {
+                None
+            }
+        }
+    }
+
+    fn address(selector: u32) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress {
+            mSelector: selector,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain,
+        }
+    }
+
+    fn add_listener(object: AudioObjectID, selector: u32) {
+        let addr = address(selector);
+        unsafe {
+            AudioObjectAddPropertyListener(object, NonNull::from(&addr), Some(on_property), std::ptr::null_mut());
+        }
+    }
+
+    fn remove_listener(object: AudioObjectID, selector: u32) {
+        let addr = address(selector);
+        unsafe {
+            AudioObjectRemovePropertyListener(
+                object,
+                NonNull::from(&addr),
+                Some(on_property),
+                std::ptr::null_mut(),
+            );
+        }
+    }
+
+    unsafe extern "C" fn on_property(
+        _object: AudioObjectID,
+        _n: u32,
+        _addresses: NonNull<AudioObjectPropertyAddress>,
+        _client: *mut c_void,
+    ) -> i32 {
+        super::DIRTY.store(true, Ordering::Relaxed);
+        super::bump();
+        0
+    }
+
+    fn property_ids(object: AudioObjectID, selector: u32) -> Vec<AudioObjectID> {
+        let addr = address(selector);
+        let mut size = 0u32;
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(
+                object,
+                NonNull::from(&addr),
+                0,
+                std::ptr::null(),
+                NonNull::from(&mut size),
+            )
+        };
+        if status != 0 || size == 0 {
+            return Vec::new();
+        }
+        let count = size as usize / std::mem::size_of::<AudioObjectID>();
+        let mut ids = vec![0u32; count];
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                NonNull::from(&addr),
+                0,
+                std::ptr::null(),
+                NonNull::from(&mut size),
+                NonNull::from(ids.as_mut_ptr()).cast::<c_void>(),
+            )
+        };
+        if status != 0 {
+            return Vec::new();
+        }
+        ids.into_iter().filter(|id| *id != 0).collect()
+    }
+
+    fn read_u32(object: AudioObjectID, selector: u32) -> Option<u32> {
+        let addr = address(selector);
+        let mut value = 0u32;
+        let mut size = std::mem::size_of::<u32>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                NonNull::from(&addr),
+                0,
+                std::ptr::null(),
+                NonNull::from(&mut size),
+                NonNull::from(&mut value).cast::<c_void>(),
+            )
+        };
+        (status == 0).then_some(value)
+    }
+
+    fn read_i32(object: AudioObjectID, selector: u32) -> Option<i32> {
+        read_u32(object, selector).map(|v| v as i32)
+    }
+
+    fn read_cf_string(object: AudioObjectID, selector: u32) -> Option<String> {
+        let addr = address(selector);
+        let mut cf: *const CFString = std::ptr::null();
+        let mut size = std::mem::size_of::<*const CFString>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                NonNull::from(&addr),
+                0,
+                std::ptr::null(),
+                NonNull::from(&mut size),
+                NonNull::from(&mut cf).cast::<c_void>(),
+            )
+        };
+        if status != 0 {
+            return None;
+        }
+        let cf = NonNull::new(cf as *mut CFString)?;
+        let owned = unsafe { CFRetained::from_raw(cf) };
+        Some(owned.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[test]
+    fn gain_map_defaults_to_unity() {
+        let map = GainMap::default();
+        assert!(is_unity(map.get("com.spotify.client")));
+        assert!(!map.has_active());
+        assert!(map.active_ids().is_empty());
+    }
+
+    #[test]
+    fn gain_map_set_reset_and_persist() {
+        let mut map = GainMap::default();
+        map.set("com.spotify.client", 0.4);
+        map.set("com.apple.Music", 1.0);
+        map.set("  ", 0.2);
+        assert!((map.get("com.spotify.client") - 0.4).abs() < f32::EPSILON);
+        assert!(is_unity(map.get("com.apple.Music")));
+        assert!(!map.has_active() || map.active_ids() == ["com.spotify.client"]);
+        let persisted = map.to_persist();
+        assert_eq!(persisted.len(), 1);
+        assert!((persisted["com.spotify.client"] - 0.4).abs() < f32::EPSILON);
+        map.reset("com.spotify.client");
+        assert!(!map.has_active());
+        let restored = GainMap::from_persist(persisted);
+        assert!((restored.get("com.spotify.client") - 0.4).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn gain_map_mute_remembers_previous_level() {
+        let mut map = GainMap::default();
+        map.set("com.apple.Safari", 0.6);
+        map.toggle_mute("com.apple.Safari");
+        assert!(map.is_muted("com.apple.Safari"));
+        assert!(map.get("com.apple.Safari") <= MUTE_EPS);
+        map.toggle_mute("com.apple.Safari");
+        assert!((map.get("com.apple.Safari") - 0.6).abs() < f32::EPSILON);
+        map.toggle_mute("com.unknown.app");
+        assert!(map.is_muted("com.unknown.app"));
+        map.toggle_mute("com.unknown.app");
+        assert!(is_unity(map.get("com.unknown.app")));
+    }
+
+    #[test]
+    fn gain_map_reset_all_clears_active() {
+        let mut map = GainMap::default();
+        map.set("a", 0.2);
+        map.set("b", 0.0);
+        assert!(map.has_active());
+        map.reset_all();
+        assert!(!map.has_active());
+        assert!(is_unity(map.get("a")));
+    }
+
+    #[test]
+    fn gain_map_clamps_and_rejects_nan() {
+        let mut map = GainMap::default();
+        map.set("x", 9.0);
+        assert!((map.get("x") - GAIN_MAX).abs() < f32::EPSILON);
+        map.set("x", f32::NAN);
+        assert!(is_unity(map.get("x")));
+    }
+
+    #[test]
+    fn scale_sample_unity_and_limiter() {
+        assert_eq!(scale_sample(0.5, 1.0), 0.5);
+        assert_eq!(scale_sample(0.5, 0.0), 0.0);
+        assert!(scale_sample(0.9, 1.5) < 0.9 * 1.5);
+        assert!(scale_sample(2.0, 1.0) <= 1.0);
+        assert_eq!(scale_sample(f32::NAN, 1.0), 0.0);
+    }
+
+    #[test]
+    fn grouping_maps_webkit_and_browser_helpers() {
+        assert_eq!(canonical_bundle_id("com.apple.WebKit.GPU"), "com.apple.Safari");
+        assert_eq!(
+            canonical_bundle_id("com.apple.WebKit.WebContent"),
+            "com.apple.Safari"
+        );
+        assert_eq!(
+            canonical_bundle_id("com.google.Chrome.helper.gpu"),
+            "com.google.Chrome"
+        );
+        assert_eq!(
+            canonical_bundle_id("com.microsoft.edgemac.helper"),
+            "com.microsoft.edgemac"
+        );
+        assert_eq!(
+            canonical_bundle_id("com.google.Chrome.canary.helper"),
+            "com.google.Chrome.canary"
+        );
+        assert_eq!(canonical_bundle_id("com.spotify.client"), "com.spotify.client");
+        assert!(is_helper_bundle("com.apple.WebKit.GPU"));
+        assert!(!is_helper_bundle("com.apple.Safari"));
+    }
+
+    #[test]
+    fn grouping_uses_responsible_parent_for_helpers() {
+        assert_eq!(
+            group_key("com.apple.WebKit.GPU", Some("com.apple.Safari")),
+            "com.apple.Safari"
+        );
+        assert_eq!(
+            group_key(
+                "com.figma.Desktop.helper",
+                Some("com.figma.Desktop")
+            ),
+            "com.figma.Desktop"
+        );
+        assert_eq!(
+            group_key("com.spotify.client", Some("com.apple.Safari")),
+            "com.spotify.client"
+        );
+    }
+
+    #[test]
+    fn grouping_merges_helper_pids_into_one_row() {
+        let gains = GainMap::from_persist(BTreeMap::from([(
+            "com.apple.Safari".into(),
+            0.5,
+        )]));
+        let apps = group_playing_apps(
+            &[
+                RawProcess {
+                    pid: 11,
+                    object_id: 100,
+                    bundle_id: "com.apple.WebKit.GPU".into(),
+                    name: "WebKit GPU".into(),
+                    running_output: true,
+                    responsible_bundle: Some("com.apple.Safari".into()),
+                },
+                RawProcess {
+                    pid: 12,
+                    object_id: 101,
+                    bundle_id: "com.apple.Safari".into(),
+                    name: "Safari".into(),
+                    running_output: true,
+                    responsible_bundle: None,
+                },
+                RawProcess {
+                    pid: 13,
+                    object_id: 102,
+                    bundle_id: "com.apple.finder".into(),
+                    name: "Finder".into(),
+                    running_output: false,
+                    responsible_bundle: None,
+                },
+            ],
+            &gains,
+        );
+        assert_eq!(apps.len(), 1);
+        assert_eq!(apps[0].bundle_id, "com.apple.Safari");
+        assert_eq!(apps[0].name, "Safari");
+        assert_eq!(apps[0].pids, vec![11, 12]);
+        assert!((apps[0].gain - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn display_names_cover_common_players() {
+        assert_eq!(display_name_for_bundle("com.spotify.client"), "Spotify");
+        assert_eq!(display_name_for_bundle("com.apple.Safari"), "Safari");
+        assert_eq!(display_name_for_bundle("org.videolan.vlc"), "VLC");
+        assert_eq!(display_name_for_bundle("com.example.FooApp"), "FooApp");
+    }
+
+    #[test]
+    fn version_gate_matches_14_4_floor() {
+        assert!(version_at_least(14, 4, 0, 14, 4, 0));
+        assert!(version_at_least(15, 0, 0, 14, 4, 0));
+        assert!(version_at_least(14, 5, 1, 14, 4, 0));
+        assert!(!version_at_least(14, 3, 9, 14, 4, 0));
+        assert!(!version_at_least(13, 6, 0, 14, 4, 0));
+    }
+
+    #[test]
+    fn tcc_preprompt_explains_recording_is_not_saved() {
+        assert!(TCC_PREPROMPT.contains("does not save"));
+        assert!(TCC_PREPROMPT.contains("recording"));
+        assert!(TCC_PREPROMPT.contains("slider"));
+        assert_eq!(
+            capture_status_label(CaptureStatus::Unavailable),
+            "Requires macOS 14.4 or later"
+        );
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct PersistShape {
+        gains: BTreeMap<String, f32>,
+    }
+
+    #[test]
+    fn persist_shape_round_trips_non_unity_only() {
+        let mut map = GainMap::default();
+        map.set("com.spotify.client", 0.25);
+        map.set("com.apple.Music", 1.0);
+        let blob = PersistShape {
+            gains: map.to_persist(),
+        };
+        let json = serde_json::to_string(&blob).unwrap();
+        let parsed: PersistShape = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.gains.len(), 1);
+        let restored = GainMap::from_persist(parsed.gains);
+        assert!((restored.get("com.spotify.client") - 0.25).abs() < f32::EPSILON);
+        assert!(is_unity(restored.get("com.apple.Music")));
+    }
+}

--- a/crates/nook-core/src/mixer.rs
+++ b/crates/nook-core/src/mixer.rs
@@ -4,6 +4,11 @@
 //! creates a Core Audio process tap (macOS 14.4+), which is a capture object
 //! and triggers the system-audio-recording consent prompt. With every gain at
 //! unity there are no taps, no aggregate device, and no IOProc.
+//!
+//! The tap path uses public HAL + `CATapDescription` APIs from objc2-core-audio
+//! 0.3.2 (objc2 0.6). Nothing private is required. Helper grouping optionally
+//! calls `responsibility_get_pid_responsible_for_pid` via `dlsym` and falls
+//! back to bundle-id heuristics when that symbol is absent.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -578,19 +583,25 @@ pub fn pump() {
             state.inner.ensure_watchers();
             let procs = state.inner.refresh_processes();
             state.apps = group_playing_apps(&procs, &state.gains);
-            let running_keys: Vec<String> = state.apps.iter().map(|a| a.bundle_id.clone()).collect();
+            let running_keys: Vec<String> =
+                state.apps.iter().map(|a| a.bundle_id.clone()).collect();
             if state.ack {
-                if let Err(err) = state.inner.sync_pipeline(&state.gains, &state.apps) {
+                let MixerState {
+                    inner,
+                    gains,
+                    apps,
+                    denied,
+                    ..
+                } = &mut *state;
+                if let Err(err) = inner.sync_pipeline(gains, apps) {
                     log::warn!("mixer pipeline: {err}");
                     if err.contains("denied") || err.contains("permission") || err.contains("-54") {
-                        state.denied = true;
+                        *denied = true;
                     }
                 }
             }
             if !state.gains.has_active()
-                && !running_keys
-                    .iter()
-                    .any(|id| !is_unity(state.gains.get(id)))
+                && !running_keys.iter().any(|id| !is_unity(state.gains.get(id)))
             {
                 state.inner.teardown_pipeline();
             }
@@ -626,9 +637,17 @@ pub fn copy_levels(apps: &mut [MixerApp]) -> bool {
 
 #[cfg(target_os = "macos")]
 mod macos {
+    //! Core Audio process-tap engine (macOS 14.4+ public APIs only).
+    //!
+    //! Aligned with objc2 0.6 / objc2-core-audio 0.3.2:
+    //! `kAudioObjectSystemObject` is `c_int`; HAL functions take `NonNull` and
+    //! `extern "C-unwind"` listeners. `CATapDescription::alloc` needs `AnyThread`.
+    //! No private entitlements. `responsibility_get_pid_responsible_for_pid` is
+    //! resolved with `dlsym` and ignored when missing.
+
     use super::*;
     use objc2::runtime::AnyObject;
-    use objc2::{class, msg_send};
+    use objc2::{class, msg_send, AnyThread, Encode, Encoding};
     use objc2_core_audio::{
         kAudioAggregateDeviceIsPrivateKey, kAudioAggregateDeviceNameKey,
         kAudioAggregateDeviceSubDeviceListKey, kAudioAggregateDeviceTapAutoStartKey,
@@ -643,9 +662,8 @@ mod macos {
         AudioDeviceDestroyIOProcID, AudioDeviceIOProcID, AudioDeviceStart, AudioDeviceStop,
         AudioHardwareCreateAggregateDevice, AudioHardwareCreateProcessTap,
         AudioHardwareDestroyAggregateDevice, AudioHardwareDestroyProcessTap,
-        AudioObjectAddPropertyListener, AudioObjectGetPropertyData,
-        AudioObjectGetPropertyDataSize, AudioObjectID, AudioObjectPropertyAddress,
-        AudioObjectPropertyListenerProc, AudioObjectRemovePropertyListener,
+        AudioObjectAddPropertyListener, AudioObjectGetPropertyData, AudioObjectGetPropertyDataSize,
+        AudioObjectID, AudioObjectPropertyAddress, AudioObjectRemovePropertyListener,
         AudioObjectSetPropertyData, CATapDescription, CATapMuteBehavior,
     };
     use objc2_core_audio_types::{AudioBufferList, AudioTimeStamp};
@@ -654,6 +672,24 @@ mod macos {
     use std::ffi::{c_void, CStr};
     use std::ptr::NonNull;
     use std::sync::atomic::AtomicU32;
+
+    /// `kAudioObjectSystemObject` is `c_int` in objc2-core-audio 0.3.2.
+    const SYSTEM_OBJECT: AudioObjectID = kAudioObjectSystemObject as AudioObjectID;
+
+    /// Same layout as Foundation's `NSOperatingSystemVersion` (`NSInteger` triple).
+    #[repr(C)]
+    struct NsVer {
+        major: isize,
+        minor: isize,
+        patch: isize,
+    }
+
+    unsafe impl Encode for NsVer {
+        const ENCODING: Encoding = Encoding::Struct(
+            "NSOperatingSystemVersion",
+            &[isize::ENCODING, isize::ENCODING, isize::ENCODING],
+        );
+    }
 
     const MAX_TAPS: usize = 16;
     const AGG_PREFIX: &str = "openNook Mixer";
@@ -701,12 +737,6 @@ mod macos {
             if info.is_null() {
                 return false;
             }
-            #[repr(C)]
-            struct NsVer {
-                major: isize,
-                minor: isize,
-                patch: isize,
-            }
             let ver = NsVer {
                 major: 14,
                 minor: 4,
@@ -718,7 +748,7 @@ mod macos {
     }
 
     pub fn cleanup_orphans() {
-        let devices = property_ids(kAudioObjectSystemObject, kAudioHardwarePropertyDevices);
+        let devices = property_ids(SYSTEM_OBJECT, kAudioHardwarePropertyDevices);
         for id in devices {
             if let Some(name) = read_cf_string(id, kAudioObjectPropertyName) {
                 if name.starts_with(AGG_PREFIX) {
@@ -736,11 +766,8 @@ mod macos {
             if self.watching || !process_taps_supported() {
                 return;
             }
-            add_listener(kAudioObjectSystemObject, kAudioHardwarePropertyProcessObjectList);
-            add_listener(
-                kAudioObjectSystemObject,
-                kAudioHardwarePropertyDefaultOutputDevice,
-            );
+            add_listener(SYSTEM_OBJECT, kAudioHardwarePropertyProcessObjectList);
+            add_listener(SYSTEM_OBJECT, kAudioHardwarePropertyDefaultOutputDevice);
             self.watching = true;
         }
 
@@ -748,11 +775,8 @@ mod macos {
             if !self.watching {
                 return;
             }
-            remove_listener(kAudioObjectSystemObject, kAudioHardwarePropertyProcessObjectList);
-            remove_listener(
-                kAudioObjectSystemObject,
-                kAudioHardwarePropertyDefaultOutputDevice,
-            );
+            remove_listener(SYSTEM_OBJECT, kAudioHardwarePropertyProcessObjectList);
+            remove_listener(SYSTEM_OBJECT, kAudioHardwarePropertyDefaultOutputDevice);
             for id in self.running_listeners.drain(..) {
                 remove_listener(id, kAudioProcessPropertyIsRunningOutput);
             }
@@ -760,7 +784,7 @@ mod macos {
         }
 
         pub fn refresh_processes(&mut self) -> Vec<RawProcess> {
-            let ids = property_ids(kAudioObjectSystemObject, kAudioHardwarePropertyProcessObjectList);
+            let ids = property_ids(SYSTEM_OBJECT, kAudioHardwarePropertyProcessObjectList);
             let mut next_listeners = Vec::new();
             let mut procs = Vec::new();
             for object_id in ids {
@@ -769,8 +793,10 @@ mod macos {
                 }
                 next_listeners.push(object_id);
                 let pid = read_i32(object_id, kAudioProcessPropertyPID).unwrap_or(0);
-                let bundle = read_cf_string(object_id, kAudioProcessPropertyBundleID).unwrap_or_default();
-                let running = read_u32(object_id, kAudioProcessPropertyIsRunningOutput).unwrap_or(0) != 0;
+                let bundle =
+                    read_cf_string(object_id, kAudioProcessPropertyBundleID).unwrap_or_default();
+                let running =
+                    read_u32(object_id, kAudioProcessPropertyIsRunningOutput).unwrap_or(0) != 0;
                 let (name, responsible) = identity_for_pid(pid, &bundle);
                 procs.push(RawProcess {
                     pid,
@@ -870,7 +896,12 @@ mod macos {
 
         let mut proc_id: AudioDeviceIOProcID = None;
         let status = unsafe {
-            AudioDeviceCreateIOProcID(agg, Some(io_proc), std::ptr::null_mut(), &mut proc_id)
+            AudioDeviceCreateIOProcID(
+                agg,
+                Some(io_proc),
+                std::ptr::null_mut(),
+                NonNull::from(&mut proc_id),
+            )
         };
         if status != 0 || proc_id.is_none() {
             unsafe {
@@ -917,9 +948,13 @@ mod macos {
             CATapDescription::initStereoMixdownOfProcesses(CATapDescription::alloc(), &array)
         };
         unsafe {
-            desc.setName(&NSString::from_str(&format!("{AGG_PREFIX} {}", app.bundle_id)));
+            desc.setName(&NSString::from_str(&format!(
+                "{AGG_PREFIX} {}",
+                app.bundle_id
+            )));
             desc.setPrivate(true);
-            desc.setMuteBehavior(CATapMuteBehavior::MutedWhenTapped);
+            // CATapMutedWhenTapped — silence the process while the tap is live.
+            desc.setMuteBehavior(CATapMuteBehavior(2));
         }
         let mut tap: AudioObjectID = 0;
         let status = unsafe { AudioHardwareCreateProcessTap(Some(&desc), &mut tap) };
@@ -980,10 +1015,7 @@ mod macos {
     }
 
     fn default_output_device() -> Option<AudioObjectID> {
-        read_u32(
-            kAudioObjectSystemObject,
-            kAudioHardwarePropertyDefaultOutputDevice,
-        )
+        read_u32(SYSTEM_OBJECT, kAudioHardwarePropertyDefaultOutputDevice)
     }
 
     fn set_buffer_frames(device: AudioObjectID, frames: u32) {
@@ -1049,16 +1081,16 @@ mod macos {
                 std::ptr::write_bytes(buf.mData, 0, buf.mDataByteSize as usize);
             }
             let input = in_data.as_ref();
-            let in_bufs = std::slice::from_raw_parts(
-                input.mBuffers.as_ptr(),
-                input.mNumberBuffers as usize,
-            );
+            let in_bufs =
+                std::slice::from_raw_parts(input.mBuffers.as_ptr(), input.mNumberBuffers as usize);
             let n = TAP_COUNT.load(Ordering::Relaxed) as usize;
             for (i, buf) in in_bufs.iter().enumerate() {
                 if buf.mData.is_null() {
                     continue;
                 }
-                let gain = f32::from_bits(TAP_GAINS[i.min(n.saturating_sub(1).min(MAX_TAPS - 1))].load(Ordering::Relaxed));
+                let gain = f32::from_bits(
+                    TAP_GAINS[i.min(n.saturating_sub(1).min(MAX_TAPS - 1))].load(Ordering::Relaxed),
+                );
                 let count = buf.mDataByteSize as usize / std::mem::size_of::<f32>();
                 let samples = std::slice::from_raw_parts(buf.mData as *const f32, count);
                 let mut peak = 0.0f32;
@@ -1186,7 +1218,12 @@ mod macos {
     fn add_listener(object: AudioObjectID, selector: u32) {
         let addr = address(selector);
         unsafe {
-            AudioObjectAddPropertyListener(object, NonNull::from(&addr), Some(on_property), std::ptr::null_mut());
+            AudioObjectAddPropertyListener(
+                object,
+                NonNull::from(&addr),
+                Some(on_property),
+                std::ptr::null_mut(),
+            );
         }
     }
 
@@ -1202,7 +1239,7 @@ mod macos {
         }
     }
 
-    unsafe extern "C" fn on_property(
+    unsafe extern "C-unwind" fn on_property(
         _object: AudioObjectID,
         _n: u32,
         _addresses: NonNull<AudioObjectPropertyAddress>,
@@ -1237,7 +1274,9 @@ mod macos {
                 0,
                 std::ptr::null(),
                 NonNull::from(&mut size),
-                NonNull::from(ids.as_mut_ptr()).cast::<c_void>(),
+                NonNull::new(ids.as_mut_ptr())
+                    .expect("audio object id buffer")
+                    .cast::<c_void>(),
             )
         };
         if status != 0 {
@@ -1367,7 +1406,10 @@ mod tests {
 
     #[test]
     fn grouping_maps_webkit_and_browser_helpers() {
-        assert_eq!(canonical_bundle_id("com.apple.WebKit.GPU"), "com.apple.Safari");
+        assert_eq!(
+            canonical_bundle_id("com.apple.WebKit.GPU"),
+            "com.apple.Safari"
+        );
         assert_eq!(
             canonical_bundle_id("com.apple.WebKit.WebContent"),
             "com.apple.Safari"
@@ -1384,7 +1426,10 @@ mod tests {
             canonical_bundle_id("com.google.Chrome.canary.helper"),
             "com.google.Chrome.canary"
         );
-        assert_eq!(canonical_bundle_id("com.spotify.client"), "com.spotify.client");
+        assert_eq!(
+            canonical_bundle_id("com.spotify.client"),
+            "com.spotify.client"
+        );
         assert!(is_helper_bundle("com.apple.WebKit.GPU"));
         assert!(!is_helper_bundle("com.apple.Safari"));
     }
@@ -1396,10 +1441,7 @@ mod tests {
             "com.apple.Safari"
         );
         assert_eq!(
-            group_key(
-                "com.figma.Desktop.helper",
-                Some("com.figma.Desktop")
-            ),
+            group_key("com.figma.Desktop.helper", Some("com.figma.Desktop")),
             "com.figma.Desktop"
         );
         assert_eq!(
@@ -1410,10 +1452,7 @@ mod tests {
 
     #[test]
     fn grouping_merges_helper_pids_into_one_row() {
-        let gains = GainMap::from_persist(BTreeMap::from([(
-            "com.apple.Safari".into(),
-            0.5,
-        )]));
+        let gains = GainMap::from_persist(BTreeMap::from([("com.apple.Safari".into(), 0.5)]));
         let apps = group_playing_apps(
             &[
                 RawProcess {

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -17,10 +17,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    Mixer = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +32,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::Mixer,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -44,7 +46,9 @@ impl WidgetModule {
     pub fn default_cells(self) -> u8 {
         match self {
             Self::Calendar | Self::Music => 5,
-            Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
+            Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents | Self::Mixer => {
+                4
+            }
             Self::Timers | Self::Speed | Self::Mirror => 3,
         }
     }
@@ -52,7 +56,9 @@ impl WidgetModule {
     pub fn min_cells(self) -> u8 {
         match self {
             Self::Calendar => 4,
-            Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
+            Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror | Self::Mixer => {
+                3
+            }
             Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
         }
     }
@@ -73,6 +79,7 @@ impl WidgetModule {
 fn default_widget_order() -> Vec<WidgetModule> {
     vec![
         WidgetModule::Music,
+        WidgetModule::Mixer,
         WidgetModule::Calendar,
         WidgetModule::Mirror,
         WidgetModule::Files,
@@ -142,6 +149,8 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default = "default_true")]
+    pub show_mixer: bool,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -231,6 +240,7 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            show_mixer: true,
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +286,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::Mixer => self.show_mixer && crate::mixer::is_available(),
         }
     }
 
@@ -291,6 +302,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::Mixer => self.show_mixer = !self.show_mixer,
         }
     }
 
@@ -611,6 +623,7 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.show_mixer);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +709,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.show_mixer = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook/src/assets/icons/volume-2.svg
+++ b/crates/nook/src/assets/icons/volume-2.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path d="M15.54 8.46a5 5 0 0 1 0 7.07"/><path d="M19.07 4.93a10 10 0 0 1 0 14.14"/>
+</svg>

--- a/crates/nook/src/assets/icons/volume-x.svg
+++ b/crates/nook/src/assets/icons/volume-x.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><line x1="22" x2="16" y1="9" y2="15"/><line x1="16" x2="22" y1="9" y2="15"/>
+</svg>

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, calendar_card, mixer_card, notes_card, observe_card, reminders_card, speed_card,
+    timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -156,6 +157,10 @@ impl Island {
                         self.settings.cells_for(module),
                         speed_card(self.speed_mbps, self.speed_progress, self.speed_running, cx),
                     ),
+                ),
+                WidgetModule::Mixer if self.settings.is_enabled(WidgetModule::Mixer) => add(
+                    &mut kids,
+                    cell_pane(self.settings.cells_for(module), mixer_card(self, cx)),
                 ),
                 _ => {}
             }

--- a/crates/nook/src/island/media.rs
+++ b/crates/nook/src/island/media.rs
@@ -357,7 +357,7 @@ fn app_badge(bundle_id: Option<&str>, app_name: Option<&str>) -> AnyElement {
         .into_any_element()
 }
 
-fn app_icon_image(
+pub(crate) fn app_icon_image(
     bundle_id: Option<&str>,
     app_name: Option<&str>,
 ) -> Option<std::sync::Arc<Image>> {

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -5,7 +5,7 @@ mod compact;
 mod expanded;
 mod files;
 mod marquee;
-mod media;
+pub(crate) mod media;
 mod render;
 mod settings;
 pub(crate) mod ui;
@@ -94,6 +94,10 @@ pub struct Island {
     /// Bumped on start and on Stop so an in-flight test cannot apply after it
     /// was cancelled (Stop then Run would otherwise take the old result).
     pub speed_gen: u64,
+    pub mixer_apps: Vec<nook_core::mixer::MixerApp>,
+    /// Pending slider value waiting on the TCC pre-prompt.
+    pub mixer_prompt: Option<(String, f32)>,
+    pub(crate) mixer_gen: u64,
     pub last_tick: Instant,
     last_frame: Instant,
     /// Last seen `nook_core::settings::settings_generation()`; the tick loop
@@ -219,6 +223,9 @@ impl Island {
             speed_progress: 0.0,
             speed_running: false,
             speed_gen: 0,
+            mixer_apps: Vec::new(),
+            mixer_prompt: None,
+            mixer_gen: 0,
             last_tick: Instant::now(),
             last_frame: Instant::now(),
             settings_gen: nook_core::settings::settings_generation(),
@@ -330,6 +337,24 @@ impl Island {
                             this.settings = settings;
                         }
                         dirty = true;
+                    }
+                    let mixer_on = this
+                        .settings
+                        .is_enabled(nook_core::settings::WidgetModule::Mixer);
+                    nook_core::mixer::set_enabled(mixer_on);
+                    nook_core::mixer::set_card_visible(
+                        this.expanded && mixer_on && this.tab == Tab::Widgets,
+                    );
+                    nook_core::mixer::pump();
+                    let mixer_gen = nook_core::mixer::generation();
+                    if this.mixer_gen != mixer_gen {
+                        this.mixer_gen = mixer_gen;
+                        this.mixer_apps = nook_core::mixer::snapshot();
+                        dirty = true;
+                    } else if this.expanded && mixer_on && this.tab == Tab::Widgets {
+                        if nook_core::mixer::copy_levels(&mut this.mixer_apps) {
+                            dirty = true;
+                        }
                     }
                     if this.repositioning {
                         this.apply_reposition(mx as f32, my as f32);
@@ -1458,6 +1483,9 @@ mod tests {
             speed_progress: 0.0,
             speed_running: false,
             speed_gen: 0,
+            mixer_apps: Vec::new(),
+            mixer_prompt: None,
+            mixer_gen: 0,
             last_tick: Instant::now(),
             last_frame: Instant::now(),
             settings_gen: 0,

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -1786,8 +1786,17 @@ mod tests {
     #[test]
     fn remaining_cells_saturate_at_zero() {
         let settings = AppSettings::default();
-        assert_eq!(AppSettings::TOTAL_CELLS, 11);
-        assert!(settings.used_cells() >= AppSettings::TOTAL_CELLS);
+        let default_used: u8 = WidgetModule::ALL
+            .iter()
+            .copied()
+            .filter(|module| module.occupies_nook_cells() && settings.is_enabled(*module))
+            .map(WidgetModule::default_cells)
+            .fold(0, u8::saturating_add);
+        assert_eq!(settings.used_cells(), default_used);
+        assert_eq!(
+            settings.remaining_cells(),
+            AppSettings::TOTAL_CELLS.saturating_sub(default_used)
+        );
         assert_eq!(settings.remaining_cells(), 0);
     }
 }

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -131,6 +131,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Mixer => "Mixer",
         }
     }
 
@@ -146,6 +147,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::Mixer => "volume-2",
         }
     }
 
@@ -161,6 +163,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::Mixer => "Per-app volume".into(),
         }
     }
 
@@ -184,6 +187,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Mixer => "Mixer",
         }
     }
 }
@@ -244,7 +248,10 @@ pub(super) struct SettingsView {
 impl SettingsView {
     pub(super) fn new(cx: &mut Context<Self>) -> Self {
         let settings = nook_core::settings::get_app_settings();
-        let module = WidgetModule::from_u8(LAST_MODULE.load(Ordering::Relaxed));
+        let mut module = WidgetModule::from_u8(LAST_MODULE.load(Ordering::Relaxed));
+        if module == WidgetModule::Mixer && !nook_core::mixer::is_available() {
+            module = WidgetModule::Calendar;
+        }
         let min = module.min_cells();
         let max = settings.max_cells_for(module).max(min);
         let (width_slider, width_slider_subscription) = create_width_slider(module, &settings, cx);
@@ -708,6 +715,9 @@ impl SettingsView {
 
         let mut list = Vec::new();
         for module in settings.ordered_widgets() {
+            if module == WidgetModule::Mixer && !nook_core::mixer::is_available() {
+                continue;
+            }
             list.push(self.widget_row(module, settings, cx).into_any_element());
         }
 
@@ -993,6 +1003,34 @@ impl SettingsView {
                         cx,
                         |this, _, cx| {
                             this.browse_metrics(cx);
+                        },
+                    )
+                    .into_any_element(),
+                );
+            }
+            WidgetModule::Mixer => {
+                rows.push(
+                    settings_row("mixer-permission")
+                        .child(label("Permission", theme::BODY, true))
+                        .child(label(
+                            nook_core::mixer::capture_status_label(
+                                nook_core::mixer::capture_status(),
+                            ),
+                            theme::SUBHEADLINE,
+                            false,
+                        ))
+                        .into_any_element(),
+                );
+                rows.push(
+                    action_row(
+                        "mixer-reset",
+                        "Volumes",
+                        "Reset All",
+                        cx,
+                        |_, _, cx| {
+                            nook_core::mixer::reset_all();
+                            nook_core::mixer::pump();
+                            cx.notify();
                         },
                     )
                     .into_any_element(),
@@ -1356,6 +1394,7 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::Mixer => nook_core::mixer::TCC_PREPROMPT.into(),
     }
 }
 
@@ -1727,6 +1766,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "Mixer",
             ]
         );
         assert!(!names

--- a/crates/nook/src/widgets/mixer.rs
+++ b/crates/nook/src/widgets/mixer.rs
@@ -1,0 +1,368 @@
+//! Per-app volume mixer card.
+
+use crate::icons::lucide_color;
+use crate::island::media::app_icon_image;
+use crate::island::ui::{nook_empty, nook_pane, scroll_body};
+use crate::island::Island;
+use crate::theme;
+use gpui::{
+    div, img, prelude::*, px, relative, rgb, rgba, AnyElement, Context, CursorStyle, FontWeight,
+    MouseButton, MouseDownEvent, ObjectFit, SharedString,
+};
+use nook_core::mixer::{self, CaptureStatus, MixerApp, TCC_PREPROMPT, UNITY};
+
+pub(crate) fn mixer_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    nook_pane("nook-mixer").child(
+        div()
+            .flex_1()
+            .min_h(px(0.))
+            .w_full()
+            .flex()
+            .flex_col()
+            .child(mixer_header(island))
+            .child(if island.mixer_prompt.is_some() {
+                preprompt(cx).into_any_element()
+            } else if island.mixer_apps.is_empty() {
+                empty_state(island).into_any_element()
+            } else {
+                app_list(island, cx).into_any_element()
+            }),
+    )
+}
+
+fn mixer_header(island: &Island) -> impl IntoElement {
+    let status = mixer::capture_status();
+    div()
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .justify_between()
+        .pb(px(6.))
+        .child(
+            div()
+                .text_size(px(12.))
+                .line_height(px(16.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::LABEL)
+                .child("Mixer"),
+        )
+        .child(
+            div()
+                .text_size(px(10.))
+                .line_height(px(12.))
+                .text_color(match status {
+                    CaptureStatus::Denied => theme::DESTRUCTIVE,
+                    CaptureStatus::Active => theme::accent(),
+                    _ => theme::TERTIARY_LABEL,
+                })
+                .child(header_caption(island, status)),
+        )
+}
+
+fn header_caption(island: &Island, status: CaptureStatus) -> SharedString {
+    if !island.mixer_apps.is_empty() {
+        let n = island.mixer_apps.len();
+        return if n == 1 {
+            "1 app".into()
+        } else {
+            format!("{n} apps").into()
+        };
+    }
+    mixer::capture_status_label(status).into()
+}
+
+fn empty_state(island: &Island) -> impl IntoElement {
+    let status = mixer::capture_status();
+    match status {
+        CaptureStatus::Denied => nook_empty("triangle-alert", "Audio recording denied"),
+        CaptureStatus::Unavailable => nook_empty("music", "Needs macOS 14.4"),
+        _ if island.mixer_apps.is_empty() => nook_empty("music", "No apps playing"),
+        _ => nook_empty("music", "No apps playing"),
+    }
+}
+
+fn preprompt(cx: &mut Context<Island>) -> impl IntoElement {
+    div()
+        .id("mixer-preprompt")
+        .flex_1()
+        .min_h(px(0.))
+        .flex()
+        .flex_col()
+        .justify_center()
+        .gap(px(8.))
+        .child(
+            div()
+                .text_size(px(11.))
+                .line_height(px(14.))
+                .text_color(theme::SECONDARY_LABEL)
+                .child(TCC_PREPROMPT),
+        )
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(8.))
+                .child(prompt_btn("mixer-cancel", "Cancel", false, cx, |this, cx| {
+                    this.dismiss_mixer_prompt(cx);
+                }))
+                .child(prompt_btn(
+                    "mixer-continue",
+                    "Continue",
+                    true,
+                    cx,
+                    |this, cx| {
+                        this.accept_mixer_prompt(cx);
+                    },
+                )),
+        )
+}
+
+fn prompt_btn(
+    id: &'static str,
+    title: &'static str,
+    accent: bool,
+    cx: &mut Context<Island>,
+    on_click: impl Fn(&mut Island, &mut Context<Island>) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .h(px(24.))
+        .px(px(10.))
+        .rounded(px(8.))
+        .bg(if accent {
+            theme::accent()
+        } else {
+            rgba(0xffffff18)
+        })
+        .flex()
+        .items_center()
+        .justify_center()
+        .cursor(CursorStyle::PointingHand)
+        .hover(|s| s.opacity(0.88))
+        .child(
+            div()
+                .text_size(px(11.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::LABEL)
+                .child(title),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                on_click(this, cx);
+            }),
+        )
+}
+
+fn app_list(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let mut col = div().flex().flex_col().gap(px(8.)).w_full();
+    for app in &island.mixer_apps {
+        col = col.child(app_row(app, cx));
+    }
+    scroll_body("nook-mixer-list", col)
+}
+
+fn app_row(app: &MixerApp, cx: &mut Context<Island>) -> impl IntoElement {
+    let bundle = SharedString::from(app.bundle_id.clone());
+    let mute_bundle = bundle.clone();
+    let gain = app.gain;
+    let muted = app.muted;
+    let level = app.level;
+    let t = (gain / mixer::GAIN_MAX).clamp(0.0, 1.0);
+    div()
+        .id(SharedString::from(format!("mixer-{}", app.bundle_id)))
+        .w_full()
+        .flex()
+        .flex_col()
+        .gap(px(3.))
+        .child(
+            div()
+                .w_full()
+                .flex()
+                .items_center()
+                .gap(px(8.))
+                .child(app_badge(&app.bundle_id, &app.name))
+                .child(
+                    div()
+                        .flex_1()
+                        .min_w(px(0.))
+                        .text_size(px(11.))
+                        .line_height(px(14.))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme::LABEL)
+                        .text_ellipsis()
+                        .child(app.name.clone()),
+                )
+                .child(
+                    div()
+                        .id(SharedString::from(format!("mixer-mute-{}", app.bundle_id)))
+                        .size(px(22.))
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .cursor(CursorStyle::PointingHand)
+                        .opacity(if muted { 0.55 } else { 0.95 })
+                        .hover(|s| s.opacity(1.0))
+                        .child(lucide_color(
+                            if muted { "volume-x" } else { "volume-2" },
+                            14.0,
+                            if muted {
+                                theme::TERTIARY_LABEL
+                            } else {
+                                theme::LABEL
+                            },
+                        ))
+                        .on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                                cx.stop_propagation();
+                                this.toggle_mixer_mute(mute_bundle.as_ref(), cx);
+                            }),
+                        ),
+                ),
+        )
+        .child(gain_slider(bundle, t, cx))
+        .child(vu_meter(level, gain))
+}
+
+fn app_badge(bundle_id: &str, name: &str) -> AnyElement {
+    if let Some(image) = app_icon_image(Some(bundle_id), Some(name)) {
+        return img(image)
+            .size(px(18.))
+            .rounded(px(4.))
+            .object_fit(ObjectFit::Fill)
+            .into_any_element();
+    }
+    div()
+        .size(px(18.))
+        .rounded(px(4.))
+        .bg(rgba(0xffffff14))
+        .flex()
+        .items_center()
+        .justify_center()
+        .child(lucide_color("music", 11.0, theme::SECONDARY_LABEL))
+        .into_any_element()
+}
+
+fn gain_slider(
+    bundle: SharedString,
+    t: f32,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    const SEGMENTS: u32 = 24;
+    let mut hits = div().absolute().inset_0().flex();
+    for i in 0..SEGMENTS {
+        let ratio = (i as f32 + 0.5) / SEGMENTS as f32;
+        let gain = ratio * mixer::GAIN_MAX;
+        let id = bundle.clone();
+        hits = hits.child(
+            div()
+                .id(SharedString::from(format!("mixer-gain-{}-{i}", bundle)))
+                .flex_1()
+                .h_full()
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                        cx.stop_propagation();
+                        this.apply_mixer_gain(id.as_ref(), gain, cx);
+                    }),
+                ),
+        );
+    }
+    div()
+        .relative()
+        .w_full()
+        .h(px(12.))
+        .flex()
+        .items_center()
+        .cursor(CursorStyle::PointingHand)
+        .child(
+            div()
+                .w_full()
+                .h(px(3.))
+                .rounded_full()
+                .bg(rgba(0xffffff26))
+                .child(
+                    div()
+                        .h_full()
+                        .w(relative(t))
+                        .rounded_full()
+                        .bg(if t < (UNITY / mixer::GAIN_MAX) - 0.01 {
+                            theme::accent()
+                        } else {
+                            rgb(0xffffff)
+                        }),
+                ),
+        )
+        .child(hits)
+}
+
+fn vu_meter(level: f32, gain: f32) -> impl IntoElement {
+    let show = !mixer::is_unity(gain) && level > 0.01;
+    div()
+        .w_full()
+        .h(px(2.))
+        .rounded_full()
+        .bg(rgba(0xffffff14))
+        .opacity(if show { 1.0 } else { 0.25 })
+        .child(
+            div()
+                .h_full()
+                .w(relative(level.clamp(0.0, 1.0)))
+                .rounded_full()
+                .bg(theme::accent()),
+        )
+}
+
+impl Island {
+    pub(crate) fn apply_mixer_gain(&mut self, bundle_id: &str, gain: f32, cx: &mut Context<Self>) {
+        if !mixer::capture_acknowledged() {
+            self.mixer_prompt = Some((bundle_id.to_string(), gain));
+            cx.notify();
+            return;
+        }
+        mixer::set_gain(bundle_id, gain);
+        mixer::pump();
+        self.mixer_apps = mixer::snapshot();
+        self.mixer_gen = mixer::generation();
+        cx.notify();
+    }
+
+    pub(crate) fn toggle_mixer_mute(&mut self, bundle_id: &str, cx: &mut Context<Self>) {
+        if !mixer::capture_acknowledged() {
+            let current = self
+                .mixer_apps
+                .iter()
+                .find(|app| app.bundle_id == bundle_id)
+                .map(|app| app.gain)
+                .unwrap_or(UNITY);
+            let next = if current <= 0.001 { UNITY } else { 0.0 };
+            self.mixer_prompt = Some((bundle_id.to_string(), next));
+            cx.notify();
+            return;
+        }
+        mixer::toggle_mute(bundle_id);
+        mixer::pump();
+        self.mixer_apps = mixer::snapshot();
+        self.mixer_gen = mixer::generation();
+        cx.notify();
+    }
+
+    pub(crate) fn accept_mixer_prompt(&mut self, cx: &mut Context<Self>) {
+        let Some((bundle, gain)) = self.mixer_prompt.take() else {
+            return;
+        };
+        mixer::acknowledge_capture();
+        mixer::set_gain(&bundle, gain);
+        mixer::pump();
+        self.mixer_apps = mixer::snapshot();
+        self.mixer_gen = mixer::generation();
+        cx.notify();
+    }
+
+    pub(crate) fn dismiss_mixer_prompt(&mut self, cx: &mut Context<Self>) {
+        self.mixer_prompt = None;
+        cx.notify();
+    }
+}

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -2,6 +2,7 @@
 
 mod agents;
 mod calendar;
+mod mixer;
 mod notes;
 mod notes_editor;
 mod observe;
@@ -13,6 +14,7 @@ pub(crate) use agents::{
     agents_card, compact_left as agents_compact_left, compact_right as agents_compact_right,
 };
 pub(crate) use calendar::calendar_card;
+pub(crate) use mixer::mixer_card;
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};
 pub(crate) use observe::{observe_card, ObserveHover};


### PR DESCRIPTION
## WP12 — Per-app volume mixer

Adds a Mixer widget that lists apps currently producing sound and lets you set per-app gain. On macOS 14.4+ this uses Core Audio process taps (AudioCap pattern): a tap + private aggregate + IOProc is built only while at least one slider is not at 100%, and the whole pipeline is torn down the moment every gain returns to unity.

### Behavior
- **Zero idle when inactive:** no taps, no aggregate, no IOProc while all gains are 1.0. Property listeners register only while the mixer card is open or a saved non-unity gain exists.
- **TCC:** listing playing apps is prompt-free. The first slider move shows an explanatory pre-prompt; creating a tap then triggers `kTCCServiceAudioCapture`. `NSAudioCaptureUsageDescription` is in `Info.plist`.
- **Hide below 14.4:** `WidgetModule::Mixer` is omitted from the island and Settings on older macOS (and on non-macOS).
- **Grouping:** WebKit/Chrome/Edge helpers collapse under the parent app (responsible-PID when available, bundle-id heuristics otherwise).
- **Settings:** enable toggle, permission status, Reset All volumes.
- **Crash safety:** `Drop` tears taps/aggregate/IOProc down; launch cleans orphaned private aggregates named `openNook Mixer*`.

### Tests
`cargo test -p nook -p nook-core` — **81 + 89 passed** (Linux CI). New unit tests cover gain map (set/mute/reset/persist), sample limiter, helper grouping, version gate, and TCC copy.

### Notes / blockers
- Process-tap + IOProc path is `#[cfg(target_os = "macos")]` and was not compiled or run on this Linux agent. Needs a macOS 14.4+ smoke test (slider, mute, device switch, TCC deny).
- macOS will show a system-audio-recording indicator while any slider is below 100% — that is inherent to public tap APIs.
- Optional compact-face scroll-to-adjust-frontmost-app was left out of this package.