### PR TITLE
WP06: High Alert keep-awake + Pomodoro

### DIFF
--- a/crates/nook-core/src/focus.rs
+++ b/crates/nook-core/src/focus.rs
@@ -1,0 +1,123 @@
+//! Optional Focus hook via the Shortcuts CLI.
+//!
+//! macOS has no public API to set a Focus mode. The supported route is a
+//! user-authored shortcut that openNook runs on pomodoro phase edges. Fire
+//! and forget — never block the island tick.
+
+pub fn run_shortcut_detached(name: Option<&str>) {
+    let Some(name) = name.map(str::trim).filter(|name| !name.is_empty()) else {
+        return;
+    };
+    let name = name.to_string();
+    crate::runtime().spawn(async move {
+        if let Err(err) = run_shortcut(&name).await {
+            log::debug!("focus shortcut '{name}': {err}");
+        }
+    });
+}
+
+pub async fn run_shortcut(name: &str) -> Result<(), String> {
+    let name = name.trim();
+    if name.is_empty() {
+        return Ok(());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::run_shortcut(name).await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = name;
+        Err("Shortcuts are only available on macOS".into())
+    }
+}
+
+pub async fn list_shortcuts() -> Vec<String> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::list_shortcuts().await
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Vec::new()
+    }
+}
+
+/// Cycle None → first listed name → next → None.
+pub fn cycle_shortcut(current: Option<&str>, listed: &[String]) -> Option<String> {
+    if listed.is_empty() {
+        return None;
+    }
+    let Some(current) = current.map(str::trim).filter(|name| !name.is_empty()) else {
+        return Some(listed[0].clone());
+    };
+    match listed.iter().position(|name| name == current) {
+        Some(i) if i + 1 < listed.len() => Some(listed[i + 1].clone()),
+        _ => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    pub async fn list_shortcuts() -> Vec<String> {
+        let output = tokio::process::Command::new("/usr/bin/shortcuts")
+            .arg("list")
+            .output()
+            .await;
+        match output {
+            Ok(output) if output.status.success() => String::from_utf8_lossy(&output.stdout)
+                .lines()
+                .map(str::trim)
+                .filter(|line| !line.is_empty())
+                .map(str::to_string)
+                .collect(),
+            Ok(output) => {
+                log::debug!(
+                    "shortcuts list failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                Vec::new()
+            }
+            Err(err) => {
+                log::debug!("shortcuts list: {err}");
+                Vec::new()
+            }
+        }
+    }
+
+    pub async fn run_shortcut(name: &str) -> Result<(), String> {
+        let output = tokio::process::Command::new("/usr/bin/shortcuts")
+            .arg("run")
+            .arg(name)
+            .kill_on_drop(true)
+            .output()
+            .await
+            .map_err(|err| err.to_string())?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cycle_shortcut_walks_the_list_then_clears() {
+        let listed = vec!["Focus Work".into(), "Focus Break".into()];
+        assert_eq!(
+            cycle_shortcut(None, &listed).as_deref(),
+            Some("Focus Work")
+        );
+        assert_eq!(
+            cycle_shortcut(Some("Focus Work"), &listed).as_deref(),
+            Some("Focus Break")
+        );
+        assert_eq!(cycle_shortcut(Some("Focus Break"), &listed), None);
+        assert_eq!(cycle_shortcut(Some("missing"), &listed), None);
+        assert_eq!(cycle_shortcut(None, &[]), None);
+    }
+}

--- a/crates/nook-core/src/high_alert.rs
+++ b/crates/nook-core/src/high_alert.rs
@@ -1,0 +1,497 @@
+//! Keep-awake via IOPM assertions (High Alert).
+//!
+//! Creating an assertion is one IPC into powerd; after that the row lives in
+//! powerd and this process takes no wakeups. Timed expiry uses
+//! `kIOPMAssertionTimeoutActionRelease` so powerd drops the assertion itself.
+//! Manual High Alert and pomodoro work-phase auto-awake share one assertion
+//! through owner bits — releasing one must not kill the other.
+//!
+//! Self-contained: WP05's battery/`power.rs` is a different module on another
+//! branch. Low-battery auto-release registers an IOPS run-loop source only
+//! while an assertion is live.
+
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU8, Ordering};
+use std::time::Duration;
+
+const OWNER_MANUAL: u32 = 1;
+const OWNER_POMODORO: u32 = 2;
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum HighAlertKind {
+    #[default]
+    Display,
+    System,
+}
+
+impl HighAlertKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Display => "Display",
+            Self::System => "System",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HighAlertOwner {
+    Manual,
+    Pomodoro,
+}
+
+impl HighAlertOwner {
+    fn bit(self) -> u32 {
+        match self {
+            Self::Manual => OWNER_MANUAL,
+            Self::Pomodoro => OWNER_POMODORO,
+        }
+    }
+}
+
+static OWNERS: AtomicU32 = AtomicU32::new(0);
+static KIND: AtomicU8 = AtomicU8::new(0);
+static TIMEOUT_SECS: AtomicU32 = AtomicU32::new(0);
+static LOW_BATTERY_PCT: AtomicU8 = AtomicU8::new(10);
+static UI_STALE: AtomicBool = AtomicBool::new(false);
+
+pub fn is_active() -> bool {
+    OWNERS.load(Ordering::Relaxed) != 0
+}
+
+pub fn is_held_by(owner: HighAlertOwner) -> bool {
+    OWNERS.load(Ordering::Relaxed) & owner.bit() != 0
+}
+
+/// Island tick / render: powerd may have released a timed assertion, or the
+/// low-battery callback cleared owners. Cheap atomic; no IOKit.
+pub fn take_ui_stale() -> bool {
+    UI_STALE.swap(false, Ordering::SeqCst)
+}
+
+pub fn set_low_battery_release_pct(pct: u8) {
+    LOW_BATTERY_PCT.store(pct, Ordering::Relaxed);
+}
+
+/// Acquire or refresh `owner`'s hold. `timeout` is stored for Manual so a
+/// later pomodoro release can recreate the timed assertion. Pomodoro passes
+/// `None` (held until the work phase ends).
+pub fn acquire(
+    owner: HighAlertOwner,
+    kind: HighAlertKind,
+    timeout: Option<Duration>,
+) -> Result<(), String> {
+    KIND.store(kind as u8, Ordering::Relaxed);
+    if owner == HighAlertOwner::Manual {
+        TIMEOUT_SECS.store(
+            timeout
+                .map(|d| d.as_secs().min(u32::MAX as u64) as u32)
+                .unwrap_or(0),
+            Ordering::Relaxed,
+        );
+    }
+    OWNERS.fetch_or(owner.bit(), Ordering::SeqCst);
+    apply_assertion()
+}
+
+pub fn release(owner: HighAlertOwner) {
+    OWNERS.fetch_and(!owner.bit(), Ordering::SeqCst);
+    let _ = apply_assertion();
+}
+
+pub fn release_all() {
+    OWNERS.store(0, Ordering::SeqCst);
+    TIMEOUT_SECS.store(0, Ordering::Relaxed);
+    native_release();
+    stop_battery_watch();
+}
+
+/// Drop the IOPS source once no owner remains (safe outside the callback).
+pub fn reap_idle() {
+    if OWNERS.load(Ordering::Relaxed) == 0 {
+        stop_battery_watch();
+    }
+}
+
+fn current_kind() -> HighAlertKind {
+    if KIND.load(Ordering::Relaxed) == HighAlertKind::System as u8 {
+        HighAlertKind::System
+    } else {
+        HighAlertKind::Display
+    }
+}
+
+fn apply_assertion() -> Result<(), String> {
+    let owners = OWNERS.load(Ordering::SeqCst);
+    if owners == 0 {
+        native_release();
+        stop_battery_watch();
+        return Ok(());
+    }
+    // Timed expiry only when Manual is the sole owner. A live pomodoro hold
+    // must not be killed by powerd when the chip countdown ends.
+    let timeout = if owners == OWNER_MANUAL {
+        match TIMEOUT_SECS.load(Ordering::Relaxed) {
+            0 => None,
+            secs => Some(Duration::from_secs(secs as u64)),
+        }
+    } else {
+        None
+    };
+    native_acquire(current_kind(), timeout)?;
+    start_battery_watch();
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn native_acquire(_kind: HighAlertKind, _timeout: Option<Duration>) -> Result<(), String> {
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn native_release() {}
+
+#[cfg(not(target_os = "macos"))]
+fn start_battery_watch() {}
+
+#[cfg(not(target_os = "macos"))]
+fn stop_battery_watch() {}
+
+#[cfg(target_os = "macos")]
+fn native_acquire(kind: HighAlertKind, timeout: Option<Duration>) -> Result<(), String> {
+    macos::acquire(kind, timeout)
+}
+
+#[cfg(target_os = "macos")]
+fn native_release() {
+    macos::release();
+}
+
+#[cfg(target_os = "macos")]
+fn start_battery_watch() {
+    macos::start_battery_watch();
+}
+
+#[cfg(target_os = "macos")]
+fn stop_battery_watch() {
+    macos::stop_battery_watch();
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use std::ffi::CStr;
+    use std::os::raw::{c_char, c_void};
+    use std::ptr;
+    use std::sync::atomic::AtomicPtr;
+
+    type CfTypeRef = *const c_void;
+    type CfStringRef = *const c_void;
+    type CfArrayRef = *const c_void;
+    type CfDictionaryRef = *const c_void;
+    type CfNumberRef = *const c_void;
+    type CfBooleanRef = *const c_void;
+    type CfAllocatorRef = *const c_void;
+    type CfRunLoopRef = *mut c_void;
+    type CfRunLoopSourceRef = *mut c_void;
+    type CfRunLoopMode = *const c_void;
+
+    const K_CFSTRING_ENCODING_UTF8: u32 = 0x0800_0100;
+    const K_CF_NUMBER_SINT32_TYPE: i32 = 3;
+    const K_IO_RETURN_SUCCESS: i32 = 0;
+    const LEVEL_ON: i32 = 255;
+
+    static ASSERTION_ID: AtomicU32 = AtomicU32::new(0);
+    static BATTERY_SRC: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+
+    #[link(name = "IOKit", kind = "framework")]
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn IOPMAssertionCreateWithDescription(
+            assertion_type: CfStringRef,
+            name: CfStringRef,
+            details: CfStringRef,
+            human_readable_reason: CfStringRef,
+            localization_bundle_path: CfStringRef,
+            timeout: f64,
+            timeout_action: CfStringRef,
+            assertion_id: *mut u32,
+        ) -> i32;
+        fn IOPMAssertionRelease(assertion_id: u32) -> i32;
+
+        fn IOPSNotificationCreateRunLoopSource(
+            callback: Option<unsafe extern "C" fn(*mut c_void)>,
+            context: *mut c_void,
+        ) -> CfRunLoopSourceRef;
+        fn IOPSCopyPowerSourcesInfo() -> CfTypeRef;
+        fn IOPSCopyPowerSourcesList(blob: CfTypeRef) -> CfArrayRef;
+        fn IOPSGetPowerSourceDescription(blob: CfTypeRef, ps: CfTypeRef) -> CfDictionaryRef;
+
+        fn CFRelease(cf: CfTypeRef);
+        fn CFGetTypeID(cf: CfTypeRef) -> usize;
+        fn CFStringCreateWithCString(
+            alloc: CfAllocatorRef,
+            c_str: *const c_char,
+            encoding: u32,
+        ) -> CfStringRef;
+        fn CFArrayGetCount(array: CfArrayRef) -> isize;
+        fn CFArrayGetValueAtIndex(array: CfArrayRef, idx: isize) -> CfTypeRef;
+        fn CFDictionaryGetValue(dict: CfDictionaryRef, key: CfTypeRef) -> CfTypeRef;
+        fn CFNumberGetTypeID() -> usize;
+        fn CFNumberGetValue(number: CfNumberRef, the_type: i32, value_ptr: *mut c_void) -> u8;
+        fn CFBooleanGetTypeID() -> usize;
+        fn CFBooleanGetValue(boolean: CfBooleanRef) -> u8;
+        fn CFRunLoopGetMain() -> CfRunLoopRef;
+        fn CFRunLoopAddSource(rl: CfRunLoopRef, source: CfRunLoopSourceRef, mode: CfRunLoopMode);
+        fn CFRunLoopRemoveSource(rl: CfRunLoopRef, source: CfRunLoopSourceRef, mode: CfRunLoopMode);
+        static kCFRunLoopDefaultMode: CfStringRef;
+    }
+
+    fn cfstr(text: &CStr) -> CfStringRef {
+        unsafe { CFStringCreateWithCString(ptr::null(), text.as_ptr(), K_CFSTRING_ENCODING_UTF8) }
+    }
+
+    fn cf_release(cf: CfTypeRef) {
+        if !cf.is_null() {
+            unsafe { CFRelease(cf) };
+        }
+    }
+
+    pub fn acquire(kind: HighAlertKind, timeout: Option<Duration>) -> Result<(), String> {
+        release();
+        let type_key = match kind {
+            HighAlertKind::Display => c"PreventUserIdleDisplaySleep",
+            HighAlertKind::System => c"PreventUserIdleSystemSleep",
+        };
+        let assertion_type = cfstr(type_key);
+        let name = cfstr(c"openNook High Alert");
+        let details = cfstr(c"Keeping the Mac awake from the island.");
+        let timeout_secs = timeout.map(|d| d.as_secs_f64()).unwrap_or(0.0);
+        let action = if timeout_secs > 0.0 {
+            cfstr(c"TimeoutActionRelease")
+        } else {
+            ptr::null()
+        };
+        let mut id = 0u32;
+        let status = unsafe {
+            IOPMAssertionCreateWithDescription(
+                assertion_type,
+                name,
+                details,
+                ptr::null(),
+                ptr::null(),
+                timeout_secs,
+                action,
+                &mut id,
+            )
+        };
+        cf_release(assertion_type);
+        cf_release(name);
+        cf_release(details);
+        cf_release(action);
+        if status != K_IO_RETURN_SUCCESS || id == 0 {
+            return Err(format!("IOPM assertion failed ({status})"));
+        }
+        ASSERTION_ID.store(id, Ordering::SeqCst);
+        Ok(())
+    }
+
+    pub fn release() {
+        let id = ASSERTION_ID.swap(0, Ordering::SeqCst);
+        if id != 0 {
+            unsafe {
+                let _ = IOPMAssertionRelease(id);
+            }
+        }
+    }
+
+    pub fn start_battery_watch() {
+        if !BATTERY_SRC.load(Ordering::SeqCst).is_null() {
+            return;
+        }
+        let src = unsafe { IOPSNotificationCreateRunLoopSource(Some(on_power_source), ptr::null_mut()) };
+        if src.is_null() {
+            return;
+        }
+        unsafe {
+            CFRunLoopAddSource(CFRunLoopGetMain(), src, kCFRunLoopDefaultMode);
+        }
+        BATTERY_SRC.store(src, Ordering::SeqCst);
+    }
+
+    pub fn stop_battery_watch() {
+        let src = BATTERY_SRC.swap(ptr::null_mut(), Ordering::SeqCst);
+        if src.is_null() {
+            return;
+        }
+        unsafe {
+            CFRunLoopRemoveSource(CFRunLoopGetMain(), src, kCFRunLoopDefaultMode);
+            CFRelease(src as CfTypeRef);
+        }
+    }
+
+    unsafe extern "C" fn on_power_source(_ctx: *mut c_void) {
+        let threshold = LOW_BATTERY_PCT.load(Ordering::Relaxed);
+        if threshold == 0 {
+            return;
+        }
+        if OWNERS.load(Ordering::Relaxed) == 0 {
+            return;
+        }
+        if should_release_for_battery(threshold) {
+            // Don't tear down the run-loop source from inside its own callback.
+            OWNERS.store(0, Ordering::SeqCst);
+            release();
+            UI_STALE.store(true, Ordering::SeqCst);
+            log::info!("High Alert released: battery at or below {threshold}%");
+        }
+    }
+
+    fn should_release_for_battery(threshold: u8) -> bool {
+        let blob = unsafe { IOPSCopyPowerSourcesInfo() };
+        if blob.is_null() {
+            return false;
+        }
+        let list = unsafe { IOPSCopyPowerSourcesList(blob) };
+        if list.is_null() {
+            cf_release(blob);
+            return false;
+        }
+        let mut release = false;
+        unsafe {
+            let count = CFArrayGetCount(list);
+            for i in 0..count {
+                let ps = CFArrayGetValueAtIndex(list, i);
+                let dict = IOPSGetPowerSourceDescription(blob, ps);
+                if dict.is_null() {
+                    continue;
+                }
+                if dict_bool(dict, c"Is Charging") {
+                    continue;
+                }
+                let state = dict_string(dict, c"Power Source State");
+                if state.as_deref() == Some("AC Power") {
+                    continue;
+                }
+                let Some(cur) = dict_i32(dict, c"Current Capacity") else {
+                    continue;
+                };
+                let max = dict_i32(dict, c"Max Capacity").unwrap_or(100).max(1);
+                let pct = ((cur as i64 * 100) / max as i64) as u8;
+                if pct <= threshold {
+                    release = true;
+                    break;
+                }
+            }
+        }
+        cf_release(list as CfTypeRef);
+        cf_release(blob);
+        release
+    }
+
+    fn dict_i32(dict: CfDictionaryRef, key: &CStr) -> Option<i32> {
+        let cf_key = cfstr(key);
+        let value = unsafe { CFDictionaryGetValue(dict, cf_key) };
+        cf_release(cf_key);
+        if value.is_null() {
+            return None;
+        }
+        unsafe {
+            if CFGetTypeID(value) != CFNumberGetTypeID() {
+                return None;
+            }
+            let mut out: i32 = 0;
+            if CFNumberGetValue(value as CfNumberRef, K_CF_NUMBER_SINT32_TYPE, &mut out as *mut i32 as *mut c_void)
+                == 0
+            {
+                return None;
+            }
+            Some(out)
+        }
+    }
+
+    fn dict_bool(dict: CfDictionaryRef, key: &CStr) -> bool {
+        let cf_key = cfstr(key);
+        let value = unsafe { CFDictionaryGetValue(dict, cf_key) };
+        cf_release(cf_key);
+        if value.is_null() {
+            return false;
+        }
+        unsafe { CFGetTypeID(value) == CFBooleanGetTypeID() && CFBooleanGetValue(value as CfBooleanRef) != 0 }
+    }
+
+    fn dict_string(dict: CfDictionaryRef, key: &CStr) -> Option<String> {
+        let cf_key = cfstr(key);
+        let value = unsafe { CFDictionaryGetValue(dict, cf_key) };
+        cf_release(cf_key);
+        if value.is_null() {
+            return None;
+        }
+        // Power Source State is a CFString; reuse GetCString via a small stack buf.
+        unsafe extern "C" {
+            fn CFStringGetTypeID() -> usize;
+            fn CFStringGetCString(
+                string: CfStringRef,
+                buffer: *mut c_char,
+                buffer_size: isize,
+                encoding: u32,
+            ) -> u8;
+        }
+        unsafe {
+            if CFGetTypeID(value) != CFStringGetTypeID() {
+                return None;
+            }
+            let mut buf = [0i8; 64];
+            if CFStringGetCString(
+                value as CfStringRef,
+                buf.as_mut_ptr(),
+                buf.len() as isize,
+                K_CFSTRING_ENCODING_UTF8,
+            ) == 0
+            {
+                return None;
+            }
+            CStr::from_ptr(buf.as_ptr()).to_str().ok().map(str::to_string)
+        }
+    }
+
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reset() {
+        release_all();
+        UI_STALE.store(false, Ordering::SeqCst);
+    }
+
+    #[test]
+    fn owners_refcount_manual_and_pomodoro() {
+        reset();
+        assert!(!is_active());
+        acquire(HighAlertOwner::Manual, HighAlertKind::Display, Some(Duration::from_secs(60)))
+            .unwrap();
+        assert!(is_active());
+        assert!(is_held_by(HighAlertOwner::Manual));
+        acquire(HighAlertOwner::Pomodoro, HighAlertKind::Display, None).unwrap();
+        assert!(is_held_by(HighAlertOwner::Pomodoro));
+        release(HighAlertOwner::Manual);
+        assert!(is_active(), "pomodoro hold survives manual off");
+        assert!(!is_held_by(HighAlertOwner::Manual));
+        release(HighAlertOwner::Pomodoro);
+        assert!(!is_active());
+        reset();
+    }
+
+    #[test]
+    fn release_all_clears_every_owner() {
+        reset();
+        let _ = acquire(HighAlertOwner::Manual, HighAlertKind::System, None);
+        let _ = acquire(HighAlertOwner::Pomodoro, HighAlertKind::System, None);
+        release_all();
+        assert!(!is_active());
+        assert!(!is_held_by(HighAlertOwner::Manual));
+        assert!(!is_held_by(HighAlertOwner::Pomodoro));
+    }
+}

--- a/crates/nook-core/src/high_alert.rs
+++ b/crates/nook-core/src/high_alert.rs
@@ -91,7 +91,14 @@ pub fn acquire(
         );
     }
     OWNERS.fetch_or(owner.bit(), Ordering::SeqCst);
-    apply_assertion()
+    if let Err(e) = apply_assertion() {
+        // Failed native create must not leave a ghost owner; remaining
+        // holders keep the assertion.
+        OWNERS.fetch_and(!owner.bit(), Ordering::SeqCst);
+        let _ = apply_assertion();
+        return Err(e);
+    }
+    Ok(())
 }
 
 pub fn release(owner: HighAlertOwner) {
@@ -143,41 +150,41 @@ fn apply_assertion() -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(test, not(target_os = "macos")))]
 fn native_acquire(_kind: HighAlertKind, _timeout: Option<Duration>) -> Result<(), String> {
     Ok(())
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(test, not(target_os = "macos")))]
 fn native_release() {}
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(test, not(target_os = "macos")))]
 fn start_battery_watch() {}
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(any(test, not(target_os = "macos")))]
 fn stop_battery_watch() {}
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(test)))]
 fn native_acquire(kind: HighAlertKind, timeout: Option<Duration>) -> Result<(), String> {
     macos::acquire(kind, timeout)
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(test)))]
 fn native_release() {
     macos::release();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(test)))]
 fn start_battery_watch() {
     macos::start_battery_watch();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(test)))]
 fn stop_battery_watch() {
     macos::stop_battery_watch();
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(all(target_os = "macos", not(test)))]
 mod macos {
     use super::*;
     use std::ffi::CStr;
@@ -460,25 +467,56 @@ mod macos {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::{Mutex, MutexGuard};
+
+    /// `OWNERS` / `TIMEOUT_SECS` are process-global.
+    static LOCK: Mutex<()> = Mutex::new(());
+
+    fn lock() -> MutexGuard<'static, ()> {
+        LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
 
     fn reset() {
         release_all();
+        set_low_battery_release_pct(0);
         UI_STALE.store(false, Ordering::SeqCst);
     }
 
     #[test]
     fn owners_refcount_manual_and_pomodoro() {
+        let _guard = lock();
         reset();
         assert!(!is_active());
-        acquire(HighAlertOwner::Manual, HighAlertKind::Display, Some(Duration::from_secs(60)))
-            .unwrap();
+        acquire(
+            HighAlertOwner::Manual,
+            HighAlertKind::Display,
+            Some(Duration::from_secs(60)),
+        )
+        .unwrap();
         assert!(is_active());
         assert!(is_held_by(HighAlertOwner::Manual));
+        assert!(!is_held_by(HighAlertOwner::Pomodoro));
+        assert_eq!(
+            TIMEOUT_SECS.load(Ordering::Relaxed),
+            60,
+            "manual hold is timed — never the forever default"
+        );
+
         acquire(HighAlertOwner::Pomodoro, HighAlertKind::Display, None).unwrap();
         assert!(is_held_by(HighAlertOwner::Pomodoro));
+        assert!(is_held_by(HighAlertOwner::Manual));
+        assert_eq!(OWNERS.load(Ordering::SeqCst), OWNER_MANUAL | OWNER_POMODORO);
+        assert_eq!(
+            TIMEOUT_SECS.load(Ordering::Relaxed),
+            60,
+            "pomodoro must not clear the manual timeout"
+        );
+
         release(HighAlertOwner::Manual);
         assert!(is_active(), "pomodoro hold survives manual off");
         assert!(!is_held_by(HighAlertOwner::Manual));
+        assert!(is_held_by(HighAlertOwner::Pomodoro));
+
         release(HighAlertOwner::Pomodoro);
         assert!(!is_active());
         reset();
@@ -486,12 +524,19 @@ mod tests {
 
     #[test]
     fn release_all_clears_every_owner() {
+        let _guard = lock();
         reset();
-        let _ = acquire(HighAlertOwner::Manual, HighAlertKind::System, None);
-        let _ = acquire(HighAlertOwner::Pomodoro, HighAlertKind::System, None);
+        acquire(
+            HighAlertOwner::Manual,
+            HighAlertKind::System,
+            Some(Duration::from_secs(30 * 60)),
+        )
+        .unwrap();
+        acquire(HighAlertOwner::Pomodoro, HighAlertKind::System, None).unwrap();
         release_all();
         assert!(!is_active());
         assert!(!is_held_by(HighAlertOwner::Manual));
         assert!(!is_held_by(HighAlertOwner::Pomodoro));
+        assert_eq!(TIMEOUT_SECS.load(Ordering::Relaxed), 0);
     }
 }

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -9,7 +9,9 @@ pub mod browser_media;
 pub mod calendar;
 pub mod database;
 pub mod files;
+pub mod focus;
 pub mod haptics;
+pub mod high_alert;
 #[cfg(target_os = "macos")]
 mod mediaremote;
 pub mod models;
@@ -18,6 +20,7 @@ pub mod notch;
 pub mod notes;
 pub mod observe;
 pub mod occupancy;
+pub mod pomodoro;
 pub mod settings;
 pub mod utils;
 pub mod widgets;

--- a/crates/nook-core/src/pomodoro.rs
+++ b/crates/nook-core/src/pomodoro.rs
@@ -1,0 +1,181 @@
+//! Pomodoro phase machine. Wall-clock deadlines live on the island timer;
+//! this module is pure so phase advance is unit-tested without GPUI.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum PomodoroPhase {
+    Work,
+    ShortBreak,
+    LongBreak,
+}
+
+impl PomodoroPhase {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Work => "Work",
+            Self::ShortBreak => "Break",
+            Self::LongBreak => "Long break",
+        }
+    }
+
+    pub fn is_work(self) -> bool {
+        matches!(self, Self::Work)
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PomodoroSpec {
+    pub phase: PomodoroPhase,
+    /// 1-based index of the current (or just-finished) work interval.
+    pub cycle: u8,
+    pub work_secs: u32,
+    pub break_secs: u32,
+    pub long_break_secs: u32,
+    pub cycles_per_long: u8,
+    pub auto_advance: bool,
+}
+
+impl PomodoroSpec {
+    pub fn new(
+        work_secs: u32,
+        break_secs: u32,
+        long_break_secs: u32,
+        cycles_per_long: u8,
+        auto_advance: bool,
+    ) -> Self {
+        Self {
+            phase: PomodoroPhase::Work,
+            cycle: 1,
+            work_secs: work_secs.max(1),
+            break_secs: break_secs.max(1),
+            long_break_secs: long_break_secs.max(1),
+            cycles_per_long: cycles_per_long.max(1),
+            auto_advance,
+        }
+    }
+
+    pub fn duration_secs(self) -> u32 {
+        match self.phase {
+            PomodoroPhase::Work => self.work_secs,
+            PomodoroPhase::ShortBreak => self.break_secs,
+            PomodoroPhase::LongBreak => self.long_break_secs,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        self.phase.label()
+    }
+
+    /// Advance to the next phase. Work N → short break, or long break when
+    /// `cycle` is a multiple of `cycles_per_long`. Any break → next work.
+    pub fn advance(self) -> Self {
+        match self.phase {
+            PomodoroPhase::Work => {
+                let long = self.cycles_per_long > 0 && self.cycle % self.cycles_per_long == 0;
+                Self {
+                    phase: if long {
+                        PomodoroPhase::LongBreak
+                    } else {
+                        PomodoroPhase::ShortBreak
+                    },
+                    ..self
+                }
+            }
+            PomodoroPhase::ShortBreak => Self {
+                phase: PomodoroPhase::Work,
+                cycle: self.cycle.saturating_add(1),
+                ..self
+            },
+            PomodoroPhase::LongBreak => Self {
+                phase: PomodoroPhase::Work,
+                cycle: 1,
+                ..self
+            },
+        }
+    }
+
+    /// Dots filled in the featured timer: the current work cycle, including
+    /// the break that follows it.
+    pub fn filled_cycles(self) -> u8 {
+        self.cycle.min(self.cycles_per_long)
+    }
+}
+
+/// Seconds left until `deadline`. Zero when the deadline is missing or past.
+pub fn remaining_until(deadline: Option<std::time::SystemTime>, now: std::time::SystemTime) -> u32 {
+    let Some(deadline) = deadline else {
+        return 0;
+    };
+    deadline
+        .duration_since(now)
+        .map(|d| d.as_secs().min(u32::MAX as u64) as u32)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    fn spec(cycle: u8, phase: PomodoroPhase) -> PomodoroSpec {
+        PomodoroSpec {
+            phase,
+            cycle,
+            work_secs: 1500,
+            break_secs: 300,
+            long_break_secs: 900,
+            cycles_per_long: 4,
+            auto_advance: true,
+        }
+    }
+
+    #[test]
+    fn work_advances_to_short_break() {
+        let next = spec(1, PomodoroPhase::Work).advance();
+        assert_eq!(next.phase, PomodoroPhase::ShortBreak);
+        assert_eq!(next.cycle, 1);
+        assert_eq!(next.duration_secs(), 300);
+        assert_eq!(next.filled_cycles(), 1);
+    }
+
+    #[test]
+    fn fourth_work_advances_to_long_break() {
+        let next = spec(4, PomodoroPhase::Work).advance();
+        assert_eq!(next.phase, PomodoroPhase::LongBreak);
+        assert_eq!(next.cycle, 4);
+        assert_eq!(next.duration_secs(), 900);
+        assert_eq!(next.filled_cycles(), 4);
+    }
+
+    #[test]
+    fn short_break_starts_next_work() {
+        let next = spec(2, PomodoroPhase::ShortBreak).advance();
+        assert_eq!(next.phase, PomodoroPhase::Work);
+        assert_eq!(next.cycle, 3);
+        assert_eq!(next.duration_secs(), 1500);
+    }
+
+    #[test]
+    fn long_break_restarts_the_set() {
+        let next = spec(4, PomodoroPhase::LongBreak).advance();
+        assert_eq!(next.phase, PomodoroPhase::Work);
+        assert_eq!(next.cycle, 1);
+        assert_eq!(next.duration_secs(), 1500);
+    }
+
+    #[test]
+    fn remaining_until_is_zero_when_past() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(100);
+        assert_eq!(remaining_until(None, now), 0);
+        assert_eq!(
+            remaining_until(Some(now - Duration::from_secs(5)), now),
+            0
+        );
+        assert_eq!(
+            remaining_until(Some(now + Duration::from_secs(90)), now),
+            90
+        );
+    }
+}

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -1,4 +1,5 @@
 use crate::database;
+use crate::high_alert::HighAlertKind;
 use crate::observe::ObserveConfig;
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
@@ -17,10 +18,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    HighAlert = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +33,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::HighAlert,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -45,7 +48,7 @@ impl WidgetModule {
         match self {
             Self::Calendar | Self::Music => 5,
             Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
-            Self::Timers | Self::Speed | Self::Mirror => 3,
+            Self::Timers | Self::Speed | Self::Mirror | Self::HighAlert => 3,
         }
     }
 
@@ -53,13 +56,13 @@ impl WidgetModule {
         match self {
             Self::Calendar => 4,
             Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
-            Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
+            Self::Notes | Self::Timers | Self::Speed | Self::Agents | Self::HighAlert => 2,
         }
     }
 
     pub fn max_cells(self) -> u8 {
         match self {
-            Self::Timers | Self::Speed | Self::Agents | Self::Mirror => 6,
+            Self::Timers | Self::Speed | Self::Agents | Self::Mirror | Self::HighAlert => 6,
             _ => 8,
         }
     }
@@ -82,6 +85,7 @@ fn default_widget_order() -> Vec<WidgetModule> {
         WidgetModule::Timers,
         WidgetModule::Notes,
         WidgetModule::Speed,
+        WidgetModule::HighAlert,
     ]
 }
 
@@ -142,6 +146,32 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default = "default_true")]
+    pub show_high_alert: bool,
+    /// Seconds; `0` means until turned off. Default is 30 minutes — never forever.
+    #[serde(default = "default_high_alert_duration")]
+    pub high_alert_default_duration_secs: u32,
+    #[serde(default)]
+    pub high_alert_kind: HighAlertKind,
+    /// Auto-release the assertion at or below this battery percent. `0` disables.
+    #[serde(default = "default_low_battery_pct")]
+    pub low_battery_release_pct: u8,
+    #[serde(default = "default_pomo_work")]
+    pub pomodoro_work_secs: u32,
+    #[serde(default = "default_pomo_break")]
+    pub pomodoro_break_secs: u32,
+    #[serde(default = "default_pomo_long")]
+    pub pomodoro_long_break_secs: u32,
+    #[serde(default = "default_pomo_cycles")]
+    pub pomodoro_cycles_per_long: u8,
+    #[serde(default = "default_true")]
+    pub pomodoro_auto_advance: bool,
+    #[serde(default = "default_true")]
+    pub pomodoro_keep_awake: bool,
+    #[serde(default)]
+    pub focus_shortcut_work: Option<String>,
+    #[serde(default)]
+    pub focus_shortcut_break: Option<String>,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -217,6 +247,30 @@ fn default_true() -> bool {
     true
 }
 
+fn default_high_alert_duration() -> u32 {
+    30 * 60
+}
+
+fn default_low_battery_pct() -> u8 {
+    10
+}
+
+fn default_pomo_work() -> u32 {
+    25 * 60
+}
+
+fn default_pomo_break() -> u32 {
+    5 * 60
+}
+
+fn default_pomo_long() -> u32 {
+    15 * 60
+}
+
+fn default_pomo_cycles() -> u8 {
+    4
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -231,6 +285,18 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            show_high_alert: true,
+            high_alert_default_duration_secs: default_high_alert_duration(),
+            high_alert_kind: HighAlertKind::default(),
+            low_battery_release_pct: default_low_battery_pct(),
+            pomodoro_work_secs: default_pomo_work(),
+            pomodoro_break_secs: default_pomo_break(),
+            pomodoro_long_break_secs: default_pomo_long(),
+            pomodoro_cycles_per_long: default_pomo_cycles(),
+            pomodoro_auto_advance: true,
+            pomodoro_keep_awake: true,
+            focus_shortcut_work: None,
+            focus_shortcut_break: None,
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +342,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::HighAlert => self.show_high_alert,
         }
     }
 
@@ -291,6 +358,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::HighAlert => self.show_high_alert = !self.show_high_alert,
         }
     }
 
@@ -611,6 +679,17 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.show_high_alert);
+        assert_eq!(parsed.high_alert_default_duration_secs, 30 * 60);
+        assert_eq!(parsed.high_alert_kind, HighAlertKind::Display);
+        assert_eq!(parsed.low_battery_release_pct, 10);
+        assert_eq!(parsed.pomodoro_work_secs, 25 * 60);
+        assert_eq!(parsed.pomodoro_break_secs, 5 * 60);
+        assert_eq!(parsed.pomodoro_long_break_secs, 15 * 60);
+        assert_eq!(parsed.pomodoro_cycles_per_long, 4);
+        assert!(parsed.pomodoro_auto_advance);
+        assert!(parsed.pomodoro_keep_awake);
+        assert_eq!(parsed.focus_shortcut_work, None);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +775,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.show_high_alert = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook/src/assets/icons/sun.svg
+++ b/crates/nook/src/assets/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<circle cx="12" cy="12" r="4"/>
+<path d="M12 2v2"/>
+<path d="M12 20v2"/>
+<path d="m4.93 4.93 1.41 1.41"/>
+<path d="m17.66 17.66 1.41 1.41"/>
+<path d="M2 12h2"/>
+<path d="M20 12h2"/>
+<path d="m6.34 17.66-1.41 1.41"/>
+<path d="m19.07 4.93-1.41 1.41"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -3,7 +3,7 @@
 use super::media::{album_chip, visualizer};
 use super::ui::{label, timer_text};
 use super::{CompactMode, Island};
-use crate::icons::lucide;
+use crate::icons::{lucide, lucide_color};
 use crate::theme;
 use crate::widgets;
 use gpui::{
@@ -36,7 +36,15 @@ impl Island {
                     .items_center()
                     .justify_start()
                     .overflow_hidden()
-                    .child(self.compact_left(mode, cx)),
+                    .child(self.compact_left(mode, cx))
+                    .when(mode != CompactMode::Idle && self.high_alert_active(), |d| {
+                        d.child(
+                            div()
+                                .ml(px(4.))
+                                .flex_shrink_0()
+                                .child(lucide_color("sun", 10.0, theme::SUCCESS)),
+                        )
+                    }),
             )
             .child(div().w(px(notch_w)).flex_shrink_0().h_full())
             .child(
@@ -64,7 +72,13 @@ impl Island {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
             CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
-            CompactMode::Idle => div().into_any_element(),
+            CompactMode::Idle => {
+                if self.high_alert_active() {
+                    lucide_color("sun", 12.0, theme::SUCCESS).into_any_element()
+                } else {
+                    div().into_any_element()
+                }
+            }
         }
     }
 

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, calendar_card, high_alert_card, notes_card, observe_card, reminders_card,
+    speed_card, timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -155,6 +156,13 @@ impl Island {
                     cell_pane(
                         self.settings.cells_for(module),
                         speed_card(self.speed_mbps, self.speed_progress, self.speed_running, cx),
+                    ),
+                ),
+                WidgetModule::HighAlert if self.settings.show_high_alert => add(
+                    &mut kids,
+                    cell_pane(
+                        self.settings.cells_for(module),
+                        high_alert_card(self, cx),
                     ),
                 ),
                 _ => {}

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -26,9 +26,11 @@ use nook_core::files::FileTrayItem;
 use nook_core::models::NowPlayingData;
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
+use nook_core::high_alert::HighAlertOwner;
+use nook_core::pomodoro::{PomodoroPhase, PomodoroSpec};
 use nook_core::settings::AppSettings;
 use settings::SettingsView;
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CompactMode {
@@ -47,6 +49,12 @@ pub enum Tab {
     Files,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum TimerKind {
+    Countdown,
+    Pomodoro(PomodoroSpec),
+}
+
 #[derive(Clone)]
 pub struct Timer {
     pub id: u64,
@@ -55,6 +63,10 @@ pub struct Timer {
     pub remaining: u32,
     pub total: u32,
     pub running: bool,
+    pub kind: TimerKind,
+    /// Wall-clock end of a running pomodoro phase. Instant would stall across
+    /// lid-close sleep; powerd-side High Alert does not need this.
+    pub ends_at: Option<SystemTime>,
 }
 
 pub struct Island {
@@ -83,6 +95,10 @@ pub struct Island {
     pub calendar_day: u8,
     /// Preset chips for a new timer, matching the React add dialog.
     pub timer_composer: bool,
+    /// Manual High Alert deadline for the card readout. `None` = until off.
+    /// powerd owns expiry; this is display-only and is not a wakeup source.
+    pub awake_deadline: Option<Instant>,
+    pub awake_active: bool,
     pub observe: ObserveSnapshot,
     observe_history: MetricHistory,
     pub(crate) observe_hover: Option<crate::widgets::ObserveHover>,
@@ -210,6 +226,8 @@ impl Island {
             next_timer_id: 1,
             calendar_day: 3,
             timer_composer: false,
+            awake_deadline: None,
+            awake_active: false,
             observe: ObserveSnapshot::default(),
             observe_history: nook_core::observe::load_history(),
             observe_hover: None,
@@ -329,6 +347,9 @@ impl Island {
                         } else {
                             this.settings = settings;
                         }
+                        nook_core::high_alert::set_low_battery_release_pct(
+                            this.settings.low_battery_release_pct,
+                        );
                         dirty = true;
                     }
                     if this.repositioning {
@@ -448,18 +469,14 @@ impl Island {
                         // Repaint only when a countdown actually moved — an
                         // unconditional dirty here kept the island rendering
                         // (and Metal submitting) once a second forever.
-                        for t in &mut this.timers {
-                            if t.running && t.remaining > 0 {
-                                t.remaining = t.remaining.saturating_sub(elapsed_secs);
-                                dirty = true;
-                                if t.remaining == 0 {
-                                    t.running = false;
-                                    nook_core::haptics::trigger(Some(nook_core::haptics::HapticConfig {
-                                        pattern: nook_core::haptics::HapticPattern::Success,
-                                        intensity: 1.0,
-                                    }));
-                                }
-                            }
+                        if this.apply_timer_tick(SystemTime::now(), elapsed_secs) {
+                            dirty = true;
+                        }
+                        if this.sync_high_alert_ui(Instant::now()) {
+                            dirty = true;
+                        } else if this.expanded && this.awake_active {
+                            // Card readout only; idle face is an on/off glyph.
+                            dirty = true;
                         }
                     }
                     let levels = nook_core::audio::get_audio_levels();
@@ -750,13 +767,193 @@ impl Island {
         if let Some(t) = self.timers.iter_mut().find(|t| t.id == id) {
             t.remaining = t.total;
             t.running = false;
+            t.ends_at = None;
+            if let TimerKind::Pomodoro(spec) = t.kind {
+                t.name = spec.label().to_string();
+            }
         }
+        self.sync_pomodoro_awake();
     }
 
     pub(crate) fn remove_timer(&mut self, id: u64) {
         self.timers.retain(|t| t.id != id);
         if self.timers.is_empty() {
             self.timer_composer = false;
+        }
+        self.sync_pomodoro_awake();
+    }
+
+    pub(crate) fn toggle_timer(&mut self, id: u64) {
+        let now = SystemTime::now();
+        if let Some(t) = self.timers.iter_mut().find(|t| t.id == id) {
+            t.running = !t.running;
+            if t.running {
+                if matches!(t.kind, TimerKind::Pomodoro(_)) {
+                    t.ends_at = Some(now + Duration::from_secs(t.remaining.max(1) as u64));
+                }
+            } else {
+                t.ends_at = None;
+            }
+        }
+        self.sync_pomodoro_awake();
+    }
+
+    /// Advance running timers. Pomodoro remaining is computed from a wall-clock
+    /// deadline so a lid-close does not stall a break. Countdown still uses the
+    /// existing Instant-derived `elapsed_secs`. Returns whether anything moved.
+    pub(crate) fn apply_timer_tick(&mut self, now: SystemTime, elapsed_secs: u32) -> bool {
+        let mut dirty = false;
+        let mut edges: Vec<(bool, PomodoroPhase)> = Vec::new();
+        for t in &mut self.timers {
+            if !t.running {
+                continue;
+            }
+            match t.kind {
+                TimerKind::Countdown => {
+                    if t.remaining == 0 {
+                        continue;
+                    }
+                    t.remaining = t.remaining.saturating_sub(elapsed_secs);
+                    dirty = true;
+                    if t.remaining == 0 {
+                        t.running = false;
+                        nook_core::haptics::trigger(Some(nook_core::haptics::HapticConfig {
+                            pattern: nook_core::haptics::HapticPattern::Success,
+                            intensity: 1.0,
+                        }));
+                    }
+                }
+                TimerKind::Pomodoro(spec) => {
+                    let remaining = nook_core::pomodoro::remaining_until(t.ends_at, now);
+                    if remaining != t.remaining {
+                        t.remaining = remaining;
+                        dirty = true;
+                    }
+                    if remaining > 0 {
+                        continue;
+                    }
+                    nook_core::haptics::trigger(Some(nook_core::haptics::HapticConfig {
+                        pattern: nook_core::haptics::HapticPattern::Success,
+                        intensity: 1.0,
+                    }));
+                    if spec.auto_advance {
+                        let next = spec.advance();
+                        t.kind = TimerKind::Pomodoro(next);
+                        t.total = next.duration_secs();
+                        t.remaining = next.duration_secs();
+                        t.name = next.label().to_string();
+                        t.running = true;
+                        t.ends_at = Some(now + Duration::from_secs(next.duration_secs() as u64));
+                        edges.push((next.phase.is_work(), next.phase));
+                    } else {
+                        t.running = false;
+                        t.ends_at = None;
+                    }
+                    dirty = true;
+                }
+            }
+        }
+        for (is_work, _) in edges {
+            self.on_pomodoro_edge(is_work);
+        }
+        if dirty {
+            self.sync_pomodoro_awake();
+        }
+        dirty
+    }
+
+    fn on_pomodoro_edge(&self, work: bool) {
+        let name = if work {
+            self.settings.focus_shortcut_work.as_deref()
+        } else {
+            self.settings.focus_shortcut_break.as_deref()
+        };
+        nook_core::focus::run_shortcut_detached(name);
+    }
+
+    fn running_pomodoro_work(&self) -> bool {
+        self.timers.iter().any(|t| {
+            t.running
+                && matches!(
+                    t.kind,
+                    TimerKind::Pomodoro(spec) if spec.phase == PomodoroPhase::Work
+                )
+        })
+    }
+
+    fn sync_pomodoro_awake(&mut self) {
+        if self.settings.pomodoro_keep_awake && self.running_pomodoro_work() {
+            nook_core::high_alert::set_low_battery_release_pct(self.settings.low_battery_release_pct);
+            let _ = nook_core::high_alert::acquire(
+                HighAlertOwner::Pomodoro,
+                self.settings.high_alert_kind,
+                None,
+            );
+        } else {
+            nook_core::high_alert::release(HighAlertOwner::Pomodoro);
+        }
+        self.awake_active = nook_core::high_alert::is_active();
+    }
+
+    pub(crate) fn high_alert_active(&self) -> bool {
+        self.awake_active || nook_core::high_alert::is_active()
+    }
+
+    pub(crate) fn high_alert_remaining_secs(&self) -> Option<u32> {
+        let deadline = self.awake_deadline?;
+        Some(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .as_secs()
+                .min(u32::MAX as u64) as u32,
+        )
+    }
+
+    /// Sync UI with powerd / low-battery release. Cheap atomics; no extra loops.
+    pub(crate) fn sync_high_alert_ui(&mut self, now: Instant) -> bool {
+        let stale = nook_core::high_alert::take_ui_stale();
+        let expired = self
+            .awake_deadline
+            .is_some_and(|deadline| now >= deadline);
+        if expired && nook_core::high_alert::is_held_by(HighAlertOwner::Manual) {
+            nook_core::high_alert::release(HighAlertOwner::Manual);
+        }
+        let active = nook_core::high_alert::is_active();
+        let changed = stale || expired || self.awake_active != active;
+        if expired {
+            self.awake_deadline = None;
+        }
+        self.awake_active = active;
+        if !nook_core::high_alert::is_held_by(HighAlertOwner::Manual) {
+            self.awake_deadline = None;
+        }
+        nook_core::high_alert::reap_idle();
+        changed
+    }
+
+    pub(crate) fn set_high_alert(&mut self, on: bool, duration_secs: Option<u32>) {
+        nook_core::high_alert::set_low_battery_release_pct(self.settings.low_battery_release_pct);
+        if on {
+            let secs = duration_secs.unwrap_or(self.settings.high_alert_default_duration_secs);
+            let timeout = if secs == 0 {
+                None
+            } else {
+                Some(Duration::from_secs(secs as u64))
+            };
+            if nook_core::high_alert::acquire(
+                HighAlertOwner::Manual,
+                self.settings.high_alert_kind,
+                timeout,
+            )
+            .is_ok()
+            {
+                self.awake_deadline = timeout.map(|d| Instant::now() + d);
+                self.awake_active = true;
+            }
+        } else {
+            nook_core::high_alert::release(HighAlertOwner::Manual);
+            self.awake_deadline = None;
+            self.awake_active = nook_core::high_alert::is_active();
         }
     }
 
@@ -1331,10 +1528,37 @@ impl Island {
             remaining: seconds,
             total: seconds,
             running: true,
+            kind: TimerKind::Countdown,
+            ends_at: None,
         });
         self.next_timer_id += 1;
         self.timer_composer = false;
         self.preferred = Some(CompactMode::Timer);
+    }
+
+    pub(crate) fn add_pomodoro(&mut self) {
+        let spec = PomodoroSpec::new(
+            self.settings.pomodoro_work_secs,
+            self.settings.pomodoro_break_secs,
+            self.settings.pomodoro_long_break_secs,
+            self.settings.pomodoro_cycles_per_long,
+            self.settings.pomodoro_auto_advance,
+        );
+        let secs = spec.duration_secs();
+        self.timers.push(Timer {
+            id: self.next_timer_id,
+            name: spec.label().to_string(),
+            remaining: secs,
+            total: secs,
+            running: true,
+            kind: TimerKind::Pomodoro(spec),
+            ends_at: Some(SystemTime::now() + Duration::from_secs(secs as u64)),
+        });
+        self.next_timer_id += 1;
+        self.timer_composer = false;
+        self.preferred = Some(CompactMode::Timer);
+        self.on_pomodoro_edge(true);
+        self.sync_pomodoro_awake();
     }
 
     pub(crate) fn arm_file_drag(&mut self, path: String) {
@@ -1449,6 +1673,8 @@ mod tests {
             next_timer_id: 1,
             calendar_day: 3,
             timer_composer: false,
+            awake_deadline: None,
+            awake_active: false,
             observe: ObserveSnapshot::default(),
             observe_history: HashMap::new(),
             observe_hover: None,
@@ -1667,6 +1893,8 @@ mod tests {
             remaining: 30,
             total: 60,
             running: true,
+            kind: TimerKind::Countdown,
+            ends_at: None,
         });
         assert!(island.available_modes().contains(&CompactMode::Files));
         assert!(island.available_modes().contains(&CompactMode::Timer));
@@ -2107,5 +2335,102 @@ mod tests {
         assert!(island.blur > 0.5, "crossfade left the content sharp");
         let (dx, dy) = island.blur_offset().expect("crossfade needs a smear");
         assert!(dx > dy, "a still island should smear along its long axis");
+    }
+
+    fn pomo_timer(remaining: u32, spec: PomodoroSpec, ends_at: SystemTime) -> Timer {
+        Timer {
+            id: 1,
+            name: spec.label().to_string(),
+            remaining,
+            total: spec.duration_secs(),
+            running: true,
+            kind: TimerKind::Pomodoro(spec),
+            ends_at: Some(ends_at),
+        }
+    }
+
+    #[test]
+    fn pomodoro_tick_advances_work_to_short_break() {
+        let mut island = test_island();
+        island.settings.pomodoro_keep_awake = false;
+        let spec = PomodoroSpec::new(25, 5, 15, 4, true);
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(1_000);
+        island.timers.push(pomo_timer(1, spec, now));
+        assert!(island.apply_timer_tick(now, 1));
+        let t = &island.timers[0];
+        assert_eq!(
+            t.kind,
+            TimerKind::Pomodoro(PomodoroSpec {
+                phase: PomodoroPhase::ShortBreak,
+                cycle: 1,
+                ..spec
+            })
+        );
+        assert_eq!(t.remaining, 5);
+        assert_eq!(t.total, 5);
+        assert!(t.running);
+        assert_eq!(t.name, "Break");
+    }
+
+    #[test]
+    fn pomodoro_tick_fourth_work_goes_to_long_break() {
+        let mut island = test_island();
+        island.settings.pomodoro_keep_awake = false;
+        let spec = PomodoroSpec {
+            phase: PomodoroPhase::Work,
+            cycle: 4,
+            work_secs: 25,
+            break_secs: 5,
+            long_break_secs: 15,
+            cycles_per_long: 4,
+            auto_advance: true,
+        };
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(2_000);
+        island.timers.push(pomo_timer(0, spec, now));
+        island.apply_timer_tick(now, 1);
+        match island.timers[0].kind {
+            TimerKind::Pomodoro(next) => {
+                assert_eq!(next.phase, PomodoroPhase::LongBreak);
+                assert_eq!(next.cycle, 4);
+                assert_eq!(island.timers[0].remaining, 15);
+            }
+            TimerKind::Countdown => panic!("expected pomodoro"),
+        }
+    }
+
+    #[test]
+    fn pomodoro_without_auto_advance_stops() {
+        let mut island = test_island();
+        island.settings.pomodoro_keep_awake = false;
+        let spec = PomodoroSpec::new(25, 5, 15, 4, false);
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(3_000);
+        island.timers.push(pomo_timer(0, spec, now));
+        island.apply_timer_tick(now, 1);
+        assert!(!island.timers[0].running);
+        assert_eq!(island.timers[0].remaining, 0);
+        assert!(matches!(
+            island.timers[0].kind,
+            TimerKind::Pomodoro(s) if s.phase == PomodoroPhase::Work
+        ));
+    }
+
+    #[test]
+    fn countdown_tick_still_decrements() {
+        let mut island = test_island();
+        island.timers.push(Timer {
+            id: 1,
+            name: String::new(),
+            remaining: 10,
+            total: 10,
+            running: true,
+            kind: TimerKind::Countdown,
+            ends_at: None,
+        });
+        assert!(island.apply_timer_tick(SystemTime::UNIX_EPOCH, 3));
+        assert_eq!(island.timers[0].remaining, 7);
+        assert!(island.timers[0].running);
+        island.apply_timer_tick(SystemTime::UNIX_EPOCH, 7);
+        assert_eq!(island.timers[0].remaining, 0);
+        assert!(!island.timers[0].running);
     }
 }

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -9,6 +9,7 @@ use gpui::{
     ObjectFit, Pixels, Rgba, SharedString, Subscription, Window,
 };
 use gpui_component::slider::{Slider, SliderEvent, SliderState};
+use nook_core::high_alert::HighAlertKind;
 use nook_core::settings::{AppSettings, IslandSwatch, WidgetModule, ISLAND_SWATCHES};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -131,6 +132,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::HighAlert => "High Alert",
         }
     }
 
@@ -146,6 +148,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::HighAlert => "sun",
         }
     }
 
@@ -161,6 +164,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::HighAlert => "Keep awake".into(),
         }
     }
 
@@ -184,6 +188,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::HighAlert => "Alert",
         }
     }
 }
@@ -376,6 +381,26 @@ impl SettingsView {
                     }
                     Err(err) => this.catalog_error = Some(err),
                 }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    fn fetch_shortcuts(&mut self, cx: &mut Context<Self>) {
+        if self.catalog_loading {
+            return;
+        }
+        self.catalog_loading = true;
+        cx.spawn(async move |this, cx| {
+            let names = cx
+                .background_executor()
+                .spawn(async { nook_core::runtime().block_on(nook_core::focus::list_shortcuts()) })
+                .await;
+            this.update(cx, |this, cx| {
+                this.catalog_loading = false;
+                this.catalog = names;
                 cx.notify();
             })
             .ok();
@@ -795,6 +820,9 @@ impl SettingsView {
                 cx.listener(move |this, _, _, cx| {
                     this.module = module;
                     this.persist_nav();
+                    if module == WidgetModule::Timers {
+                        this.fetch_shortcuts(cx);
+                    }
                     cx.notify();
                 }),
             )
@@ -997,6 +1025,12 @@ impl SettingsView {
                     )
                     .into_any_element(),
                 );
+            }
+            WidgetModule::HighAlert => {
+                rows.extend(high_alert_rows(settings, cx));
+            }
+            WidgetModule::Timers => {
+                rows.extend(pomodoro_rows(settings, &self.catalog, cx));
             }
             _ => {}
         }
@@ -1349,13 +1383,18 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Now Playing from MediaRemote on macOS, with an AppleScript fallback.".into()
         }
         WidgetModule::Files => "Drop zone and tray live on the Tray tab of the expanded island.".into(),
-        WidgetModule::Timers => "Countdown presets and a compact ring while a timer is running.".into(),
+        WidgetModule::Timers => {
+            "Countdown presets, a Pomodoro work/break cycle, and an optional Focus shortcut.".into()
+        }
         WidgetModule::Reminders => "Incomplete reminders from EventKit, same store as Calendar.".into(),
         WidgetModule::Speed => "Cloudflare (then OVH) download probe. Runs from the island card.".into(),
         WidgetModule::Agents => {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::HighAlert => {
+            "IOPM keep-awake. Timed chips expire in powerd — lid-close sleep is not prevented.".into()
+        }
     }
 }
 
@@ -1393,6 +1432,200 @@ fn caption_text(text: impl Into<SharedString>) -> impl IntoElement {
         .child(text.into())
 }
 
+fn high_alert_rows(
+    settings: &AppSettings,
+    cx: &mut Context<SettingsView>,
+) -> Vec<AnyElement> {
+    let duration = settings.high_alert_default_duration_secs;
+    let kind = settings.high_alert_kind;
+    let battery = settings.low_battery_release_pct;
+    vec![
+        chip_row(
+            "Default duration",
+            &[
+                ("15m", duration == 15 * 60),
+                ("30m", duration == 30 * 60),
+                ("1h", duration == 60 * 60),
+                ("On", duration == 0),
+            ],
+            cx,
+            |caption, s| {
+                s.high_alert_default_duration_secs = match caption {
+                    "15m" => 15 * 60,
+                    "1h" => 60 * 60,
+                    "On" => 0,
+                    _ => 30 * 60,
+                };
+            },
+        )
+        .into_any_element(),
+        chip_row(
+            "Keep awake",
+            &[
+                ("Display", kind == HighAlertKind::Display),
+                ("System", kind == HighAlertKind::System),
+            ],
+            cx,
+            |caption, s| {
+                s.high_alert_kind = if caption == "System" {
+                    HighAlertKind::System
+                } else {
+                    HighAlertKind::Display
+                };
+            },
+        )
+        .into_any_element(),
+        chip_row(
+            "Release below",
+            &[
+                ("Off", battery == 0),
+                ("10%", battery == 10),
+                ("20%", battery == 20),
+            ],
+            cx,
+            |caption, s| {
+                s.low_battery_release_pct = match caption {
+                    "Off" => 0,
+                    "20%" => 20,
+                    _ => 10,
+                };
+            },
+        )
+        .into_any_element(),
+    ]
+}
+
+fn pomodoro_rows(
+    settings: &AppSettings,
+    catalog: &[String],
+    cx: &mut Context<SettingsView>,
+) -> Vec<AnyElement> {
+    let work = settings.pomodoro_work_secs;
+    let brk = settings.pomodoro_break_secs;
+    let long = settings.pomodoro_long_break_secs;
+    let cycles = settings.pomodoro_cycles_per_long;
+    let work_name = settings
+        .focus_shortcut_work
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("None")
+        .to_string();
+    let break_name = settings
+        .focus_shortcut_break
+        .as_deref()
+        .filter(|s| !s.is_empty())
+        .unwrap_or("None")
+        .to_string();
+    let listed: Vec<String> = catalog.to_vec();
+    vec![
+        chip_row(
+            "Work",
+            &[("25m", work == 25 * 60), ("50m", work == 50 * 60)],
+            cx,
+            |caption, s| {
+                s.pomodoro_work_secs = if caption == "50m" { 50 * 60 } else { 25 * 60 };
+            },
+        )
+        .into_any_element(),
+        chip_row(
+            "Break",
+            &[("5m", brk == 5 * 60), ("10m", brk == 10 * 60)],
+            cx,
+            |caption, s| {
+                s.pomodoro_break_secs = if caption == "10m" { 10 * 60 } else { 5 * 60 };
+            },
+        )
+        .into_any_element(),
+        chip_row(
+            "Long break",
+            &[("15m", long == 15 * 60), ("20m", long == 20 * 60)],
+            cx,
+            |caption, s| {
+                s.pomodoro_long_break_secs = if caption == "20m" { 20 * 60 } else { 15 * 60 };
+            },
+        )
+        .into_any_element(),
+        chip_row(
+            "Cycles",
+            &[("3", cycles == 3), ("4", cycles == 4)],
+            cx,
+            |caption, s| {
+                s.pomodoro_cycles_per_long = if caption == "3" { 3 } else { 4 };
+            },
+        )
+        .into_any_element(),
+        toggle_row(
+            "Auto-advance phases",
+            settings.pomodoro_auto_advance,
+            cx,
+            |s| s.pomodoro_auto_advance = !s.pomodoro_auto_advance,
+        )
+        .into_any_element(),
+        toggle_row(
+            "Keep awake on work",
+            settings.pomodoro_keep_awake,
+            cx,
+            |s| s.pomodoro_keep_awake = !s.pomodoro_keep_awake,
+        )
+        .into_any_element(),
+        action_row(
+            "focus-work",
+            "Work shortcut",
+            work_name,
+            cx,
+            move |_, _, cx| {
+                let next = nook_core::focus::cycle_shortcut(
+                    nook_core::settings::get_app_settings()
+                        .focus_shortcut_work
+                        .as_deref(),
+                    &listed,
+                );
+                nook_core::settings::tweak_app_settings(|s| s.focus_shortcut_work = next);
+                cx.notify();
+            },
+        )
+        .into_any_element(),
+        action_row(
+            "focus-break",
+            "Break shortcut",
+            break_name,
+            cx,
+            {
+                let listed = catalog.to_vec();
+                move |_, _, cx| {
+                    let next = nook_core::focus::cycle_shortcut(
+                        nook_core::settings::get_app_settings()
+                            .focus_shortcut_break
+                            .as_deref(),
+                        &listed,
+                    );
+                    nook_core::settings::tweak_app_settings(|s| s.focus_shortcut_break = next);
+                    cx.notify();
+                }
+            },
+        )
+        .into_any_element(),
+    ]
+}
+
+fn chip_row(
+    title: &'static str,
+    chips: &[(&'static str, bool)],
+    cx: &mut Context<SettingsView>,
+    tweak: impl Fn(&'static str, &mut AppSettings) + Copy + 'static,
+) -> impl IntoElement {
+    let mut group = segmented_group();
+    for (caption, selected) in chips.iter().copied() {
+        group = group.child(segment(caption, selected, cx, move |_, _, cx| {
+            nook_core::settings::tweak_app_settings(|s| tweak(caption, s));
+            cx.notify();
+        }));
+    }
+    settings_row(title)
+        .child(label(title, theme::BODY, true))
+        .child(group)
+}
+
 fn settings_group(rows: Vec<AnyElement>) -> impl IntoElement {
     let mut group = div()
         .flex()
@@ -1423,7 +1656,7 @@ fn settings_row(id: impl Into<SharedString>) -> gpui::Stateful<gpui::Div> {
 fn action_row(
     id: &'static str,
     title: &'static str,
-    caption: &'static str,
+    caption: impl Into<SharedString>,
     cx: &mut Context<SettingsView>,
     on_click: impl Fn(&mut SettingsView, &mut Window, &mut Context<SettingsView>) + 'static,
 ) -> impl IntoElement {
@@ -1727,6 +1960,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "High Alert",
             ]
         );
         assert!(!names

--- a/crates/nook/src/main.rs
+++ b/crates/nook/src/main.rs
@@ -21,7 +21,10 @@ fn main() {
             nook_core::init();
             platform::install();
             platform::install_status_item();
-            cx.on_action(|_: &Quit, cx| cx.quit());
+            cx.on_action(|_: &Quit, cx| {
+                nook_core::high_alert::release_all();
+                cx.quit();
+            });
             cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
             open_island(cx);
             cx.activate(false);

--- a/crates/nook/src/widgets/high_alert.rs
+++ b/crates/nook/src/widgets/high_alert.rs
@@ -1,0 +1,160 @@
+//! High Alert keep-awake card: toggle + duration chips + remaining readout.
+
+use crate::icons::lucide_color;
+use crate::island::ui::{format_timer, nook_display, nook_pane};
+use crate::island::Island;
+use crate::theme;
+use gpui::{
+    div, prelude::*, px, rgba, Context, CursorStyle, FontWeight, MouseButton, MouseDownEvent,
+    SharedString,
+};
+
+const CHIPS: [(&str, Option<u32>); 4] = [
+    ("15m", Some(15 * 60)),
+    ("30m", Some(30 * 60)),
+    ("1h", Some(60 * 60)),
+    ("On", None),
+];
+
+pub(crate) fn high_alert_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let active = island.high_alert_active();
+    let remaining = if active {
+        island
+            .high_alert_remaining_secs()
+            .map(format_timer)
+            .unwrap_or_else(|| "On".into())
+    } else {
+        "Off".into()
+    };
+    let selected = if active {
+        island
+            .awake_deadline
+            .and_then(|_| island.high_alert_remaining_secs())
+            .map(|secs| nearest_chip(secs, island.settings.high_alert_default_duration_secs))
+            .unwrap_or(None)
+    } else {
+        Some(island.settings.high_alert_default_duration_secs).filter(|s| *s > 0)
+    };
+
+    nook_pane("nook-high-alert")
+        .w_full()
+        .child(
+            div()
+                .flex()
+                .items_end()
+                .justify_between()
+                .gap(px(12.))
+                .flex_shrink_0()
+                .child(nook_display(remaining))
+                .child(toggle_btn(active, cx)),
+        )
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(6.))
+                .children(CHIPS.iter().map(|(label, secs)| {
+                    chip(*label, *secs, selected == *secs && active, cx)
+                })),
+        )
+        .child(
+            div()
+                .text_size(px(9.))
+                .line_height(px(11.))
+                .text_color(theme::TERTIARY_LABEL)
+                .child("Lid-close sleep is not prevented."),
+        )
+}
+
+fn nearest_chip(remaining: u32, default_secs: u32) -> Option<u32> {
+    if remaining == 0 {
+        return None;
+    }
+    CHIPS
+        .iter()
+        .filter_map(|(_, secs)| *secs)
+        .min_by_key(|secs| secs.abs_diff(remaining.max(default_secs.min(remaining))))
+}
+
+fn toggle_btn(active: bool, cx: &mut Context<Island>) -> impl IntoElement {
+    div()
+        .id("high-alert-toggle")
+        .size(px(22.))
+        .flex()
+        .items_center()
+        .justify_center()
+        .opacity(0.9)
+        .hover(|s| s.opacity(1.0))
+        .active(|s| s.opacity(0.75))
+        .cursor(CursorStyle::PointingHand)
+        .child(lucide_color(
+            "sun",
+            16.0,
+            if active {
+                theme::SUCCESS
+            } else {
+                theme::LABEL
+            },
+        ))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                if this.high_alert_active() && nook_core::high_alert::is_held_by(
+                    nook_core::high_alert::HighAlertOwner::Manual,
+                ) {
+                    this.set_high_alert(false, None);
+                } else {
+                    let secs = this.settings.high_alert_default_duration_secs;
+                    this.set_high_alert(true, Some(secs));
+                }
+                cx.notify();
+            }),
+        )
+}
+
+fn chip(
+    label: &'static str,
+    secs: Option<u32>,
+    selected: bool,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    div()
+        .id(SharedString::from(format!("high-alert-chip-{label}")))
+        .h(px(22.))
+        .px(px(8.))
+        .rounded(px(6.))
+        .flex()
+        .items_center()
+        .justify_center()
+        .bg(if selected {
+            theme::FILL_SECONDARY
+        } else {
+            rgba(0xffffff14)
+        })
+        .hover(|s| s.opacity(0.85))
+        .cursor(CursorStyle::PointingHand)
+        .child(
+            div()
+                .text_size(px(11.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(if selected {
+                    theme::LABEL
+                } else {
+                    theme::SECONDARY_LABEL
+                })
+                .child(label),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                this.settings.high_alert_default_duration_secs = secs.unwrap_or(0);
+                nook_core::settings::tweak_app_settings(|s| {
+                    s.high_alert_default_duration_secs = secs.unwrap_or(0);
+                });
+                this.set_high_alert(true, Some(secs.unwrap_or(0)));
+                cx.notify();
+            }),
+        )
+}

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -2,6 +2,7 @@
 
 mod agents;
 mod calendar;
+mod high_alert;
 mod notes;
 mod notes_editor;
 mod observe;
@@ -13,6 +14,7 @@ pub(crate) use agents::{
     agents_card, compact_left as agents_compact_left, compact_right as agents_compact_right,
 };
 pub(crate) use calendar::calendar_card;
+pub(crate) use high_alert::high_alert_card;
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};
 pub(crate) use observe::{observe_card, ObserveHover};

--- a/crates/nook/src/widgets/timers.rs
+++ b/crates/nook/src/widgets/timers.rs
@@ -2,7 +2,7 @@
 
 use crate::icons::{lucide, lucide_color};
 use crate::island::ui::{format_timer, nook_display, nook_empty, nook_icon_btn, nook_pane};
-use crate::island::{Island, Timer};
+use crate::island::{Island, Timer, TimerKind};
 use crate::theme;
 use gpui::{
     canvas, div, point, prelude::*, px, rgb, rgba, AnyElement, Context, FontWeight, MouseButton,
@@ -38,9 +38,7 @@ pub(crate) fn compact_left(island: &Island, cx: &mut Context<Island>) -> AnyElem
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                if let Some(t) = this.timers.iter_mut().find(|t| t.id == id) {
-                    t.running = !t.running;
-                }
+                this.toggle_timer(id);
                 cx.notify();
             }),
         )
@@ -52,7 +50,7 @@ pub(crate) fn compact_left(island: &Island, cx: &mut Context<Island>) -> AnyElem
             if done {
                 theme::DESTRUCTIVE
             } else {
-                rgb(0xffffff)
+                phase_color(timer)
             },
             rgba(0xffffff40),
         ))
@@ -114,6 +112,7 @@ pub(crate) fn timer_card(
     for (id, unit, num, seconds) in PRESETS {
         week = week.child(preset_col(id, unit, num, seconds, cx));
     }
+    week = week.child(pomodoro_col(cx));
 
     let remaining = timers.first().map(|t| format_timer(t.remaining));
     let body = if timers.is_empty() {
@@ -193,7 +192,7 @@ fn featured_timer(timer: &Timer, cx: &mut Context<Island>) -> impl IntoElement {
     let ring_color = if done {
         theme::DESTRUCTIVE
     } else {
-        theme::accent()
+        phase_color(timer)
     };
     let play_icon = if timer.running {
         "pause-fill"
@@ -246,6 +245,7 @@ fn featured_timer(timer: &Timer, cx: &mut Context<Island>) -> impl IntoElement {
                             timer.name.clone()
                         }),
                 )
+                .when_some(cycle_dots(timer), |d, dots| d.child(dots))
                 .child(
                     div()
                         .flex()
@@ -296,9 +296,7 @@ fn timer_face(
             MouseButton::Left,
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
-                if let Some(t) = this.timers.iter_mut().find(|t| t.id == id) {
-                    t.running = !t.running;
-                }
+                this.toggle_timer(id);
                 cx.notify();
             }),
         )
@@ -322,4 +320,67 @@ fn timer_face(
                     .child(lucide_color(play_icon, 16.0, rgb(0xffffff))),
             )
         })
+}
+
+fn pomodoro_col(cx: &mut Context<Island>) -> impl IntoElement {
+    div()
+        .id("timer-preset-pomo")
+        .flex()
+        .flex_col()
+        .items_center()
+        .gap(px(4.))
+        .cursor(gpui::CursorStyle::PointingHand)
+        .hover(|s| s.opacity(0.85))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                this.add_pomodoro();
+                cx.notify();
+            }),
+        )
+        .child(
+            div()
+                .text_size(px(9.))
+                .line_height(px(11.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::SECONDARY_LABEL)
+                .child("P"),
+        )
+        .child(
+            div()
+                .text_size(px(15.))
+                .line_height(px(18.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::LABEL)
+                .child("omo"),
+        )
+}
+
+fn phase_color(timer: &Timer) -> Rgba {
+    match timer.kind {
+        TimerKind::Pomodoro(spec) if !spec.phase.is_work() => theme::SUCCESS,
+        _ => theme::accent(),
+    }
+}
+
+fn cycle_dots(timer: &Timer) -> Option<impl IntoElement> {
+    let TimerKind::Pomodoro(spec) = timer.kind else {
+        return None;
+    };
+    let filled = spec.filled_cycles();
+    let mut row = div().flex().items_center().gap(px(4.)).mt(px(4.));
+    for i in 1..=spec.cycles_per_long {
+        row = row.child(
+            div()
+                .size(px(5.))
+                .rounded_full()
+                .bg(if i <= filled {
+                    theme::LABEL
+                } else {
+                    theme::TERTIARY_LABEL
+                }),
+        );
+    }
+    Some(row)
 }


### PR DESCRIPTION
## WP06 — focus-tools

High Alert (keep-awake via IOPM assertions) and Pomodoro (work/break cycles on the existing island timers), plus an optional Focus hook through Shortcuts.

Self-contained: does **not** depend on unmerged WP05 `power.rs`. Assertions live in `nook-core::high_alert`.

### High Alert
- `IOPMAssertionCreateWithDescription` / `IOPMAssertionRelease` (IOKit)
- Display vs system sleep (settings)
- Timed chips (15m / 30m / 1h / until off); default **30 minutes**, never forever
- Timeout is handed to powerd (`TimeoutActionRelease`) — zero app wakeups for expiry
- Manual + Pomodoro work-phase shares one assertion via owner bits
- Low-battery auto-release via `IOPSNotificationCreateRunLoopSource` (registered only while an assertion is live)
- Expanded card + sun glyph on the compact face
- Settings toggle; lid-close sleep disclaimer in the card
- Released on quit

### Pomodoro
- `TimerKind::Pomodoro` on the existing timer struct
- Phase advance on the existing 1 Hz tick; wall-clock deadlines (`SystemTime`) so lid-close does not stall a break
- Composer preset, phase-tinted ring, cycle dots
- Optional keep-awake during work phases
- Optional `shortcuts run` on work/break edges (fire-and-forget)

### Tests
`cargo test -p nook -p nook-core` — green (85 + 84).

Includes unit tests for pomodoro phase advance (work → short break, 4th work → long break, no auto-advance, countdown still decrements) and High Alert owner refcount.

### Honest limits
- Lid-close (clamshell) sleep is not preventable from user space.
- Focus cannot be set natively; the ceiling is a user-authored shortcut.