### PR TITLE
WP07: Weather on the shelf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,6 +3835,7 @@ dependencies = [
  "futures-util",
  "log",
  "objc2",
+ "objc2-core-location",
  "objc2-event-kit",
  "objc2-foundation",
  "open",
@@ -4058,6 +4059,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-contacts"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b034b578389f89a85c055eacc8d8b368be5f04a6c1b07f672bf3aec21d0ef621"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4086,7 +4097,10 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
+ "block2",
+ "dispatch2",
  "objc2",
+ "objc2-contacts",
  "objc2-foundation",
 ]
 

--- a/Info.plist
+++ b/Info.plist
@@ -28,6 +28,10 @@
 	<string>openNook shows reminders in the island and lets you mark them complete from there.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>openNook can use a one-shot city-level location so Weather can show the forecast for where you are. Location is optional — you can enter a city instead. The grant is tied to this build's signature and resets after an ad-hoc re-sign.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>openNook can use a one-shot city-level location so Weather can show the forecast for where you are. Location is optional — you can enter a city instead.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
 </dict>

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -22,6 +22,7 @@ sysinfo = "0.37"
 objc2 = "0.6"
 objc2-foundation = "0.3"
 objc2-event-kit = { version = "0.3", features = ["EKEventStore", "EKEvent", "EKReminder", "EKCalendar"] }
+objc2-core-location = { version = "0.3", features = ["CLLocationManager", "CLLocation"] }
 block2 = "0.6"
 security-framework = "3.7"
 

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
+pub mod location;
 #[cfg(target_os = "macos")]
 mod mediaremote;
 pub mod models;
@@ -20,6 +21,7 @@ pub mod observe;
 pub mod occupancy;
 pub mod settings;
 pub mod utils;
+pub mod weather;
 pub mod widgets;
 
 pub use models::{NotchInfo, NowPlayingData};

--- a/crates/nook-core/src/location.rs
+++ b/crates/nook-core/src/location.rs
@@ -1,0 +1,265 @@
+//! Opt-in one-shot CoreLocation lookup.
+//!
+//! Manual city entry is the default weather path (no TCC). This module is
+//! only used when the user taps "Use system location". It never starts
+//! continuous updates — `requestLocation` once, reduced accuracy, then done.
+//! The grant is keyed to the code signature and resets on ad-hoc re-sign.
+
+use tokio::sync::oneshot;
+
+/// Start a one-shot location request. Must be called on the main thread on
+/// macOS (`CLLocationManager` is main-thread affine). The receiver completes
+/// with coordinates or a UI-safe error string.
+pub fn begin_request() -> oneshot::Receiver<Result<(f64, f64), String>> {
+    let (tx, rx) = oneshot::channel();
+    #[cfg(target_os = "macos")]
+    {
+        macos::start(tx);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = tx.send(Err(
+            "System location is only available on macOS. Enter a city instead.".into(),
+        ));
+    }
+    rx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn begin_request_degrades_without_core_location() {
+        let rx = begin_request();
+        let result = nook_core_runtime_block(rx);
+        #[cfg(not(target_os = "macos"))]
+        {
+            let err = result.expect_err("linux/windows have no CoreLocation");
+            assert!(err.contains("macOS"), "{err}");
+        }
+        let _ = result;
+    }
+
+    fn nook_core_runtime_block(
+        rx: oneshot::Receiver<Result<(f64, f64), String>>,
+    ) -> Result<(f64, f64), String> {
+        crate::runtime()
+            .block_on(async { rx.await.unwrap_or_else(|_| Err("ended".into())) })
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use objc2::encode::{Encode, Encoding};
+    use objc2::rc::{Allocated, Retained};
+    use objc2::runtime::{AnyObject, NSObject, NSObjectProtocol};
+    use objc2::runtime::AnyClass;
+    use objc2::{define_class, msg_send, AllocAnyThread, ClassType, DefinedClass};
+    use objc2_foundation::MainThreadMarker;
+    use std::cell::RefCell;
+    use std::sync::Mutex;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct CLLocationCoordinate2D {
+        latitude: f64,
+        longitude: f64,
+    }
+
+    unsafe impl Encode for CLLocationCoordinate2D {
+        const ENCODING: Encoding = Encoding::Struct(
+            "CLLocationCoordinate2D",
+            &[f64::ENCODING, f64::ENCODING],
+        );
+    }
+
+    #[link(name = "CoreLocation", kind = "framework")]
+    extern "C" {
+        static kCLLocationAccuracyReduced: f64;
+    }
+
+    // CLAuthorizationStatus
+    const AUTH_NOT_DETERMINED: i64 = 0;
+    const AUTH_RESTRICTED: i64 = 1;
+    const AUTH_DENIED: i64 = 2;
+    const AUTH_AUTHORIZED_ALWAYS: i64 = 3;
+    const AUTH_AUTHORIZED_WHEN_IN_USE: i64 = 4;
+
+    struct Ivars {
+        tx: RefCell<Option<oneshot::Sender<Result<(f64, f64), String>>>>,
+    }
+
+    define_class!(
+        #[unsafe(super(NSObject))]
+        #[name = "NookWeatherLocationDelegate"]
+        #[ivars = Ivars]
+        struct NookWeatherLocationDelegate;
+
+        unsafe impl NSObjectProtocol for NookWeatherLocationDelegate {}
+
+        impl NookWeatherLocationDelegate {
+            #[unsafe(method(locationManager:didUpdateLocations:))]
+            fn did_update(&self, _manager: *mut AnyObject, locations: *mut AnyObject) {
+                let coord = unsafe { first_coordinate(locations) };
+                match coord {
+                    Some(pair) => finish(self, Ok(pair)),
+                    None => finish(self, Err("Location Services returned no fix.".into())),
+                }
+            }
+
+            #[unsafe(method(locationManager:didFailWithError:))]
+            fn did_fail(&self, _manager: *mut AnyObject, error: *mut AnyObject) {
+                finish(self, Err(friendly_error(error)));
+            }
+
+            #[unsafe(method(locationManagerDidChangeAuthorization:))]
+            fn did_change_auth(&self, manager: *mut AnyObject) {
+                let status = unsafe { authorization_status(manager) };
+                match status {
+                    AUTH_AUTHORIZED_ALWAYS | AUTH_AUTHORIZED_WHEN_IN_USE => unsafe {
+                        let _: () = msg_send![manager, requestLocation];
+                    },
+                    AUTH_DENIED | AUTH_RESTRICTED => finish(
+                        self,
+                        Err(
+                            "Location is off or denied. Enter a city, or enable Location Services."
+                                .into(),
+                        ),
+                    ),
+                    _ => {}
+                }
+            }
+        }
+    );
+
+    impl NookWeatherLocationDelegate {
+        fn new(tx: oneshot::Sender<Result<(f64, f64), String>>) -> Retained<Self> {
+            let this = Self::alloc().set_ivars(Ivars {
+                tx: RefCell::new(Some(tx)),
+            });
+            unsafe { msg_send![super(this), init] }
+        }
+    }
+
+    unsafe fn first_coordinate(locations: *mut AnyObject) -> Option<(f64, f64)> {
+        if locations.is_null() {
+            return None;
+        }
+        let loc: *mut AnyObject = msg_send![locations, firstObject];
+        if loc.is_null() {
+            return None;
+        }
+        let coord: CLLocationCoordinate2D = msg_send![loc, coordinate];
+        Some((coord.latitude, coord.longitude))
+    }
+
+    unsafe fn authorization_status(manager: *mut AnyObject) -> i64 {
+        if manager.is_null() {
+            return AUTH_DENIED;
+        }
+        msg_send![manager, authorizationStatus]
+    }
+
+    fn friendly_error(error: *mut AnyObject) -> String {
+        if error.is_null() {
+            return "Location failed. Enter a city instead.".into();
+        }
+        let code: isize = unsafe { msg_send![error, code] };
+        match code {
+            1 => "Location is off or denied. Enter a city, or enable Location Services.".into(),
+            0 => "Could not determine location. Try again, or enter a city.".into(),
+            _ => format!("Location failed ({code}). Enter a city instead."),
+        }
+    }
+
+    fn finish(delegate: &NookWeatherLocationDelegate, result: Result<(f64, f64), String>) {
+        if let Some(tx) = delegate.ivars().tx.borrow_mut().take() {
+            let _ = tx.send(result);
+        }
+        if let Ok(mut live) = LIVE.lock() {
+            *live = None;
+        }
+    }
+
+    struct LiveRequest {
+        _manager: Retained<AnyObject>,
+        _delegate: Retained<NookWeatherLocationDelegate>,
+    }
+
+    unsafe impl Send for LiveRequest {}
+
+    static LIVE: Mutex<Option<LiveRequest>> = Mutex::new(None);
+
+    pub fn start(tx: oneshot::Sender<Result<(f64, f64), String>>) {
+        if MainThreadMarker::new().is_none() {
+            let _ = tx.send(Err(
+                "System location must be requested from the main thread.".into(),
+            ));
+            return;
+        }
+        if let Ok(guard) = LIVE.lock() {
+            if guard.is_some() {
+                let _ = tx.send(Err("A location request is already in progress.".into()));
+                return;
+            }
+        }
+
+        let delegate = NookWeatherLocationDelegate::new(tx);
+        unsafe {
+            let manager: *mut AnyObject = msg_send![objc2::class!(CLLocationManager), new];
+            if manager.is_null() {
+                finish(
+                    &delegate,
+                    Err("Location Services are unavailable on this Mac.".into()),
+                );
+                return;
+            }
+            let accuracy = kCLLocationAccuracyReduced;
+            let _: () = msg_send![manager, setDesiredAccuracy: accuracy];
+            let _: () = msg_send![manager, setDelegate: &*delegate];
+            let status = authorization_status(manager);
+            match status {
+                AUTH_AUTHORIZED_ALWAYS | AUTH_AUTHORIZED_WHEN_IN_USE => {
+                    let _: () = msg_send![manager, requestLocation];
+                }
+                AUTH_DENIED | AUTH_RESTRICTED => {
+                    finish(
+                        &delegate,
+                        Err(
+                            "Location is off or denied. Enter a city, or enable Location Services."
+                                .into(),
+                        ),
+                    );
+                    return;
+                }
+                AUTH_NOT_DETERMINED => {
+                    let _: () = msg_send![manager, requestWhenInUseAuthorization];
+                }
+                _ => {
+                    let _: () = msg_send![manager, requestWhenInUseAuthorization];
+                }
+            }
+            let Some(manager) = Retained::from_raw(manager) else {
+                finish(
+                    &delegate,
+                    Err("Location Services are unavailable on this Mac.".into()),
+                );
+                return;
+            };
+            if let Ok(mut live) = LIVE.lock() {
+                *live = Some(LiveRequest {
+                    _manager: manager,
+                    _delegate: delegate,
+                });
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn _retain_class_traits() -> Option<&'static AnyClass> {
+        let _ = AllocAnyThread::alloc as fn() -> Allocated<NookWeatherLocationDelegate>;
+        Some(NookWeatherLocationDelegate::class())
+    }
+}

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -1,5 +1,6 @@
 use crate::database;
 use crate::observe::ObserveConfig;
+use crate::weather::WeatherSettings;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 
@@ -17,10 +18,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    Weather = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +33,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::Weather,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -45,7 +48,7 @@ impl WidgetModule {
         match self {
             Self::Calendar | Self::Music => 5,
             Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
-            Self::Timers | Self::Speed | Self::Mirror => 3,
+            Self::Timers | Self::Speed | Self::Mirror | Self::Weather => 3,
         }
     }
 
@@ -53,13 +56,13 @@ impl WidgetModule {
         match self {
             Self::Calendar => 4,
             Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
-            Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
+            Self::Notes | Self::Timers | Self::Speed | Self::Agents | Self::Weather => 2,
         }
     }
 
     pub fn max_cells(self) -> u8 {
         match self {
-            Self::Timers | Self::Speed | Self::Agents | Self::Mirror => 6,
+            Self::Timers | Self::Speed | Self::Agents | Self::Mirror | Self::Weather => 6,
             _ => 8,
         }
     }
@@ -82,6 +85,7 @@ fn default_widget_order() -> Vec<WidgetModule> {
         WidgetModule::Timers,
         WidgetModule::Notes,
         WidgetModule::Speed,
+        WidgetModule::Weather,
     ]
 }
 
@@ -142,6 +146,8 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default)]
+    pub weather: WeatherSettings,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -231,6 +237,7 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            weather: WeatherSettings::default(),
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +283,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::Weather => self.weather.enabled,
         }
     }
 
@@ -291,6 +299,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::Weather => self.weather.enabled = !self.weather.enabled,
         }
     }
 
@@ -611,6 +620,8 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.weather.enabled);
+        assert!(parsed.weather.show_on_compact_face);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +707,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.weather.enabled = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook-core/src/weather.rs
+++ b/crates/nook-core/src/weather.rs
@@ -1,0 +1,802 @@
+//! Open-Meteo weather client.
+//!
+//! Keyless forecast + geocoding. Snapshots are cached for [`CACHE_TTL`]
+//! (30 min). Callers must not poll faster than that — [`fetch`] returns the
+//! cached snapshot when it is still fresh, and network failures back off
+//! exponentially up to the same cap.
+
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Open-Meteo model updates hourly; anything faster is wasted radio.
+pub const CACHE_TTL: Duration = Duration::from_secs(30 * 60);
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
+const MAX_BACKOFF: Duration = CACHE_TTL;
+const HOURLY_POINTS: usize = 8;
+const USER_AGENT: &str = "openNook (https://github.com/prodBirdy/openNook)";
+const FORECAST_URL: &str = "https://api.open-meteo.com/v1/forecast";
+const GEOCODE_URL: &str = "https://geocoding-api.open-meteo.com/v1/search";
+
+/// CC-BY 4.0 attribution required by Open-Meteo's free tier.
+pub const ATTRIBUTION: &str = "Weather data by Open-Meteo.com";
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum WeatherUnits {
+    #[default]
+    Celsius,
+    Fahrenheit,
+}
+
+impl WeatherUnits {
+    pub fn query_value(self) -> &'static str {
+        match self {
+            Self::Celsius => "celsius",
+            Self::Fahrenheit => "fahrenheit",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Celsius => "°C",
+            Self::Fahrenheit => "°F",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum WeatherLocationMode {
+    Manual { name: String, lat: f64, lon: f64 },
+    System { name: String, lat: f64, lon: f64 },
+}
+
+impl Default for WeatherLocationMode {
+    fn default() -> Self {
+        Self::Manual {
+            name: String::new(),
+            lat: 0.0,
+            lon: 0.0,
+        }
+    }
+}
+
+impl WeatherLocationMode {
+    pub fn is_system(&self) -> bool {
+        matches!(self, Self::System { .. })
+    }
+
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Manual { name, .. } | Self::System { name, .. } => name,
+        }
+    }
+
+    pub fn coords(&self) -> Option<(f64, f64)> {
+        let (lat, lon) = match self {
+            Self::Manual { lat, lon, .. } | Self::System { lat, lon, .. } => (*lat, *lon),
+        };
+        if lat == 0.0 && lon == 0.0 {
+            None
+        } else {
+            Some((lat, lon))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WeatherSettings {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    #[serde(default)]
+    pub units: WeatherUnits,
+    #[serde(default)]
+    pub location: WeatherLocationMode,
+    #[serde(default = "default_true")]
+    pub show_on_compact_face: bool,
+}
+
+impl Default for WeatherSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            units: WeatherUnits::Celsius,
+            location: WeatherLocationMode::default(),
+            show_on_compact_face: true,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct HourlyForecast {
+    pub hour: String,
+    pub temperature: f64,
+    pub wmo_code: u8,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct WeatherSnapshot {
+    pub location_name: String,
+    pub latitude: f64,
+    pub longitude: f64,
+    pub units: WeatherUnits,
+    pub temperature: f64,
+    pub feels_like: f64,
+    pub wmo_code: u8,
+    pub is_day: bool,
+    pub high: Option<f64>,
+    pub low: Option<f64>,
+    pub precip_probability: Option<u8>,
+    pub wind_speed: Option<f64>,
+    pub hourly: Vec<HourlyForecast>,
+    pub fetched_at: Instant,
+}
+
+impl WeatherSnapshot {
+    pub fn is_fresh(&self) -> bool {
+        snapshot_is_fresh(self.fetched_at, CACHE_TTL)
+    }
+
+    pub fn matches(&self, lat: f64, lon: f64, units: WeatherUnits) -> bool {
+        self.units == units && (self.latitude - lat).abs() < 1e-4 && (self.longitude - lon).abs() < 1e-4
+    }
+
+    pub fn icon(&self) -> &'static str {
+        wmo_icon(self.wmo_code, self.is_day)
+    }
+
+    pub fn label(&self) -> &'static str {
+        wmo_label(self.wmo_code)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeoPlace {
+    pub name: String,
+    pub country: Option<String>,
+    pub admin1: Option<String>,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+impl GeoPlace {
+    pub fn display_name(&self) -> String {
+        match (&self.admin1, &self.country) {
+            (Some(admin), Some(country)) if !admin.is_empty() => {
+                format!("{}, {}, {}", self.name, admin, country)
+            }
+            (_, Some(country)) => format!("{}, {}", self.name, country),
+            _ => self.name.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ParsedForecast {
+    pub temperature: f64,
+    pub feels_like: f64,
+    pub wmo_code: u8,
+    pub is_day: bool,
+    pub high: Option<f64>,
+    pub low: Option<f64>,
+    pub precip_probability: Option<u8>,
+    pub wind_speed: Option<f64>,
+    pub hourly: Vec<HourlyForecast>,
+}
+
+#[derive(Deserialize)]
+struct ForecastResponse {
+    current: Option<CurrentBlock>,
+    daily: Option<DailyBlock>,
+    hourly: Option<HourlyBlock>,
+}
+
+#[derive(Deserialize)]
+struct CurrentBlock {
+    time: Option<String>,
+    temperature_2m: Option<f64>,
+    apparent_temperature: Option<f64>,
+    weather_code: Option<u8>,
+    wind_speed_10m: Option<f64>,
+    is_day: Option<u8>,
+}
+
+#[derive(Deserialize)]
+struct DailyBlock {
+    temperature_2m_max: Option<Vec<Option<f64>>>,
+    temperature_2m_min: Option<Vec<Option<f64>>>,
+    precipitation_probability_max: Option<Vec<Option<i32>>>,
+}
+
+#[derive(Deserialize)]
+struct HourlyBlock {
+    time: Option<Vec<String>>,
+    temperature_2m: Option<Vec<Option<f64>>>,
+    weather_code: Option<Vec<Option<u8>>>,
+}
+
+#[derive(Deserialize)]
+struct GeocodeResponse {
+    results: Option<Vec<GeocodeHit>>,
+}
+
+#[derive(Deserialize)]
+struct GeocodeHit {
+    name: Option<String>,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    country: Option<String>,
+    admin1: Option<String>,
+}
+
+struct Cache {
+    snapshot: Option<WeatherSnapshot>,
+}
+
+fn cache() -> &'static Mutex<Cache> {
+    static CACHE: OnceLock<Mutex<Cache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(Cache { snapshot: None }))
+}
+
+fn fail_streak() -> &'static AtomicU32 {
+    static STREAK: AtomicU32 = AtomicU32::new(0);
+    &STREAK
+}
+
+fn next_attempt() -> &'static Mutex<Option<Instant>> {
+    static NEXT: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    NEXT.get_or_init(|| Mutex::new(None))
+}
+
+fn fetching() -> &'static AtomicBool {
+    static FETCHING: AtomicBool = AtomicBool::new(false);
+    &FETCHING
+}
+
+fn wake_flag() -> &'static AtomicBool {
+    static WAKE: AtomicBool = AtomicBool::new(false);
+    &WAKE
+}
+
+/// True when `fetched_at` is still inside `ttl`.
+pub fn snapshot_is_fresh(fetched_at: Instant, ttl: Duration) -> bool {
+    fetched_at.elapsed() < ttl
+}
+
+/// Format a temperature for the compact face / card (`18°`).
+pub fn format_temp(value: f64) -> String {
+    format!("{:.0}°", value.round())
+}
+
+/// Lucide icon name for a WMO weather code, with a night variant when `is_day`
+/// is false.
+pub fn wmo_icon(code: u8, is_day: bool) -> &'static str {
+    match code {
+        0 => {
+            if is_day {
+                "sun"
+            } else {
+                "moon"
+            }
+        }
+        1 | 2 => {
+            if is_day {
+                "cloud-sun"
+            } else {
+                "cloud-moon"
+            }
+        }
+        3 => "cloud",
+        45 | 48 => "cloud-fog",
+        51 | 53 | 55 | 56 | 57 => "cloud-drizzle",
+        61 | 63 | 65 | 66 | 67 | 80 | 81 | 82 => "cloud-rain",
+        71 | 73 | 75 | 77 | 85 | 86 => "cloud-snow",
+        95 | 96 | 99 => "cloud-lightning",
+        _ => {
+            if is_day {
+                "cloud-sun"
+            } else {
+                "cloud-moon"
+            }
+        }
+    }
+}
+
+/// Short English label for a WMO weather code.
+pub fn wmo_label(code: u8) -> &'static str {
+    match code {
+        0 => "Clear",
+        1 => "Mostly clear",
+        2 => "Partly cloudy",
+        3 => "Overcast",
+        45 => "Fog",
+        48 => "Rime fog",
+        51 => "Light drizzle",
+        53 => "Drizzle",
+        55 => "Heavy drizzle",
+        56 => "Freezing drizzle",
+        57 => "Heavy freezing drizzle",
+        61 => "Light rain",
+        63 => "Rain",
+        65 => "Heavy rain",
+        66 => "Freezing rain",
+        67 => "Heavy freezing rain",
+        71 => "Light snow",
+        73 => "Snow",
+        75 => "Heavy snow",
+        77 => "Snow grains",
+        80 => "Light showers",
+        81 => "Showers",
+        82 => "Heavy showers",
+        85 => "Light snow showers",
+        86 => "Snow showers",
+        95 => "Thunderstorm",
+        96 => "Thunderstorm + hail",
+        99 => "Severe thunderstorm",
+        _ => "Unknown",
+    }
+}
+
+/// Parse an Open-Meteo forecast body. Location / units / fetched_at are filled
+/// by [`fetch`].
+pub fn parse_forecast(json: &str) -> Result<ParsedForecast, String> {
+    let parsed: ForecastResponse =
+        serde_json::from_str(json).map_err(|err| format!("weather parse: {err}"))?;
+    let current = parsed
+        .current
+        .ok_or_else(|| "weather parse: missing current".to_string())?;
+    let temperature = current
+        .temperature_2m
+        .ok_or_else(|| "weather parse: missing temperature".to_string())?;
+    let feels_like = current.apparent_temperature.unwrap_or(temperature);
+    let wmo_code = current.weather_code.unwrap_or(0);
+    let is_day = current.is_day.unwrap_or(1) != 0;
+    let wind_speed = current.wind_speed_10m;
+    let (high, low, precip_probability) = match parsed.daily {
+        Some(daily) => (
+            first_opt_f64(daily.temperature_2m_max.as_deref()),
+            first_opt_f64(daily.temperature_2m_min.as_deref()),
+            first_opt_u8(daily.precipitation_probability_max.as_deref()),
+        ),
+        None => (None, None, None),
+    };
+    let hourly = parsed
+        .hourly
+        .map(|block| take_hourly(&block, current.time.as_deref(), HOURLY_POINTS))
+        .unwrap_or_default();
+    Ok(ParsedForecast {
+        temperature,
+        feels_like,
+        wmo_code,
+        is_day,
+        high,
+        low,
+        precip_probability,
+        wind_speed,
+        hourly,
+    })
+}
+
+fn first_opt_f64(values: Option<&[Option<f64>]>) -> Option<f64> {
+    values.and_then(|list| list.iter().flatten().copied().next())
+}
+
+fn first_opt_u8(values: Option<&[Option<i32>]>) -> Option<u8> {
+    values.and_then(|list| {
+        list.iter()
+            .flatten()
+            .find_map(|v| u8::try_from(*v).ok().or(Some((*v).clamp(0, 100) as u8)))
+    })
+}
+
+fn take_hourly(block: &HourlyBlock, from_time: Option<&str>, limit: usize) -> Vec<HourlyForecast> {
+    let times = block.time.as_deref().unwrap_or(&[]);
+    let temps = block.temperature_2m.as_deref().unwrap_or(&[]);
+    let codes = block.weather_code.as_deref().unwrap_or(&[]);
+    let start = from_time
+        .and_then(|from| times.iter().position(|t| t.as_str() >= from))
+        .unwrap_or(0);
+    times
+        .iter()
+        .zip(temps.iter().chain(std::iter::repeat(&None)))
+        .zip(codes.iter().chain(std::iter::repeat(&None)))
+        .skip(start)
+        .filter_map(|((time, temp), code)| {
+            Some(HourlyForecast {
+                hour: hour_label(time),
+                temperature: (*temp)?,
+                wmo_code: code.unwrap_or(0),
+            })
+        })
+        .take(limit)
+        .collect()
+}
+
+fn hour_label(time: &str) -> String {
+    time.split('T')
+        .nth(1)
+        .and_then(|clock| clock.get(..2))
+        .unwrap_or("--")
+        .to_string()
+}
+
+fn client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .user_agent(USER_AGENT)
+        .build()
+        .map_err(|err| err.to_string())
+}
+
+/// Cached snapshot when one exists, regardless of age.
+pub fn cached_snapshot() -> Option<WeatherSnapshot> {
+    cache()
+        .lock()
+        .ok()
+        .and_then(|guard| guard.snapshot.clone())
+}
+
+/// Cached snapshot only when it still matches `settings` and is within TTL.
+pub fn fresh_snapshot(settings: &WeatherSettings) -> Option<WeatherSnapshot> {
+    let (lat, lon) = settings.location.coords()?;
+    let guard = cache().lock().ok()?;
+    let snap = guard.snapshot.as_ref()?;
+    if snap.matches(lat, lon, settings.units) && snap.is_fresh() {
+        Some(snap.clone())
+    } else {
+        None
+    }
+}
+
+pub fn is_fresh_for(settings: &WeatherSettings) -> bool {
+    fresh_snapshot(settings).is_some()
+}
+
+/// Drop the in-memory cache (location / units changed).
+pub fn invalidate() {
+    if let Ok(mut guard) = cache().lock() {
+        guard.snapshot = None;
+    }
+    fail_streak().store(0, Ordering::Relaxed);
+    if let Ok(mut next) = next_attempt().lock() {
+        *next = None;
+    }
+}
+
+/// Wake notification from `NSWorkspaceDidWakeNotification`.
+pub fn note_wake() {
+    wake_flag().store(true, Ordering::Relaxed);
+}
+
+pub fn take_wake() -> bool {
+    wake_flag().swap(false, Ordering::Relaxed)
+}
+
+fn backoff_allows() -> bool {
+    let Ok(next) = next_attempt().lock() else {
+        return true;
+    };
+    match *next {
+        Some(when) => Instant::now() >= when,
+        None => true,
+    }
+}
+
+fn note_success() {
+    fail_streak().store(0, Ordering::Relaxed);
+    if let Ok(mut next) = next_attempt().lock() {
+        *next = None;
+    }
+}
+
+fn note_failure() {
+    let streak = fail_streak().fetch_add(1, Ordering::Relaxed) + 1;
+    let secs = 30u64.saturating_mul(1u64 << streak.min(6).saturating_sub(1).min(6));
+    let wait = Duration::from_secs(secs).min(MAX_BACKOFF);
+    if let Ok(mut next) = next_attempt().lock() {
+        *next = Some(Instant::now() + wait);
+    }
+}
+
+/// TTL-gated fetch. Returns the cached snapshot when it is still fresh for
+/// this location and unit system. Concurrent callers share one in-flight GET.
+pub async fn fetch(settings: &WeatherSettings) -> Result<WeatherSnapshot, String> {
+    let (lat, lon) = settings
+        .location
+        .coords()
+        .ok_or_else(|| "Set a city in Settings".to_string())?;
+    if let Some(snap) = fresh_snapshot(settings) {
+        return Ok(snap);
+    }
+    if !backoff_allows() {
+        return cached_snapshot()
+            .filter(|snap| snap.matches(lat, lon, settings.units))
+            .ok_or_else(|| "Weather is temporarily unavailable".to_string());
+    }
+    if fetching()
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return cached_snapshot()
+            .filter(|snap| snap.matches(lat, lon, settings.units))
+            .ok_or_else(|| "Weather is updating".to_string());
+    }
+    let result = fetch_uncached(lat, lon, settings).await;
+    fetching().store(false, Ordering::SeqCst);
+    match result {
+        Ok(snap) => {
+            note_success();
+            if let Ok(mut guard) = cache().lock() {
+                guard.snapshot = Some(snap.clone());
+            }
+            Ok(snap)
+        }
+        Err(err) => {
+            note_failure();
+            if let Some(snap) = cached_snapshot().filter(|s| s.matches(lat, lon, settings.units)) {
+                Ok(snap)
+            } else {
+                Err(err)
+            }
+        }
+    }
+}
+
+async fn fetch_uncached(
+    lat: f64,
+    lon: f64,
+    settings: &WeatherSettings,
+) -> Result<WeatherSnapshot, String> {
+    let client = client()?;
+    let url = format!(
+        "{FORECAST_URL}?latitude={lat:.4}&longitude={lon:.4}\
+         &current=temperature_2m,apparent_temperature,weather_code,wind_speed_10m,is_day\
+         &daily=temperature_2m_max,temperature_2m_min,weather_code,precipitation_probability_max\
+         &hourly=temperature_2m,weather_code\
+         &forecast_days=5&temperature_unit={}",
+        settings.units.query_value()
+    );
+    let body = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| format!("weather: {err}"))?
+        .error_for_status()
+        .map_err(|err| format!("weather: {err}"))?
+        .text()
+        .await
+        .map_err(|err| format!("weather: {err}"))?;
+    let parsed = parse_forecast(&body)?;
+    Ok(WeatherSnapshot {
+        location_name: settings.location.name().to_string(),
+        latitude: lat,
+        longitude: lon,
+        units: settings.units,
+        temperature: parsed.temperature,
+        feels_like: parsed.feels_like,
+        wmo_code: parsed.wmo_code,
+        is_day: parsed.is_day,
+        high: parsed.high,
+        low: parsed.low,
+        precip_probability: parsed.precip_probability,
+        wind_speed: parsed.wind_speed,
+        hourly: parsed.hourly,
+        fetched_at: Instant::now(),
+    })
+}
+
+/// Search Open-Meteo's geocoder. Returns up to `count` places (max 5).
+pub async fn search_places(name: &str, count: usize) -> Result<Vec<GeoPlace>, String> {
+    let query = name.trim();
+    if query.is_empty() {
+        return Ok(Vec::new());
+    }
+    let count = count.clamp(1, 5);
+    let client = client()?;
+    let url = format!(
+        "{GEOCODE_URL}?name={}&count={count}&language=en&format=json",
+        urlencoding_name(query)
+    );
+    let body = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|err| format!("geocode: {err}"))?
+        .error_for_status()
+        .map_err(|err| format!("geocode: {err}"))?
+        .text()
+        .await
+        .map_err(|err| format!("geocode: {err}"))?;
+    parse_geocode(&body)
+}
+
+fn urlencoding_name(name: &str) -> String {
+    let mut out = String::new();
+    for byte in name.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            b' ' => out.push('+'),
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{byte:02X}"));
+            }
+        }
+    }
+    out
+}
+
+pub fn parse_geocode(json: &str) -> Result<Vec<GeoPlace>, String> {
+    let parsed: GeocodeResponse =
+        serde_json::from_str(json).map_err(|err| format!("geocode parse: {err}"))?;
+    Ok(parsed
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|hit| {
+            Some(GeoPlace {
+                name: hit.name?,
+                country: hit.country,
+                admin1: hit.admin1,
+                latitude: hit.latitude?,
+                longitude: hit.longitude?,
+            })
+        })
+        .take(5)
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+        "current": {
+            "time": "2026-08-28T14:00",
+            "temperature_2m": 18.4,
+            "apparent_temperature": 17.1,
+            "weather_code": 2,
+            "wind_speed_10m": 8.2,
+            "is_day": 1
+        },
+        "daily": {
+            "time": ["2026-08-28"],
+            "temperature_2m_max": [22.0],
+            "temperature_2m_min": [11.5],
+            "weather_code": [2],
+            "precipitation_probability_max": [20]
+        },
+        "hourly": {
+            "time": [
+                "2026-08-28T12:00",
+                "2026-08-28T13:00",
+                "2026-08-28T14:00",
+                "2026-08-28T15:00",
+                "2026-08-28T16:00"
+            ],
+            "temperature_2m": [16.0, 17.0, 18.4, 19.0, 19.5],
+            "weather_code": [1, 1, 2, 2, 3]
+        }
+    }"#;
+
+    #[test]
+    fn wmo_maps_clear_day_and_night() {
+        assert_eq!(wmo_icon(0, true), "sun");
+        assert_eq!(wmo_icon(0, false), "moon");
+        assert_eq!(wmo_label(0), "Clear");
+    }
+
+    #[test]
+    fn wmo_maps_documented_codes() {
+        assert_eq!(wmo_icon(3, true), "cloud");
+        assert_eq!(wmo_label(3), "Overcast");
+        assert_eq!(wmo_icon(45, true), "cloud-fog");
+        assert_eq!(wmo_icon(61, true), "cloud-rain");
+        assert_eq!(wmo_label(61), "Light rain");
+        assert_eq!(wmo_icon(73, true), "cloud-snow");
+        assert_eq!(wmo_icon(95, false), "cloud-lightning");
+        assert_eq!(wmo_label(95), "Thunderstorm");
+        assert_eq!(wmo_icon(2, false), "cloud-moon");
+        assert_eq!(wmo_label(99), "Severe thunderstorm");
+        assert_eq!(wmo_label(200), "Unknown");
+    }
+
+    #[test]
+    fn parse_forecast_reads_current_daily_and_hourly() {
+        let parsed = parse_forecast(SAMPLE).unwrap();
+        assert!((parsed.temperature - 18.4).abs() < f64::EPSILON);
+        assert!((parsed.feels_like - 17.1).abs() < f64::EPSILON);
+        assert_eq!(parsed.wmo_code, 2);
+        assert!(parsed.is_day);
+        assert_eq!(parsed.high, Some(22.0));
+        assert_eq!(parsed.low, Some(11.5));
+        assert_eq!(parsed.precip_probability, Some(20));
+        assert_eq!(parsed.wind_speed, Some(8.2));
+        assert_eq!(parsed.hourly.len(), 3);
+        assert_eq!(parsed.hourly[0].hour, "14");
+        assert!((parsed.hourly[0].temperature - 18.4).abs() < f64::EPSILON);
+        assert_eq!(parsed.hourly[0].wmo_code, 2);
+        assert_eq!(parsed.hourly[2].hour, "16");
+    }
+
+    #[test]
+    fn parse_forecast_rejects_empty_current() {
+        assert!(parse_forecast(r#"{"daily":{}}"#).is_err());
+        assert!(parse_forecast("not-json").is_err());
+    }
+
+    #[test]
+    fn parse_geocode_takes_five_named_hits() {
+        let json = r#"{
+            "results": [
+                {"name":"Berlin","latitude":52.52,"longitude":13.41,"country":"Germany","admin1":"Berlin"},
+                {"name":"Bergen","latitude":60.39,"longitude":5.32,"country":"Norway"},
+                {"name":"SkipMe"},
+                {"name":"Paris","latitude":48.85,"longitude":2.35,"country":"France"},
+                {"name":"Rome","latitude":41.9,"longitude":12.5,"country":"Italy"},
+                {"name":"Madrid","latitude":40.4,"longitude":-3.7,"country":"Spain"},
+                {"name":"Lisbon","latitude":38.7,"longitude":-9.1,"country":"Portugal"}
+            ]
+        }"#;
+        let places = parse_geocode(json).unwrap();
+        assert_eq!(places.len(), 5);
+        assert_eq!(places[0].display_name(), "Berlin, Berlin, Germany");
+        assert_eq!(places[1].display_name(), "Bergen, Norway");
+        assert!(places.iter().all(|p| p.name != "SkipMe"));
+        assert!(places.iter().all(|p| p.name != "Lisbon"));
+    }
+
+    #[test]
+    fn format_temp_rounds_to_a_degree() {
+        assert_eq!(format_temp(18.4), "18°");
+        assert_eq!(format_temp(18.6), "19°");
+        assert_eq!(format_temp(-1.2), "-1°");
+    }
+
+    #[test]
+    fn snapshot_freshness_uses_ttl() {
+        assert!(snapshot_is_fresh(Instant::now(), CACHE_TTL));
+        assert_eq!(CACHE_TTL, Duration::from_secs(30 * 60));
+        let stale = Instant::now()
+            .checked_sub(CACHE_TTL + Duration::from_secs(1))
+            .unwrap_or_else(Instant::now);
+        if Instant::now().duration_since(stale) > CACHE_TTL {
+            assert!(!snapshot_is_fresh(stale, CACHE_TTL));
+        }
+    }
+
+    #[test]
+    fn empty_manual_location_has_no_coords() {
+        let settings = WeatherSettings::default();
+        assert!(settings.enabled);
+        assert!(settings.show_on_compact_face);
+        assert_eq!(settings.units, WeatherUnits::Celsius);
+        assert!(settings.location.coords().is_none());
+        assert!(!settings.location.is_system());
+    }
+
+    #[test]
+    fn weather_settings_round_trip() {
+        let settings = WeatherSettings {
+            enabled: true,
+            units: WeatherUnits::Fahrenheit,
+            location: WeatherLocationMode::Manual {
+                name: "Oslo".into(),
+                lat: 59.91,
+                lon: 10.75,
+            },
+            show_on_compact_face: false,
+        };
+        let json = serde_json::to_string(&settings).unwrap();
+        let parsed: WeatherSettings = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed, settings);
+        assert_eq!(parsed.location.coords(), Some((59.91, 10.75)));
+    }
+}

--- a/crates/nook/src/assets/icons/cloud-drizzle.svg
+++ b/crates/nook/src/assets/icons/cloud-drizzle.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M8 19v1"/><path d="M8 14v1"/><path d="M16 19v1"/><path d="M16 14v1"/><path d="M12 21v1"/><path d="M12 16v1"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud-fog.svg
+++ b/crates/nook/src/assets/icons/cloud-fog.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M16 17H7"/><path d="M17 21H9"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud-lightning.svg
+++ b/crates/nook/src/assets/icons/cloud-lightning.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973"/><path d="m13 12-3 5h4l-3 5"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud-moon.svg
+++ b/crates/nook/src/assets/icons/cloud-moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M13 16a3 3 0 0 1 0 6H7a5 5 0 1 1 4.9-6Z"/><path d="M10.188 8.5A6 6 0 0 1 16 4a1 1 0 0 0 6 6 6 6 0 0 1-3 5.197"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud-rain.svg
+++ b/crates/nook/src/assets/icons/cloud-rain.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M16 14v6"/><path d="M8 14v6"/><path d="M12 16v6"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud-snow.svg
+++ b/crates/nook/src/assets/icons/cloud-snow.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M4 14.899A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 2.5 8.242"/><path d="M8 15h.01"/><path d="M8 19h.01"/><path d="M12 17h.01"/><path d="M12 21h.01"/><path d="M16 15h.01"/><path d="M16 19h.01"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud-sun.svg
+++ b/crates/nook/src/assets/icons/cloud-sun.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 2v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="M20 12h2"/><path d="m19.07 4.93-1.41 1.41"/><path d="M15.947 12.65a4 4 0 0 0-5.925-4.128"/><path d="M13 22H7a5 5 0 1 1 4.9-6H13a3 3 0 0 1 0 6Z"/>
+</svg>

--- a/crates/nook/src/assets/icons/cloud.svg
+++ b/crates/nook/src/assets/icons/cloud.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9Z"/>
+</svg>

--- a/crates/nook/src/assets/icons/moon.svg
+++ b/crates/nook/src/assets/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z"/>
+</svg>

--- a/crates/nook/src/assets/icons/sun.svg
+++ b/crates/nook/src/assets/icons/sun.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<circle cx="12" cy="12" r="4"/><path d="M12 2v2"/><path d="M12 20v2"/><path d="m4.93 4.93 1.41 1.41"/><path d="m17.66 17.66 1.41 1.41"/><path d="M2 12h2"/><path d="M20 12h2"/><path d="m6.34 17.66-1.41 1.41"/><path d="m19.07 4.93-1.41 1.41"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -64,7 +64,7 @@ impl Island {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
             CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
-            CompactMode::Idle => div().into_any_element(),
+            CompactMode::Idle => widgets::compact_weather(self),
         }
     }
 

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -6,6 +6,7 @@ use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
     agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    weather_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -156,6 +157,10 @@ impl Island {
                         self.settings.cells_for(module),
                         speed_card(self.speed_mbps, self.speed_progress, self.speed_running, cx),
                     ),
+                ),
+                WidgetModule::Weather if self.settings.weather.enabled => add(
+                    &mut kids,
+                    cell_pane(self.settings.cells_for(module), weather_card(self, cx)),
                 ),
                 _ => {}
             }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -27,6 +27,7 @@ use nook_core::models::NowPlayingData;
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
+use nook_core::weather::WeatherSnapshot;
 use settings::SettingsView;
 use std::time::{Duration, Instant};
 
@@ -94,6 +95,9 @@ pub struct Island {
     /// Bumped on start and on Stop so an in-flight test cannot apply after it
     /// was cancelled (Stop then Run would otherwise take the old result).
     pub speed_gen: u64,
+    pub weather: Option<WeatherSnapshot>,
+    pub weather_error: Option<String>,
+    pub(crate) weather_inflight: bool,
     pub last_tick: Instant,
     last_frame: Instant,
     /// Last seen `nook_core::settings::settings_generation()`; the tick loop
@@ -219,6 +223,9 @@ impl Island {
             speed_progress: 0.0,
             speed_running: false,
             speed_gen: 0,
+            weather: nook_core::weather::cached_snapshot(),
+            weather_error: None,
+            weather_inflight: false,
             last_tick: Instant::now(),
             last_frame: Instant::now(),
             settings_gen: nook_core::settings::settings_generation(),
@@ -263,6 +270,7 @@ impl Island {
         this.anim_h.set(h);
 
         platform::install_media_observers();
+        platform::install_weather_observers();
         nook_core::runtime().spawn(async {
             let _ = nook_core::calendar::request_calendar_access().await;
         });
@@ -688,6 +696,32 @@ impl Island {
             cx.background_executor()
                 .timer(Duration::from_secs(wait))
                 .await;
+        })
+        .detach();
+
+        // Weather: 30 min TTL, fetch only when stale and the card/adornment
+        // is visible, or after a wake. The wait is a clock compare — no radio
+        // unless fetch() decides the cache is stale.
+        cx.spawn(async move |this, cx| loop {
+            let wake = nook_core::weather::take_wake();
+            let plan = this
+                .update(cx, |this, _| {
+                    let enabled = this.settings.weather.enabled;
+                    let has_coords = this.settings.weather.location.coords().is_some();
+                    let fresh = nook_core::weather::is_fresh_for(&this.settings.weather);
+                    let visible = this.weather_visible();
+                    (enabled && has_coords && (!fresh || this.weather.is_none()) && (visible || wake), fresh)
+                })
+                .unwrap_or((false, true));
+            if plan.0 {
+                let _ = this.update(cx, |this, cx| this.refresh_weather(cx));
+            }
+            let wait = if plan.1 {
+                Duration::from_secs(30 * 60)
+            } else {
+                Duration::from_secs(30)
+            };
+            cx.background_executor().timer(wait).await;
         })
         .detach();
     }
@@ -1458,6 +1492,9 @@ mod tests {
             speed_progress: 0.0,
             speed_running: false,
             speed_gen: 0,
+            weather: None,
+            weather_error: None,
+            weather_inflight: false,
             last_tick: Instant::now(),
             last_frame: Instant::now(),
             settings_gen: 0,

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -131,6 +131,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Weather => "Weather",
         }
     }
 
@@ -146,6 +147,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::Weather => "cloud-sun",
         }
     }
 
@@ -161,6 +163,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::Weather => weather_subtitle(settings),
         }
     }
 
@@ -184,7 +187,17 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Weather => "Weather",
         }
+    }
+}
+
+fn weather_subtitle(settings: &AppSettings) -> SharedString {
+    let name = settings.weather.location.name();
+    if name.is_empty() {
+        "Open-Meteo".into()
+    } else {
+        name.to_string().into()
     }
 }
 
@@ -227,10 +240,17 @@ pub(super) struct SettingsView {
     url_focus: FocusHandle,
     token_focus: FocusHandle,
     query_focus: FocusHandle,
+    city_focus: FocusHandle,
     url_draft: String,
     token_draft: String,
     token_revealed: bool,
     query_draft: String,
+    city_draft: String,
+    geo_results: Vec<nook_core::weather::GeoPlace>,
+    geo_error: Option<String>,
+    geo_loading: bool,
+    location_status: Option<String>,
+    location_busy: bool,
     catalog: Vec<String>,
     catalog_error: Option<String>,
     catalog_loading: bool,
@@ -254,10 +274,17 @@ impl SettingsView {
             url_focus: cx.focus_handle(),
             token_focus: cx.focus_handle(),
             query_focus: cx.focus_handle(),
+            city_focus: cx.focus_handle(),
             url_draft: settings.observe.prometheus_url,
             token_draft: settings.observe.metrics_token,
             token_revealed: false,
             query_draft: String::new(),
+            city_draft: settings.weather.location.name().to_string(),
+            geo_results: Vec::new(),
+            geo_error: None,
+            geo_loading: false,
+            location_status: None,
+            location_busy: false,
             catalog: Vec::new(),
             catalog_error: None,
             catalog_loading: false,
@@ -382,6 +409,94 @@ impl SettingsView {
         })
         .detach();
     }
+
+    fn search_city(&mut self, cx: &mut Context<Self>) {
+        let query = self.city_draft.trim().to_string();
+        if query.is_empty() || self.geo_loading {
+            return;
+        }
+        self.geo_loading = true;
+        self.geo_error = None;
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move {
+                    nook_core::runtime().block_on(nook_core::weather::search_places(&query, 5))
+                })
+                .await;
+            this.update(cx, |this, cx| {
+                this.geo_loading = false;
+                match result {
+                    Ok(places) => {
+                        this.geo_results = places;
+                        this.geo_error = if this.geo_results.is_empty() {
+                            Some("No matching cities.".into())
+                        } else {
+                            None
+                        };
+                    }
+                    Err(err) => this.geo_error = Some(err),
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn pick_place(&mut self, place: nook_core::weather::GeoPlace, cx: &mut Context<Self>) {
+        let name = place.display_name();
+        nook_core::settings::tweak_app_settings(|s| {
+            s.weather.location = nook_core::weather::WeatherLocationMode::Manual {
+                name: name.clone(),
+                lat: place.latitude,
+                lon: place.longitude,
+            };
+        });
+        nook_core::weather::invalidate();
+        self.city_draft = name;
+        self.geo_results.clear();
+        self.location_status = None;
+        cx.notify();
+    }
+
+    fn use_system_location(&mut self, cx: &mut Context<Self>) {
+        if self.location_busy {
+            return;
+        }
+        self.location_busy = true;
+        self.location_status = Some("Locating…".into());
+        cx.notify();
+        let rx = nook_core::location::begin_request();
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { rx.await.unwrap_or_else(|_| Err("Location request ended.".into())) })
+                .await;
+            this.update(cx, |this, cx| {
+                this.location_busy = false;
+                match result {
+                    Ok((lat, lon)) => {
+                        nook_core::settings::tweak_app_settings(|s| {
+                            s.weather.location = nook_core::weather::WeatherLocationMode::System {
+                                name: "Current location".into(),
+                                lat,
+                                lon,
+                            };
+                        });
+                        nook_core::weather::invalidate();
+                        this.city_draft = "Current location".into();
+                        this.location_status = None;
+                    }
+                    Err(err) => this.location_status = Some(err),
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
 }
 
 impl gpui::Render for SettingsView {
@@ -390,6 +505,7 @@ impl gpui::Render for SettingsView {
         let url_focused = self.url_focus.is_focused(window);
         let token_focused = self.token_focus.is_focused(window);
         let query_focused = self.query_focus.is_focused(window);
+        let city_focused = self.city_focus.is_focused(window);
 
         div()
             .id("settings-root")
@@ -412,7 +528,14 @@ impl gpui::Render for SettingsView {
             .child(self.sidebar(cx))
             .child(div().w(px(1.)).h_full().bg(hairline()))
             .child(if self.category == SettingsCategory::Widgets {
-                self.render_widgets(&settings, url_focused, token_focused, query_focused, cx)
+                self.render_widgets(
+                    &settings,
+                    url_focused,
+                    token_focused,
+                    query_focused,
+                    city_focused,
+                    cx,
+                )
                     .into_any_element()
             } else {
                 self.render_general(&settings, cx).into_any_element()
@@ -694,6 +817,7 @@ impl SettingsView {
         url_focused: bool,
         token_focused: bool,
         query_focused: bool,
+        city_focused: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let remaining = settings.remaining_cells();
@@ -733,6 +857,7 @@ impl SettingsView {
                     url_focused,
                     token_focused,
                     query_focused,
+                    city_focused,
                     cx,
                 )),
         )
@@ -954,6 +1079,7 @@ impl SettingsView {
         url_focused: bool,
         token_focused: bool,
         query_focused: bool,
+        city_focused: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let name = self.module.name();
@@ -1021,6 +1147,158 @@ impl SettingsView {
                     cx,
                 ))
             })
+            .when(self.module == WidgetModule::Weather, |d| {
+                d.child(self.render_weather_settings(settings, city_focused, cx))
+            })
+    }
+
+    fn render_weather_settings(
+        &self,
+        settings: &AppSettings,
+        city_focused: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        use nook_core::weather::{WeatherLocationMode, WeatherUnits};
+
+        let units = settings.weather.units;
+        let mut unit_row = segmented_group();
+        for (caption, value) in [("°C", WeatherUnits::Celsius), ("°F", WeatherUnits::Fahrenheit)] {
+            unit_row = unit_row.child(segment(caption, units == value, cx, move |_, _, cx| {
+                nook_core::settings::tweak_app_settings(|s| s.weather.units = value);
+                nook_core::weather::invalidate();
+                cx.notify();
+            }));
+        }
+
+        let city_text = if self.city_draft.is_empty() {
+            "City name"
+        } else {
+            self.city_draft.as_str()
+        };
+        let mut location_rows = vec![
+            field_row(
+                "weather-city",
+                "City",
+                city_text,
+                self.city_draft.is_empty(),
+                city_focused,
+                &self.city_focus,
+                cx,
+                |this, event, cx| {
+                    if event.keystroke.key == "enter" {
+                        this.search_city(cx);
+                    } else if SettingsView::apply_key(&mut this.city_draft, event, cx) {
+                        cx.notify();
+                    }
+                },
+            )
+            .into_any_element(),
+            settings_row("weather-city-actions")
+                .child(div().flex_1())
+                .child(
+                    div()
+                        .flex()
+                        .gap(px(6.))
+                        .child(push_button(
+                            "weather-search",
+                            if self.geo_loading {
+                                "Searching…"
+                            } else {
+                                "Search"
+                            },
+                            cx,
+                            |this, _, cx| this.search_city(cx),
+                        ))
+                        .child(push_button(
+                            "weather-system",
+                            if self.location_busy {
+                                "Locating…"
+                            } else {
+                                "Use system location"
+                            },
+                            cx,
+                            |this, _, cx| this.use_system_location(cx),
+                        )),
+                )
+                .into_any_element(),
+        ];
+        if let Some(status) = &self.location_status {
+            location_rows.push(
+                settings_row("weather-loc-status")
+                    .child(label(status.clone(), theme::BODY, false))
+                    .into_any_element(),
+            );
+        }
+        if let Some(err) = &self.geo_error {
+            location_rows.push(
+                settings_row("weather-geo-err")
+                    .child(label(err.clone(), theme::BODY, false))
+                    .into_any_element(),
+            );
+        }
+        for (i, place) in self.geo_results.iter().enumerate() {
+            let caption = place.display_name();
+            let picked = place.clone();
+            location_rows.push(
+                settings_row(SharedString::from(format!("weather-hit-{i}")))
+                    .child(label(caption, theme::BODY, true))
+                    .child(push_button(
+                        SharedString::from(format!("weather-pick-{i}")),
+                        "Use",
+                        cx,
+                        move |this, _, cx| this.pick_place(picked.clone(), cx),
+                    ))
+                    .into_any_element(),
+            );
+        }
+
+        let location_note = match &settings.weather.location {
+            WeatherLocationMode::System { .. } => {
+                "Using a one-shot system fix (city-level). The Location Services grant is keyed to this build's signature and resets after an ad-hoc re-sign."
+            }
+            WeatherLocationMode::Manual { name, .. } if !name.is_empty() => {
+                "Manual city. System location is opt-in and optional."
+            }
+            _ => "Enter a city (no permission prompt). System location is opt-in and resets on re-sign.",
+        };
+
+        div()
+            .flex()
+            .flex_col()
+            .gap(px(16.))
+            .child(section(
+                "Units",
+                settings_group(vec![settings_row("weather-units")
+                    .child(label("Temperature", theme::BODY, true))
+                    .child(unit_row)
+                    .into_any_element()]),
+                None::<SharedString>,
+            ))
+            .child(section(
+                "Location",
+                settings_group(location_rows),
+                Some(location_note),
+            ))
+            .child(section(
+                "Compact face",
+                settings_group(vec![toggle_row(
+                    "Show on idle face",
+                    settings.weather.show_on_compact_face,
+                    cx,
+                    |s| {
+                        s.weather.show_on_compact_face = !s.weather.show_on_compact_face;
+                    },
+                )
+                .into_any_element()]),
+                Some("Temp and condition next to the notch while the island is idle."),
+            ))
+            .child(section(
+                "Attribution",
+                settings_group(vec![settings_row("weather-attr")
+                    .child(label(nook_core::weather::ATTRIBUTION, theme::BODY, false))
+                    .into_any_element()]),
+                Some("Required by Open-Meteo's CC-BY 4.0 license."),
+            ))
     }
 
     fn render_observe_settings(
@@ -1356,6 +1634,9 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::Weather => {
+            "Current conditions and a short hourly strip from Open-Meteo. Manual city by default.".into()
+        }
     }
 }
 
@@ -1696,6 +1977,21 @@ mod tests {
     }
 
     #[test]
+    fn weather_subtitle_uses_the_saved_city() {
+        let mut settings = AppSettings::default();
+        assert_eq!(
+            WidgetModule::Weather.subtitle(&settings).as_ref(),
+            "Open-Meteo"
+        );
+        settings.weather.location = nook_core::weather::WeatherLocationMode::Manual {
+            name: "Oslo".into(),
+            lat: 59.91,
+            lon: 10.75,
+        };
+        assert_eq!(WidgetModule::Weather.subtitle(&settings).as_ref(), "Oslo");
+    }
+
+    #[test]
     fn calendar_subtitle_uses_the_week_strip_count() {
         let settings = AppSettings::default();
         assert_eq!(
@@ -1727,6 +2023,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "Weather",
             ]
         );
         assert!(!names

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -1433,6 +1433,46 @@ pub fn install_media_observers() {
     }
 }
 
+/// Refresh weather after sleep without polling through it. The weather loop
+/// consumes [`nook_core::weather::take_wake`] and only hits the network when
+/// the 30 min cache is stale.
+pub fn install_weather_observers() {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use block2::RcBlock;
+        use objc2::runtime::AnyObject;
+        use objc2::*;
+
+        static INSTALLED: Once = Once::new();
+        INSTALLED.call_once(|| {
+            let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+            if workspace.is_null() {
+                return;
+            }
+            let center: *mut AnyObject = msg_send![workspace, notificationCenter];
+            if center.is_null() {
+                return;
+            }
+            let ns_name: *mut AnyObject = msg_send![
+                class!(NSString),
+                stringWithUTF8String: c"NSWorkspaceDidWakeNotification".as_ptr()
+            ];
+            let block = RcBlock::new(move |_note: *mut AnyObject| {
+                nook_core::weather::note_wake();
+            });
+            let token: *mut AnyObject = msg_send![
+                center,
+                addObserverForName: ns_name,
+                object: std::ptr::null_mut::<AnyObject>(),
+                queue: std::ptr::null_mut::<AnyObject>(),
+                usingBlock: &*block
+            ];
+            std::mem::forget(block);
+            let _ = token;
+        });
+    }
+}
+
 /// GPUI-space island rect (origin top-left) for the native glass underlay.
 #[derive(Clone, Copy, Debug)]
 pub struct IslandGlass {

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -8,6 +8,7 @@ mod observe;
 mod reminders;
 mod speed;
 mod timers;
+mod weather;
 
 pub(crate) use agents::{
     agents_card, compact_left as agents_compact_left, compact_right as agents_compact_right,
@@ -19,3 +20,4 @@ pub(crate) use observe::{observe_card, ObserveHover};
 pub(crate) use reminders::reminders_card;
 pub(crate) use speed::speed_card;
 pub(crate) use timers::{compact_left as timer_compact_left, timer_card};
+pub(crate) use weather::{compact_weather, weather_card};

--- a/crates/nook/src/widgets/weather.rs
+++ b/crates/nook/src/widgets/weather.rs
@@ -1,0 +1,199 @@
+//! Open-Meteo weather Nook pane.
+
+use crate::icons::lucide_color;
+use crate::island::ui::{nook_display, nook_empty, nook_pane};
+use crate::island::Island;
+use crate::theme;
+use gpui::{div, prelude::*, px, AnyElement, Context, FontWeight};
+use nook_core::weather::{self, WeatherSnapshot};
+
+pub(crate) fn weather_card(island: &mut Island, cx: &mut Context<Island>) -> impl IntoElement {
+    island.ensure_weather(cx);
+    let body = match (&island.weather, &island.weather_error) {
+        (Some(snap), _) => forecast_body(snap).into_any_element(),
+        (None, Some(err)) => nook_empty("cloud", err.clone()).into_any_element(),
+        (None, None) if island.settings.weather.location.coords().is_none() => {
+            nook_empty("map-pin", "Set a city in Settings").into_any_element()
+        }
+        (None, None) => nook_empty("cloud-sun", "Loading weather…").into_any_element(),
+    };
+    nook_pane("nook-weather").w_full().child(body)
+}
+
+fn forecast_body(snap: &WeatherSnapshot) -> impl IntoElement {
+    let place = if snap.location_name.is_empty() {
+        snap.label().to_string()
+    } else {
+        snap.location_name.clone()
+    };
+    let hi_lo = match (snap.high, snap.low) {
+        (Some(hi), Some(lo)) => format!(
+            "H {}  L {}",
+            weather::format_temp(hi),
+            weather::format_temp(lo)
+        ),
+        _ => snap.label().to_string(),
+    };
+    let mut hours = div().flex().items_end().justify_between().w_full().gap(px(6.));
+    for (i, hour) in snap.hourly.iter().take(6).enumerate() {
+        hours = hours.child(hour_col(i, hour));
+    }
+    div()
+        .w_full()
+        .h_full()
+        .flex()
+        .flex_col()
+        .justify_between()
+        .overflow_hidden()
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(px(10.))
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(8.))
+                        .child(lucide_color(snap.icon(), 22.0, theme::LABEL))
+                        .child(nook_display(weather::format_temp(snap.temperature))),
+                )
+                .child(
+                    div()
+                        .flex()
+                        .flex_col()
+                        .items_end()
+                        .gap(px(1.))
+                        .child(
+                            div()
+                                .text_size(px(12.))
+                                .line_height(px(15.))
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(theme::LABEL)
+                                .child(place),
+                        )
+                        .child(
+                            div()
+                                .text_size(px(11.))
+                                .line_height(px(14.))
+                                .text_color(theme::SECONDARY_LABEL)
+                                .child(hi_lo),
+                        ),
+                ),
+        )
+        .child(hours)
+}
+
+fn hour_col(index: usize, hour: &nook_core::weather::HourlyForecast) -> impl IntoElement {
+    div()
+        .id(("wx-h", index))
+        .flex()
+        .flex_col()
+        .items_center()
+        .gap(px(2.))
+        .child(
+            div()
+                .text_size(px(10.))
+                .line_height(px(12.))
+                .text_color(theme::TERTIARY_LABEL)
+                .child(hour.hour.clone()),
+        )
+        .child(lucide_color(
+            weather::wmo_icon(hour.wmo_code, true),
+            12.0,
+            theme::SECONDARY_LABEL,
+        ))
+        .child(
+            div()
+                .text_size(px(11.))
+                .line_height(px(13.))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(theme::LABEL)
+                .child(weather::format_temp(hour.temperature)),
+        )
+}
+
+pub(crate) fn compact_weather(island: &Island) -> AnyElement {
+    let Some(snap) = island.weather.as_ref() else {
+        return div().into_any_element();
+    };
+    if !island.settings.weather.enabled || !island.settings.weather.show_on_compact_face {
+        return div().into_any_element();
+    }
+    div()
+        .flex()
+        .items_center()
+        .gap(px(6.))
+        .child(lucide_color(snap.icon(), 16.0, theme::LABEL))
+        .child(
+            div()
+                .text_size(px(13.))
+                .line_height(px(16.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::LABEL)
+                .child(weather::format_temp(snap.temperature)),
+        )
+        .into_any_element()
+}
+
+impl Island {
+    pub(crate) fn weather_visible(&self) -> bool {
+        if !self.settings.weather.enabled {
+            return false;
+        }
+        if self.expanded {
+            return true;
+        }
+        self.settings.weather.show_on_compact_face
+    }
+
+    pub(crate) fn ensure_weather(&mut self, cx: &mut Context<Self>) {
+        if self.weather_inflight {
+            return;
+        }
+        if !self.settings.weather.enabled {
+            return;
+        }
+        if self.settings.weather.location.coords().is_none() {
+            return;
+        }
+        if weather::is_fresh_for(&self.settings.weather) && self.weather.is_some() {
+            return;
+        }
+        self.refresh_weather(cx);
+    }
+
+    pub(crate) fn refresh_weather(&mut self, cx: &mut Context<Self>) {
+        if self.weather_inflight {
+            return;
+        }
+        let settings = self.settings.weather.clone();
+        if settings.location.coords().is_none() {
+            return;
+        }
+        self.weather_inflight = true;
+        cx.spawn(async move |this, cx| {
+            let result = cx
+                .background_executor()
+                .spawn(async move { nook_core::runtime().block_on(weather::fetch(&settings)) })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.weather_inflight = false;
+                match result {
+                    Ok(snap) => {
+                        this.weather = Some(snap);
+                        this.weather_error = None;
+                    }
+                    Err(err) => {
+                        if this.weather.is_none() {
+                            this.weather_error = Some(err);
+                        }
+                    }
+                }
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+}


### PR DESCRIPTION
Weather on the shelf (WP07 only). Open-Meteo forecast + geocoding, no WeatherKit.

## What landed
- `nook-core` Open-Meteo client with a 30-minute TTL, exponential backoff, WMO → icon/label mapping, and geocoding search
- `WidgetModule::Weather` (3 cells default) with enable toggle, °C/°F, city search (up to 5 results), and optional CoreLocation one-shot (`requestLocation`, reduced accuracy)
- Expanded card: current temp, condition glyph, hi/lo, hourly strip
- Compact idle-face adornment (temp + glyph) when the setting is on
- Settings attribution: “Weather data by Open-Meteo.com” (CC-BY)
- Refresh is lazy (card/adornment) and wake-driven (`NSWorkspaceDidWakeNotification`); no hot poll loop
- Manual location is the default (no TCC). System location is opt-in; Info.plist usage strings added

## Tests
`cargo test -p nook -p nook-core` green (nook-core 86, nook 82). New coverage: WMO mapping, forecast/geocode parse, TTL, settings defaults, location fallback without CoreLocation.

## Notes / blockers
- CoreLocation was not compiled on this Linux CI host; the macOS `define_class!` delegate needs a macOS build to verify
- No IP geolocation first-run guess (privacy)
- WeatherKit remains a dead end for unsigned/dev-signed distribution