### PR TITLE
WP13: automation entry (URL scheme / CLI / Finder Services / Termi-Notch)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -30,5 +30,38 @@
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>Termi-Notch runs commands you type in the island. A command that touches Desktop needs this so the prompt names openNook.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>Termi-Notch runs commands you type in the island. A command that touches Documents needs this so the prompt names openNook.</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>com.jonasvogel.opennook-gpui</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>opennook</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Send to openNook</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>sendToOpenNook</string>
+			<key>NSPortName</key>
+			<string>openNook</string>
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.item</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>

--- a/crates/nook-core/src/automation.rs
+++ b/crates/nook-core/src/automation.rs
@@ -1,0 +1,449 @@
+//! `opennook://` URL grammar, tray-path checks, and the external-action bus.
+//!
+//! LaunchServices, the CLI shim, and Finder Services all push
+//! [`ExternalAction`]s here. The island drains the queue on the GPUI
+//! foreground executor. **Command execution is never a URL action** — browsers
+//! can invoke custom schemes, so mapping any of these to a shell would be RCE.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use tokio::sync::Notify;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpenNookCommand {
+    TrayAdd { paths: Vec<String> },
+    TrayClear,
+    TimerStart { seconds: u32 },
+    Expand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalAction {
+    TrayAdd(Vec<PathBuf>),
+    TrayClear,
+    TimerStart { seconds: u32 },
+    Expand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UrlError {
+    WrongScheme,
+    Forbidden,
+    UnknownAction,
+    MissingPath,
+    MissingSeconds,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathError {
+    Invalid,
+    Missing,
+    NotFileOrDir,
+}
+
+const SCHEME: &str = "opennook:";
+
+/// Actions a custom-scheme URL must never reach. Browsers can invoke
+/// `opennook://…` from a web page.
+const FORBIDDEN_SEGMENTS: &[&str] = &[
+    "shell", "exec", "run", "cmd", "command", "term", "terminal", "sh", "bash", "zsh",
+];
+
+pub fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+pub fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(hex) = std::str::from_utf8(&bytes[i + 1..i + 3]) {
+                if let Ok(value) = u8::from_str_radix(hex, 16) {
+                    out.push(value);
+                    i += 3;
+                    continue;
+                }
+            }
+        }
+        if bytes[i] == b'+' {
+            out.push(b' ');
+            i += 1;
+            continue;
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn looks_like_exec(path: &str) -> bool {
+    path.split('/')
+        .any(|seg| FORBIDDEN_SEGMENTS.contains(&seg.to_ascii_lowercase().as_str()))
+}
+
+fn query_params(query: Option<&str>) -> Vec<(String, String)> {
+    let Some(query) = query else {
+        return Vec::new();
+    };
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| match pair.split_once('=') {
+            Some((k, v)) => (percent_decode(k), percent_decode(v)),
+            None => (percent_decode(pair), String::new()),
+        })
+        .collect()
+}
+
+/// Parse an `opennook://` URL. Never returns a shell-exec action.
+pub fn parse_opennook_url(raw: &str) -> Result<OpenNookCommand, UrlError> {
+    let raw = raw.trim();
+    let rest = raw.strip_prefix(SCHEME).ok_or(UrlError::WrongScheme)?;
+    let rest = rest.strip_prefix("//").unwrap_or(rest);
+    let rest = rest.trim_start_matches('/');
+    let (path, query) = match rest.split_once('?') {
+        Some((path, query)) => (path, Some(query)),
+        None => (rest, None),
+    };
+    let path = path.trim_end_matches('/');
+    if path.is_empty() {
+        return Err(UrlError::UnknownAction);
+    }
+    if looks_like_exec(path) {
+        return Err(UrlError::Forbidden);
+    }
+    match path {
+        "tray/add" => {
+            let paths: Vec<String> = query_params(query)
+                .into_iter()
+                .filter(|(key, _)| key == "path")
+                .map(|(_, value)| value)
+                .filter(|value| !value.is_empty())
+                .collect();
+            if paths.is_empty() {
+                return Err(UrlError::MissingPath);
+            }
+            Ok(OpenNookCommand::TrayAdd { paths })
+        }
+        "tray/clear" => Ok(OpenNookCommand::TrayClear),
+        "timer/start" => {
+            let seconds = query_params(query)
+                .into_iter()
+                .find(|(key, _)| key == "seconds")
+                .and_then(|(_, value)| value.parse().ok())
+                .ok_or(UrlError::MissingSeconds)?;
+            Ok(OpenNookCommand::TimerStart { seconds })
+        }
+        "expand" => Ok(OpenNookCommand::Expand),
+        _ => Err(UrlError::UnknownAction),
+    }
+}
+
+/// Canonicalize `raw` and require a regular file or directory that exists.
+/// Used by `tray/add`, the CLI, and Finder Services — not by shell exec.
+pub fn validate_tray_path(raw: &str) -> Result<String, PathError> {
+    if raw.is_empty() || raw.contains('\0') {
+        return Err(PathError::Invalid);
+    }
+    let path = Path::new(raw);
+    let meta = fs_metadata(path)?;
+    if !meta.is_file() && !meta.is_dir() {
+        return Err(PathError::NotFileOrDir);
+    }
+    let canon = std::fs::canonicalize(path).map_err(|_| PathError::Missing)?;
+    Ok(canon.to_string_lossy().into_owned())
+}
+
+fn fs_metadata(path: &Path) -> Result<std::fs::Metadata, PathError> {
+    std::fs::metadata(path).map_err(|_| PathError::Missing)
+}
+
+pub fn tray_add_url(paths: &[impl AsRef<Path>]) -> String {
+    let mut url = String::from("opennook://tray/add");
+    let mut first = true;
+    for path in paths {
+        url.push(if first { '?' } else { '&' });
+        first = false;
+        url.push_str("path=");
+        url.push_str(&percent_encode(&path.as_ref().to_string_lossy()));
+    }
+    url
+}
+
+pub fn tray_clear_url() -> String {
+    "opennook://tray/clear".into()
+}
+
+pub fn timer_start_url(seconds: u32) -> String {
+    format!("opennook://timer/start?seconds={seconds}")
+}
+
+pub fn expand_url() -> String {
+    "opennook://expand".into()
+}
+
+/// Resolve and validate raw path strings from a parsed `tray/add`.
+pub fn validated_paths(raw: &[String]) -> Vec<PathBuf> {
+    raw.iter()
+        .filter_map(|path| validate_tray_path(path).ok().map(PathBuf::from))
+        .collect()
+}
+
+fn queue() -> &'static Mutex<Vec<ExternalAction>> {
+    static QUEUE: OnceLock<Mutex<Vec<ExternalAction>>> = OnceLock::new();
+    QUEUE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn wake() -> &'static Notify {
+    static WAKE: OnceLock<Notify> = OnceLock::new();
+    WAKE.get_or_init(Notify::new)
+}
+
+pub fn push_action(action: ExternalAction) {
+    if let Ok(mut guard) = queue().lock() {
+        guard.push(action);
+    }
+    wake().notify_waiters();
+}
+
+/// Parse LaunchServices URLs and enqueue only side-effect-safe actions.
+/// `file://` (and bare paths) become tray adds after [`validate_tray_path`].
+/// Anything that looks like shell execution is dropped.
+pub fn ingest_open_urls(urls: &[String]) {
+    for url in urls {
+        if let Some(path) = file_url_path(url) {
+            if let Ok(valid) = validate_tray_path(&path) {
+                push_action(ExternalAction::TrayAdd(vec![PathBuf::from(valid)]));
+            }
+            continue;
+        }
+        match parse_opennook_url(url) {
+            Ok(OpenNookCommand::TrayAdd { paths }) => {
+                let valid = validated_paths(&paths);
+                if !valid.is_empty() {
+                    push_action(ExternalAction::TrayAdd(valid));
+                }
+            }
+            Ok(OpenNookCommand::TrayClear) => push_action(ExternalAction::TrayClear),
+            Ok(OpenNookCommand::TimerStart { seconds }) => {
+                push_action(ExternalAction::TimerStart { seconds });
+            }
+            Ok(OpenNookCommand::Expand) => push_action(ExternalAction::Expand),
+            Err(UrlError::Forbidden) => {
+                log::warn!("ignored forbidden opennook URL (no shell mapping)");
+            }
+            Err(err) => log::debug!("ignored opennook URL ({err:?}): {url}"),
+        }
+    }
+}
+
+fn file_url_path(url: &str) -> Option<String> {
+    let rest = url.strip_prefix("file://")?;
+    let path = percent_decode(rest);
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+/// Block until an external action is available. Event-driven (tokio Notify).
+pub async fn recv_action() -> ExternalAction {
+    loop {
+        if let Some(action) = pop_action() {
+            return action;
+        }
+        wake().notified().await;
+    }
+}
+
+fn pop_action() -> Option<ExternalAction> {
+    queue().lock().ok()?.pop()
+}
+
+/// Enqueue already-validated file paths from Finder Services.
+pub fn ingest_service_paths(paths: Vec<PathBuf>) {
+    let valid: Vec<PathBuf> = paths
+        .into_iter()
+        .filter_map(|path| validate_tray_path(&path.to_string_lossy()).ok().map(PathBuf::from))
+        .collect();
+    if !valid.is_empty() {
+        push_action(ExternalAction::TrayAdd(valid));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_item(name: &str, dir: bool) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!("nook-wp13-{name}-{stamp}"));
+        if dir {
+            fs::create_dir_all(&path).unwrap();
+        } else {
+            fs::write(&path, b"ok").unwrap();
+        }
+        path
+    }
+
+    #[test]
+    fn parse_tray_add_repeats_path() {
+        let cmd = parse_opennook_url(
+            "opennook://tray/add?path=%2Ftmp%2Fa.txt&path=%2FUsers%2Fme%2Fb%20c",
+        )
+        .unwrap();
+        assert_eq!(
+            cmd,
+            OpenNookCommand::TrayAdd {
+                paths: vec!["/tmp/a.txt".into(), "/Users/me/b c".into()]
+            }
+        );
+    }
+
+    #[test]
+    fn parse_accepts_slash_variants() {
+        assert_eq!(
+            parse_opennook_url("opennook:tray/clear").unwrap(),
+            OpenNookCommand::TrayClear
+        );
+        assert_eq!(
+            parse_opennook_url("opennook:///expand").unwrap(),
+            OpenNookCommand::Expand
+        );
+        assert_eq!(
+            parse_opennook_url("opennook://timer/start?seconds=300").unwrap(),
+            OpenNookCommand::TimerStart { seconds: 300 }
+        );
+    }
+
+    #[test]
+    fn parse_rejects_wrong_scheme_and_unknown() {
+        assert_eq!(
+            parse_opennook_url("https://example.com/tray/add?path=/tmp"),
+            Err(UrlError::WrongScheme)
+        );
+        assert_eq!(
+            parse_opennook_url("opennook://settings"),
+            Err(UrlError::UnknownAction)
+        );
+        assert_eq!(
+            parse_opennook_url("opennook://tray/add"),
+            Err(UrlError::MissingPath)
+        );
+        assert_eq!(
+            parse_opennook_url("opennook://timer/start"),
+            Err(UrlError::MissingSeconds)
+        );
+    }
+
+    #[test]
+    fn parse_never_maps_urls_to_shell_exec() {
+        for url in [
+            "opennook://shell/exec?cmd=rm%20-rf%20/",
+            "opennook://exec?cmd=id",
+            "opennook://run/ls",
+            "opennook://cmd/whoami",
+            "opennook://command/id",
+            "opennook://term/run?cmd=ls",
+            "opennook://terminal?cmd=ls",
+            "opennook://sh?c=id",
+            "opennook://bash?c=id",
+            "opennook://zsh?c=id",
+            "opennook://tray/add/shell?path=/tmp",
+        ] {
+            assert_eq!(
+                parse_opennook_url(url),
+                Err(UrlError::Forbidden),
+                "{url}"
+            );
+        }
+    }
+
+    #[test]
+    fn builders_round_trip() {
+        let url = tray_add_url(&[Path::new("/tmp/hello world.txt")]);
+        assert_eq!(
+            parse_opennook_url(&url).unwrap(),
+            OpenNookCommand::TrayAdd {
+                paths: vec!["/tmp/hello world.txt".into()]
+            }
+        );
+        assert_eq!(
+            parse_opennook_url(&tray_clear_url()).unwrap(),
+            OpenNookCommand::TrayClear
+        );
+        assert_eq!(
+            parse_opennook_url(&timer_start_url(12)).unwrap(),
+            OpenNookCommand::TimerStart { seconds: 12 }
+        );
+        assert_eq!(
+            parse_opennook_url(&expand_url()).unwrap(),
+            OpenNookCommand::Expand
+        );
+    }
+
+    #[test]
+    fn validate_accepts_file_and_dir() {
+        let file = temp_item("file", false);
+        let dir = temp_item("dir", true);
+        let file_out = validate_tray_path(&file.to_string_lossy()).unwrap();
+        let dir_out = validate_tray_path(&dir.to_string_lossy()).unwrap();
+        assert!(Path::new(&file_out).is_file());
+        assert!(Path::new(&dir_out).is_dir());
+        let _ = fs::remove_file(&file);
+        let _ = fs::remove_dir(&dir);
+    }
+
+    #[test]
+    fn validate_rejects_missing_empty_and_nul() {
+        assert_eq!(
+            validate_tray_path("/no/such/nook-wp13-missing-path"),
+            Err(PathError::Missing)
+        );
+        assert_eq!(validate_tray_path(""), Err(PathError::Invalid));
+        assert_eq!(validate_tray_path("a\0b"), Err(PathError::Invalid));
+    }
+
+    #[test]
+    fn validate_resolves_relative_and_dotdot() {
+        let dir = temp_item("rel", true);
+        let file = dir.join("inner.txt");
+        fs::write(&file, b"x").unwrap();
+        let sneaky = dir.join("sub");
+        fs::create_dir_all(&sneaky).unwrap();
+        let via_dotdot = sneaky.join("..").join("inner.txt");
+        let canon = validate_tray_path(&via_dotdot.to_string_lossy()).unwrap();
+        assert_eq!(
+            Path::new(&canon),
+            fs::canonicalize(&file).unwrap().as_path()
+        );
+        let _ = fs::remove_file(&file);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn file_url_becomes_tray_path_candidate() {
+        assert_eq!(
+            file_url_path("file:///tmp/hello%20world"),
+            Some("/tmp/hello world".into())
+        );
+        assert_eq!(file_url_path("opennook://expand"), None);
+    }
+}

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod agents;
 pub mod audio;
+pub mod automation;
 pub mod browser_media;
 pub mod calendar;
 pub mod database;
@@ -19,6 +20,7 @@ pub mod notes;
 pub mod observe;
 pub mod occupancy;
 pub mod settings;
+pub mod shell;
 pub mod utils;
 pub mod widgets;
 
@@ -63,5 +65,6 @@ pub fn init() {
         audio::init_audio_state();
         audio::setup_audio_monitoring();
         mouse::start_polling();
+        shell::reap_orphaned_jobs();
     });
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -167,8 +167,25 @@ pub struct AppSettings {
     /// Per-widget widths in Nook cells. Missing entries use [`WidgetModule::default_cells`].
     #[serde(default)]
     pub widget_widths: Vec<(WidgetModule, u8)>,
+    /// Termi-Notch one-shot shell card. Off until the user opts in — this is
+    /// an arbitrary-code-execution surface and must stay unreachable from
+    /// `opennook://` URLs, the CLI, and Finder Services.
+    #[serde(default)]
+    pub terminal_enabled: bool,
+    /// Login shell used for `-lc`. Empty means `$SHELL`.
+    #[serde(default)]
+    pub terminal_shell: String,
+    #[serde(default = "default_terminal_timeout")]
+    pub terminal_timeout_secs: u32,
+    /// Persist typed commands in the settings DB. Off by default.
+    #[serde(default)]
+    pub terminal_history: bool,
     #[serde(default)]
     pub window: WindowSettings,
+}
+
+fn default_terminal_timeout() -> u32 {
+    30
 }
 
 fn default_island_x() -> f32 {
@@ -239,6 +256,10 @@ impl Default for AppSettings {
             hide_when_maximized: false,
             island_color: None,
             widget_widths: Vec::new(),
+            terminal_enabled: false,
+            terminal_shell: String::new(),
+            terminal_timeout_secs: default_terminal_timeout(),
+            terminal_history: false,
             window: WindowSettings::default(),
         }
     }
@@ -617,6 +638,10 @@ mod tests {
         assert_eq!(parsed.island_y, 0.0);
         assert!(!parsed.hide_when_maximized);
         assert_eq!(parsed.island_color, None);
+        assert!(!parsed.terminal_enabled);
+        assert!(parsed.terminal_shell.is_empty());
+        assert_eq!(parsed.terminal_timeout_secs, 30);
+        assert!(!parsed.terminal_history);
     }
 
     #[test]

--- a/crates/nook-core/src/shell.rs
+++ b/crates/nook-core/src/shell.rs
@@ -1,0 +1,438 @@
+//! One-shot login-shell commands for Termi-Notch (pipe MVP).
+//!
+//! Reachable only from typing in the island UI. URLs, the CLI, Services, and
+//! Alfred must never call this module. Children run in their own process group
+//! so cancel = `killpg`. Output is capped and timed out.
+
+use crate::app_data_dir;
+use crate::database;
+use crate::settings::get_app_settings;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::{Duration, Instant};
+use tokio::sync::Notify;
+
+pub const OUTPUT_CAP: usize = 256 * 1024;
+const HISTORY_KEY: &str = "shell_history";
+const HISTORY_CAP: usize = 50;
+const PGID_FILE: &str = "shell.pgid";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JobSnapshot {
+    pub output: String,
+    pub done: bool,
+    pub exit: Option<i32>,
+    pub timed_out: bool,
+    pub capped: bool,
+}
+
+struct JobInner {
+    output: Mutex<String>,
+    done: AtomicBool,
+    timed_out: AtomicBool,
+    capped: AtomicBool,
+    exit: Mutex<Option<i32>>,
+    notify: Notify,
+    pgid: AtomicU32,
+    cancel: AtomicBool,
+}
+
+#[derive(Clone)]
+pub struct JobHandle {
+    inner: Arc<JobInner>,
+}
+
+impl JobHandle {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(JobInner {
+                output: Mutex::new(String::new()),
+                done: AtomicBool::new(false),
+                timed_out: AtomicBool::new(false),
+                capped: AtomicBool::new(false),
+                exit: Mutex::new(None),
+                notify: Notify::new(),
+                pgid: AtomicU32::new(0),
+                cancel: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    pub fn snapshot(&self) -> JobSnapshot {
+        JobSnapshot {
+            output: self
+                .inner
+                .output
+                .lock()
+                .map(|g| g.clone())
+                .unwrap_or_default(),
+            done: self.inner.done.load(Ordering::SeqCst),
+            exit: self.inner.exit.lock().ok().and_then(|g| *g),
+            timed_out: self.inner.timed_out.load(Ordering::SeqCst),
+            capped: self.inner.capped.load(Ordering::SeqCst),
+        }
+    }
+
+    pub async fn wait_update(&self) -> JobSnapshot {
+        self.inner.notify.notified().await;
+        self.snapshot()
+    }
+
+    pub fn cancel(&self) {
+        self.inner.cancel.store(true, Ordering::SeqCst);
+        let pgid = self.inner.pgid.load(Ordering::SeqCst);
+        if pgid != 0 {
+            kill_group(pgid as i32);
+        }
+        self.inner.notify.notify_waiters();
+    }
+}
+
+/// `$SHELL` (or the settings override), used only by the in-island card.
+pub fn resolved_shell(override_path: &str) -> String {
+    let trimmed = override_path.trim();
+    if !trimmed.is_empty() {
+        return trimmed.to_string();
+    }
+    std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".into())
+}
+
+pub fn default_timeout_secs() -> u32 {
+    30
+}
+
+/// Strip CSI / OSC / other C1 escapes. Color mapping is optional; the pipe
+/// MVP keeps a monochrome scrollback.
+pub fn strip_ansi(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' {
+            match chars.peek() {
+                Some('[') => {
+                    chars.next();
+                    for next in chars.by_ref() {
+                        if next.is_ascii_alphabetic() || next == '~' {
+                            break;
+                        }
+                    }
+                }
+                Some(']') => {
+                    chars.next();
+                    for next in chars.by_ref() {
+                        if next == '\u{7}' {
+                            break;
+                        }
+                        if next == '\u{1b}' {
+                            let _ = chars.next_if_eq(&'\\');
+                            break;
+                        }
+                    }
+                }
+                Some(next) if matches!(*next, '(' | ')' | '#' | '%') => {
+                    chars.next();
+                    let _ = chars.next();
+                }
+                Some(_) => {
+                    let _ = chars.next();
+                }
+                None => {}
+            }
+            continue;
+        }
+        if ch == '\r' {
+            continue;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn pgid_path() -> PathBuf {
+    app_data_dir().join(PGID_FILE)
+}
+
+fn record_pgid(pgid: u32) {
+    let _ = std::fs::write(pgid_path(), pgid.to_string());
+}
+
+fn clear_pgid() {
+    let _ = std::fs::remove_file(pgid_path());
+}
+
+fn kill_group(pgid: i32) {
+    if pgid <= 0 {
+        return;
+    }
+    #[cfg(unix)]
+    unsafe {
+        libc_killpg(pgid, 15);
+    }
+    #[cfg(not(unix))]
+    let _ = pgid;
+}
+
+#[cfg(unix)]
+unsafe fn libc_killpg(pgid: i32, sig: i32) {
+    extern "C" {
+        fn killpg(pgrp: i32, sig: i32) -> i32;
+    }
+    let _ = killpg(pgid, sig);
+}
+
+/// Kill a process group left behind by a crash, then forget the pid file.
+pub fn reap_orphaned_jobs() {
+    let path = pgid_path();
+    if let Ok(raw) = std::fs::read_to_string(&path) {
+        if let Ok(pgid) = raw.trim().parse::<i32>() {
+            kill_group(pgid);
+        }
+    }
+    let _ = std::fs::remove_file(path);
+}
+
+pub fn load_history() -> Vec<String> {
+    database::get_setting(HISTORY_KEY)
+        .and_then(|json| serde_json::from_str(&json).ok())
+        .unwrap_or_default()
+}
+
+pub fn push_history(command: &str) {
+    if !get_app_settings().terminal_history {
+        return;
+    }
+    let command = command.trim();
+    if command.is_empty() {
+        return;
+    }
+    let mut history = load_history();
+    history.retain(|row| row != command);
+    history.push(command.to_string());
+    if history.len() > HISTORY_CAP {
+        let drop = history.len() - HISTORY_CAP;
+        history.drain(0..drop);
+    }
+    if let Ok(json) = serde_json::to_string(&history) {
+        let _ = database::set_setting(HISTORY_KEY, &json);
+    }
+}
+
+/// Spawn `$SHELL -lc <command>` in a new process group. Streaming reader
+/// parks on a blocking read; nothing is left running at idle.
+pub fn spawn_login_command(shell: &str, command: &str, timeout: Duration) -> JobHandle {
+    let handle = JobHandle::new();
+    let job = handle.clone();
+    let shell = shell.to_string();
+    let command = command.to_string();
+    thread::Builder::new()
+        .name("nook-shell".into())
+        .spawn(move || run_job(job, shell, command, timeout))
+        .ok();
+    handle
+}
+
+fn run_job(job: JobHandle, shell: String, command: String, timeout: Duration) {
+    let mut cmd = Command::new(&shell);
+    cmd.arg("-lc")
+        .arg(&command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        cmd.process_group(0);
+    }
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(err) => {
+            append_output(&job, &format!("failed to spawn {shell}: {err}\n"));
+            finish(&job, Some(1), false);
+            return;
+        }
+    };
+    let pgid = child.id();
+    job.inner.pgid.store(pgid, Ordering::SeqCst);
+    record_pgid(pgid);
+
+    if let Some(stdout) = child.stdout.take() {
+        spawn_reader(job.clone(), stdout);
+    }
+    if let Some(stderr) = child.stderr.take() {
+        spawn_reader(job.clone(), stderr);
+    }
+
+    let watchdog = job.clone();
+    thread::spawn(move || {
+        let start = Instant::now();
+        while start.elapsed() < timeout {
+            if watchdog.inner.done.load(Ordering::SeqCst)
+                || watchdog.inner.cancel.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+        if !watchdog.inner.done.load(Ordering::SeqCst) {
+            watchdog.inner.timed_out.store(true, Ordering::SeqCst);
+            watchdog.cancel();
+        }
+    });
+
+    let status = child.wait();
+    clear_pgid();
+    let code = match status {
+        Ok(status) => status.code().or_else(|| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::process::ExitStatusExt;
+                status.signal()
+            }
+            #[cfg(not(unix))]
+            {
+                None
+            }
+        }),
+        Err(_) => Some(1),
+    };
+    let timed_out = job.inner.timed_out.load(Ordering::SeqCst);
+    finish(&job, code, timed_out);
+}
+
+fn spawn_reader(job: JobHandle, mut pipe: impl Read + Send + 'static) {
+    thread::spawn(move || {
+        let mut buf = [0u8; 4096];
+        loop {
+            match pipe.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let chunk = String::from_utf8_lossy(&buf[..n]);
+                    append_output(&job, &chunk);
+                    if job.inner.capped.load(Ordering::SeqCst) {
+                        job.cancel();
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+        job.inner.notify.notify_waiters();
+    });
+}
+
+fn append_output(job: &JobHandle, chunk: &str) {
+    let cleaned = strip_ansi(chunk);
+    if let Ok(mut guard) = job.inner.output.lock() {
+        if guard.len() >= OUTPUT_CAP {
+            job.inner.capped.store(true, Ordering::SeqCst);
+            return;
+        }
+        let room = OUTPUT_CAP.saturating_sub(guard.len());
+        if cleaned.len() > room {
+            guard.push_str(&cleaned[..room]);
+            job.inner.capped.store(true, Ordering::SeqCst);
+        } else {
+            guard.push_str(&cleaned);
+        }
+    }
+    job.inner.notify.notify_waiters();
+}
+
+fn finish(job: &JobHandle, exit: Option<i32>, timed_out: bool) {
+    if let Ok(mut guard) = job.inner.exit.lock() {
+        *guard = exit;
+    }
+    if timed_out {
+        job.inner.timed_out.store(true, Ordering::SeqCst);
+        append_output(job, "\n[timed out]\n");
+    }
+    job.inner.done.store(true, Ordering::SeqCst);
+    job.inner.notify.notify_waiters();
+}
+
+/// Used by tests (and the watchdog) so a leftover child cannot hang CI.
+pub fn force_kill(handle: &JobHandle) {
+    handle.cancel();
+}
+
+#[allow(dead_code)]
+fn write_all_or_log(mut w: impl Write, bytes: &[u8]) {
+    let _ = w.write_all(bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_ansi_drops_sgr_and_keeps_text() {
+        assert_eq!(strip_ansi("\u{1b}[31mred\u{1b}[0m"), "red");
+        assert_eq!(strip_ansi("plain"), "plain");
+        assert_eq!(strip_ansi("a\rb\n"), "ab\n");
+        assert_eq!(
+            strip_ansi("\u{1b}]0;title\u{7}prompt"),
+            "prompt"
+        );
+    }
+
+    #[test]
+    fn resolved_shell_prefers_override() {
+        assert_eq!(resolved_shell("/bin/sh"), "/bin/sh");
+        assert!(!resolved_shell("").is_empty());
+    }
+
+    #[test]
+    fn spawn_echo_captures_stdout() {
+        let job = spawn_login_command("/bin/sh", "printf 'hello-nook'", Duration::from_secs(5));
+        let start = Instant::now();
+        let mut snap = job.snapshot();
+        while !snap.done && start.elapsed() < Duration::from_secs(5) {
+            thread::sleep(Duration::from_millis(20));
+            snap = job.snapshot();
+        }
+        force_kill(&job);
+        assert!(snap.done, "job should finish");
+        assert!(
+            snap.output.contains("hello-nook"),
+            "output was {:?}",
+            snap.output
+        );
+        assert_eq!(snap.exit, Some(0));
+    }
+
+    #[test]
+    fn spawn_caps_output() {
+        let job = spawn_login_command(
+            "/bin/sh",
+            &format!("dd if=/dev/zero bs=1024 count=400 2>/dev/null | tr '\\0' 'x'"),
+            Duration::from_secs(5),
+        );
+        let start = Instant::now();
+        let mut snap = job.snapshot();
+        while !snap.done && start.elapsed() < Duration::from_secs(5) {
+            thread::sleep(Duration::from_millis(20));
+            snap = job.snapshot();
+        }
+        force_kill(&job);
+        assert!(snap.output.len() <= OUTPUT_CAP);
+        assert!(snap.capped || snap.output.len() == OUTPUT_CAP);
+    }
+
+    #[test]
+    fn spawn_times_out() {
+        let job = spawn_login_command("/bin/sh", "sleep 8", Duration::from_millis(200));
+        let start = Instant::now();
+        let mut snap = job.snapshot();
+        while !snap.done && start.elapsed() < Duration::from_secs(4) {
+            thread::sleep(Duration::from_millis(20));
+            snap = job.snapshot();
+        }
+        force_kill(&job);
+        assert!(snap.done);
+        assert!(snap.timed_out || snap.output.contains("timed out"));
+    }
+}

--- a/crates/nook/Cargo.toml
+++ b/crates/nook/Cargo.toml
@@ -9,6 +9,10 @@ description = "openNook — Dynamic Island client, native GPUI frontend"
 name = "nook"
 path = "src/main.rs"
 
+[[bin]]
+name = "nook-cli"
+path = "src/bin/nook.rs"
+
 [dependencies]
 nook-core.workspace = true
 gpui.workspace = true

--- a/crates/nook/src/assets/icons/terminal.svg
+++ b/crates/nook/src/assets/icons/terminal.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<polyline points="4 17 10 11 4 5"/><line x1="12" x2="20" y1="19" y2="19"/>
+</svg>

--- a/crates/nook/src/bin/nook.rs
+++ b/crates/nook/src/bin/nook.rs
@@ -1,0 +1,160 @@
+//! CLI shim: percent-encode paths and hand them to the running app via
+//! `open -g opennook://…`. No daemon, no socket, and never a shell-exec URL.
+//!
+//! Alfred File Action → Run Script can call the same scheme:
+//! `open -g "opennook://tray/add?path=$(python3 -c 'import urllib.parse,sys;print(urllib.parse.quote(sys.argv[1]))' "$1")"`
+//!
+//! `cargo run` binaries are not registered with LaunchServices — use the
+//! bundled `openNook.app` (scripts/bundle.sh runs `lsregister -f`).
+
+use nook_core::automation::{expand_url, timer_start_url, tray_add_url, tray_clear_url};
+use std::env;
+use std::path::{Path, PathBuf};
+#[cfg(target_os = "macos")]
+use std::process::Command;
+
+fn main() {
+    let mut args = env::args().skip(1).collect::<Vec<_>>();
+    if args.is_empty() || args.iter().any(|a| a == "-h" || a == "--help") {
+        print_usage();
+        if args.is_empty() {
+            std::process::exit(2);
+        }
+        return;
+    }
+
+    let url = match build_url(&mut args) {
+        Ok(url) => url,
+        Err(err) => {
+            eprintln!("nook: {err}");
+            print_usage();
+            std::process::exit(2);
+        }
+    };
+
+    if let Err(err) = open_url(&url) {
+        eprintln!("nook: {err}");
+        std::process::exit(1);
+    }
+}
+
+fn build_url(args: &mut Vec<String>) -> Result<String, String> {
+    if args.is_empty() {
+        return Err("missing command".into());
+    }
+    // Never emit a URL that parse_opennook_url would treat as exec.
+    match args[0].as_str() {
+        "clear" => Ok(tray_clear_url()),
+        "expand" => Ok(expand_url()),
+        "timer" => {
+            let seconds = args.get(1).ok_or("timer needs <seconds>")?;
+            let seconds: u32 = seconds
+                .parse()
+                .map_err(|_| "timer seconds must be a number".to_string())?;
+            Ok(timer_start_url(seconds))
+        }
+        "add" => {
+            let paths = canonicalize_paths(&args[1..])?;
+            if paths.is_empty() {
+                return Err("add needs at least one path".into());
+            }
+            Ok(tray_add_url(&paths))
+        }
+        other if looks_like_exec(other) => Err(
+            "the CLI cannot run shell commands; type them in the Termi-Notch card".into(),
+        ),
+        _ => {
+            let paths = canonicalize_paths(args)?;
+            if paths.is_empty() {
+                return Err("no paths to add".into());
+            }
+            Ok(tray_add_url(&paths))
+        }
+    }
+}
+
+fn looks_like_exec(verb: &str) -> bool {
+    matches!(
+        verb,
+        "shell" | "exec" | "run" | "cmd" | "command" | "term" | "terminal" | "sh"
+    )
+}
+
+fn canonicalize_paths(args: &[String]) -> Result<Vec<PathBuf>, String> {
+    let mut out = Vec::new();
+    for raw in args {
+        let path = Path::new(raw);
+        let resolved = path
+            .canonicalize()
+            .unwrap_or_else(|_| path.to_path_buf());
+        out.push(resolved);
+    }
+    Ok(out)
+}
+
+fn open_url(url: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let status = Command::new("/usr/bin/open")
+            .args(["-g", url])
+            .status()
+            .map_err(|err| err.to_string())?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("open exited {status}"))
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        println!("{url}");
+        Ok(())
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "\
+Usage:
+  nook add <path>...     send files to the island tray
+  nook <path>...         same as add
+  nook clear             empty the tray
+  nook timer <seconds>   start a countdown
+  nook expand            expand the island
+
+Requires the bundled openNook.app so LaunchServices can route opennook://.
+Does not execute shell commands."
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_encodes_spaces() {
+        let mut args = vec!["add".into(), "/tmp/hello world.txt".into()];
+        let url = build_url(&mut args).unwrap();
+        assert!(url.starts_with("opennook://tray/add?path="));
+        assert!(url.contains("hello%20world.txt") || url.contains("hello"));
+        assert!(!url.contains("shell") && !url.contains("exec"));
+    }
+
+    #[test]
+    fn verbs_are_safe() {
+        assert_eq!(
+            build_url(&mut vec!["clear".into()]).unwrap(),
+            tray_clear_url()
+        );
+        assert_eq!(
+            build_url(&mut vec!["expand".into()]).unwrap(),
+            expand_url()
+        );
+        assert_eq!(
+            build_url(&mut vec!["timer".into(), "90".into()]).unwrap(),
+            timer_start_url(90)
+        );
+        assert!(build_url(&mut vec!["exec".into(), "id".into()]).is_err());
+        assert!(build_url(&mut vec!["shell".into(), "ls".into()]).is_err());
+    }
+}

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -53,6 +53,9 @@ impl Island {
     }
 
     fn compact_left(&self, mode: CompactMode, cx: &mut Context<Self>) -> AnyElement {
+        if let Some(hud) = self.shell_hud.as_ref() {
+            return label(hud.clone(), theme::BODY, true).into_any_element();
+        }
         match mode {
             CompactMode::Media => {
                 album_chip(&self.now_playing, self.overlay_fade.value, cx).into_any_element()
@@ -63,6 +66,7 @@ impl Island {
             CompactMode::Observe => {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
+            CompactMode::Shell => lucide("terminal", theme::COMPACT_FACE).into_any_element(),
             CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
             CompactMode::Idle => div().into_any_element(),
         }
@@ -104,6 +108,11 @@ impl Island {
                     _ => self.observe.firing_count().to_string(),
                 };
                 label(text, theme::BODY, true).into_any_element()
+            }
+            CompactMode::Shell => {
+                let frame = ((self.pixel_t * 8.0) as usize) % 4;
+                let spin = ["⠋", "⠙", "⠹", "⠸"][frame];
+                label(spin, theme::BODY, true).into_any_element()
             }
             CompactMode::Onboard if hovered => div()
                 .id("github")
@@ -148,6 +157,7 @@ impl Island {
                 CompactMode::Timer => "timer",
                 CompactMode::Observe => "observe",
                 CompactMode::Onboard => "onboard",
+                CompactMode::Shell => "shell",
             };
             row = row.child(
                 div()

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, terminal_card,
+    timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -19,10 +20,10 @@ impl Island {
         notch_w: f32,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let tab = if self.tab == Tab::Files && !self.settings.show_files {
-            Tab::Widgets
-        } else {
-            self.tab
+        let tab = match self.tab {
+            Tab::Files if !self.settings.show_files => Tab::Widgets,
+            Tab::Terminal if !self.settings.terminal_enabled => Tab::Widgets,
+            other => other,
         };
         div()
             .flex()
@@ -35,21 +36,25 @@ impl Island {
                     .flex_1()
                     .w_full()
                     .overflow_hidden()
-                    .child(if tab == Tab::Widgets {
-                        self.render_nook(cx).into_any_element()
-                    } else {
-                        div()
+                    .child(match tab {
+                        Tab::Widgets => self.render_nook(cx).into_any_element(),
+                        Tab::Files => div()
                             .size_full()
                             .px(px(theme::EXPANDED_PAD))
                             .pb(px(theme::EXPANDED_PAD))
                             .child(self.render_files(cx))
-                            .into_any_element()
+                            .into_any_element(),
+                        Tab::Terminal => div()
+                            .size_full()
+                            .px(px(theme::EXPANDED_PAD))
+                            .pb(px(theme::EXPANDED_PAD))
+                            .child(terminal_card(self, cx))
+                            .into_any_element(),
                     }),
             )
     }
 
     fn render_topbar(&self, notch_w: f32, cx: &mut Context<Self>) -> impl IntoElement {
-        let widgets_active = self.tab == Tab::Widgets;
         div()
             .w_full()
             .flex_shrink_0()
@@ -61,7 +66,7 @@ impl Island {
             .on_scroll_wheel(cx.listener(|this, event: &ScrollWheelEvent, _, cx| {
                 this.on_wheel(event, cx);
             }))
-            .child(tab_switch(widgets_active, self.settings.show_files, cx))
+            .child(tab_switch(self, cx))
             .child(div().w(px(notch_w)))
             .child(
                 div()
@@ -198,27 +203,34 @@ fn pane_divider() -> impl IntoElement {
         .flex_shrink_0()
 }
 
-fn tab_switch(
-    widgets_active: bool,
-    show_files: bool,
-    cx: &mut Context<Island>,
-) -> impl IntoElement {
+fn tab_switch(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let current = island.tab;
     let mut row = div().flex().items_center().gap(px(4.)).child(labeled_tab(
         "tab-nook",
         "map-pin",
         "Nook",
-        widgets_active || !show_files,
+        current == Tab::Widgets,
         cx,
         Tab::Widgets,
     ));
-    if show_files {
+    if island.settings.show_files {
         row = row.child(labeled_tab(
             "tab-tray",
             "files",
             "Tray",
-            !widgets_active,
+            current == Tab::Files,
             cx,
             Tab::Files,
+        ));
+    }
+    if island.settings.terminal_enabled {
+        row = row.child(labeled_tab(
+            "tab-term",
+            "terminal",
+            "Term",
+            current == Tab::Terminal,
+            cx,
+            Tab::Terminal,
         ));
     }
     row

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -16,9 +16,9 @@ use crate::motion::{self, SpringValue};
 use crate::platform;
 use crate::theme;
 use gpui::{
-    prelude::*, px, size, Context, Entity, ExternalPaths, Focusable, MouseDownEvent, Subscription,
-    TouchPhase, Window, WindowBackgroundAppearance, WindowBounds, WindowHandle, WindowKind,
-    WindowOptions,
+    prelude::*, px, size, Context, Entity, ExternalPaths, FocusHandle, Focusable, MouseDownEvent,
+    Subscription, TouchPhase, Window, WindowBackgroundAppearance, WindowBounds, WindowHandle,
+    WindowKind, WindowOptions,
 };
 use nook_core::agents::AgentSession;
 use nook_core::calendar::{CalendarEvent, Reminder};
@@ -26,8 +26,11 @@ use nook_core::files::FileTrayItem;
 use nook_core::models::NowPlayingData;
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
+use nook_core::automation::ExternalAction;
 use nook_core::settings::AppSettings;
+use nook_core::shell::JobHandle;
 use settings::SettingsView;
+use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -39,12 +42,15 @@ pub enum CompactMode {
     Timer,
     Observe,
     Onboard,
+    /// Compact spinner / HUD while a Termi-Notch command is live.
+    Shell,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Tab {
     Widgets,
     Files,
+    Terminal,
 }
 
 #[derive(Clone)]
@@ -158,6 +164,15 @@ pub struct Island {
     pub(crate) mirror_on: bool,
     mirror_gen: u64,
     pub(crate) mirror_frame: Option<std::sync::Arc<gpui::RenderImage>>,
+    pub shell_input: String,
+    pub shell_output: String,
+    pub shell_running: bool,
+    pub shell_exit: Option<i32>,
+    pub shell_hud: Option<String>,
+    pub shell_focused: bool,
+    pub(crate) shell_focus: Option<FocusHandle>,
+    pub(crate) shell_history_idx: Option<usize>,
+    shell_job: Option<JobHandle>,
 }
 
 struct PendingFileDrag {
@@ -256,6 +271,15 @@ impl Island {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            shell_input: String::new(),
+            shell_output: String::new(),
+            shell_running: false,
+            shell_exit: None,
+            shell_hud: None,
+            shell_focused: false,
+            shell_focus: Some(cx.focus_handle()),
+            shell_history_idx: None,
+            shell_job: None,
         };
         // Start at the compact idle size so the first paint isn't a jump.
         let (w, h) = this.target_size();
@@ -271,6 +295,7 @@ impl Island {
         let _ = window;
         this.spawn_loops(cx);
         Self::spawn_pin(cx);
+        Self::spawn_external_actions(cx);
         this
     }
 
@@ -421,6 +446,7 @@ impl Island {
                         } else if this.expanded
                             && !this.settings_open
                             && !this.notes_editing
+                            && !this.shell_focused
                             && !this.mirror_on
                             && !this.file_drag
                             && !nook_core::files::outbound_drag_active()
@@ -471,11 +497,12 @@ impl Island {
                         dirty = true;
                     }
                     let any_working = this.agents.iter().any(|a| a.status.is_working());
-                    if any_working {
+                    if any_working || this.shell_running {
                         // Full-rate on purpose: this repaints the island every
                         // tick while an agent runs, which costs real battery,
                         // but the Dot Matrix loader is the app's signature
-                        // animation and smoothness wins here.
+                        // animation and smoothness wins here. A live shell
+                        // command is the same class of "something is working".
                         this.pixel_t = now.duration_since(this.pixel_origin).as_secs_f32();
                         dirty = true;
                     }
@@ -501,7 +528,8 @@ impl Island {
                         || this.pending_file_drag.is_some()
                         || this.mirror_on
                         || this.settings_open
-                        || any_working;
+                        || any_working
+                        || this.shell_running;
                     // Media playing promotes itself through `dirty` (the
                     // visualizer levels change every frame), so it needs no
                     // term of its own here.
@@ -871,6 +899,9 @@ impl Island {
         if self.has_agents() {
             modes.push(CompactMode::Agents);
         }
+        if self.settings.terminal_enabled && (self.shell_running || self.shell_hud.is_some()) {
+            modes.push(CompactMode::Shell);
+        }
         if self.settings.show_timers && self.running_timer().is_some() {
             modes.push(CompactMode::Timer);
         }
@@ -948,14 +979,20 @@ impl Island {
             return (0.0, if self.expanded { -VERTICAL } else { VERTICAL });
         }
         if self.expanded && self.tab != self.last_tab {
-            return (
-                if self.tab == Tab::Files {
-                    HORIZONTAL
-                } else {
-                    -HORIZONTAL
-                },
-                0.0,
-            );
+            let tabs = self.shown_tabs();
+            let from = tabs.iter().position(|tab| *tab == self.last_tab);
+            let to = tabs.iter().position(|tab| *tab == self.tab);
+            let delta = match (from, to) {
+                (Some(from), Some(to)) => to as isize - from as isize,
+                _ => {
+                    if self.tab == Tab::Files {
+                        1
+                    } else {
+                        -1
+                    }
+                }
+            };
+            return (HORIZONTAL * delta.signum() as f32, 0.0);
         }
         if !self.expanded && mode != self.last_mode {
             let modes = self.available_modes();
@@ -1069,10 +1106,10 @@ impl Island {
     fn toggle_expanded(&mut self, cx: &mut Context<Self>) {
         self.expanded = !self.expanded;
         if self.expanded {
-            self.tab = if self.mode() == CompactMode::Files {
-                Tab::Files
-            } else {
-                Tab::Widgets
+            self.tab = match self.mode() {
+                CompactMode::Files => Tab::Files,
+                CompactMode::Shell if self.settings.terminal_enabled => Tab::Terminal,
+                _ => Tab::Widgets,
             };
             if self.first_run {
                 self.first_run = false;
@@ -1141,11 +1178,7 @@ impl Island {
             if ax.abs() <= THRESHOLD {
                 false
             } else if self.expanded {
-                self.tab = if ax > 0.0 && self.settings.show_files {
-                    Tab::Files
-                } else {
-                    Tab::Widgets
-                };
+                self.cycle_tab(ax > 0.0);
                 true
             } else {
                 self.cycle_mode(ax > 0.0)
@@ -1302,10 +1335,17 @@ impl Island {
     }
 
     fn ingest_paths(&mut self, paths: &ExternalPaths, cx: &mut Context<Self>) {
+        self.ingest_external_paths(paths.paths().iter().cloned().collect(), cx);
+    }
+
+    /// Shared by drag-drop, `opennook://tray/add`, and Finder Services.
+    pub(crate) fn ingest_external_paths(&mut self, paths: Vec<PathBuf>, cx: &mut Context<Self>) {
         let mut added = false;
-        for path in paths.paths() {
+        for path in paths {
             let raw = path.to_string_lossy().into_owned();
-            let resolved = nook_core::files::resolve_path(raw.clone()).unwrap_or(raw);
+            let Ok(resolved) = nook_core::automation::validate_tray_path(&raw) else {
+                continue;
+            };
             if self.files.iter().any(|f| f.path == resolved) {
                 continue;
             }
@@ -1322,6 +1362,173 @@ impl Island {
             nook_core::haptics::trigger(None);
             cx.notify();
         }
+    }
+
+    pub(crate) fn apply_external_action(&mut self, action: ExternalAction, cx: &mut Context<Self>) {
+        match action {
+            ExternalAction::TrayAdd(paths) => self.ingest_external_paths(paths, cx),
+            ExternalAction::TrayClear => {
+                self.files.clear();
+                let _ = nook_core::files::save_file_tray(self.files.clone());
+                cx.notify();
+            }
+            ExternalAction::TimerStart { seconds } => {
+                self.add_timer(seconds);
+                self.expanded = true;
+                self.tab = Tab::Widgets;
+                cx.notify();
+            }
+            ExternalAction::Expand => {
+                self.expanded = true;
+                cx.notify();
+            }
+        }
+    }
+
+    fn spawn_external_actions(cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| loop {
+            let action = cx
+                .background_executor()
+                .spawn(async { nook_core::automation::recv_action().await })
+                .await;
+            if this
+                .update(cx, |this, cx| this.apply_external_action(action, cx))
+                .is_err()
+            {
+                break;
+            }
+        })
+        .detach();
+    }
+
+    pub(crate) fn shown_tabs(&self) -> Vec<Tab> {
+        let mut tabs = vec![Tab::Widgets];
+        if self.settings.show_files {
+            tabs.push(Tab::Files);
+        }
+        if self.settings.terminal_enabled {
+            tabs.push(Tab::Terminal);
+        }
+        tabs
+    }
+
+    fn cycle_tab(&mut self, next: bool) {
+        let tabs = self.shown_tabs();
+        if tabs.is_empty() {
+            self.tab = Tab::Widgets;
+            return;
+        }
+        let idx = tabs.iter().position(|tab| *tab == self.tab).unwrap_or(0);
+        let new_idx = if next {
+            (idx + 1) % tabs.len()
+        } else {
+            (idx + tabs.len() - 1) % tabs.len()
+        };
+        self.tab = tabs[new_idx];
+    }
+
+    /// User-typed command only. Callers must not wire this to a URL.
+    pub(crate) fn run_typed_shell(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if !self.settings.terminal_enabled {
+            return;
+        }
+        let command = self.shell_input.trim().to_string();
+        if command.is_empty() || command.len() > 8192 {
+            return;
+        }
+        if self.shell_running {
+            self.cancel_shell();
+        }
+        self.shell_output.clear();
+        self.shell_exit = None;
+        self.shell_hud = None;
+        self.shell_running = true;
+        self.shell_history_idx = None;
+        self.preferred = Some(CompactMode::Shell);
+        self.tab = Tab::Terminal;
+        self.expanded = true;
+        nook_core::shell::push_history(&command);
+        let shell = nook_core::shell::resolved_shell(&self.settings.terminal_shell);
+        let timeout = Duration::from_secs(self.settings.terminal_timeout_secs.max(1) as u64);
+        let handle = nook_core::shell::spawn_login_command(&shell, &command, timeout);
+        self.shell_job = Some(handle.clone());
+        nook_core::haptics::trigger(None);
+        cx.notify();
+        Self::spawn_shell_watch(handle, cx);
+    }
+
+    fn spawn_shell_watch(handle: JobHandle, cx: &mut Context<Self>) {
+        cx.spawn(async move |this, cx| {
+            loop {
+                let snap = cx
+                    .background_executor()
+                    .spawn({
+                        let handle = handle.clone();
+                        async move { handle.wait_update().await }
+                    })
+                    .await;
+                let done = this
+                    .update(cx, |this, cx| {
+                        this.shell_output = snap.output.clone();
+                        this.shell_running = !snap.done;
+                        this.shell_exit = snap.exit;
+                        if snap.done {
+                            this.shell_job = None;
+                            this.shell_hud = Some(if snap.timed_out {
+                                "timeout".into()
+                            } else {
+                                format!("exit {}", snap.exit.unwrap_or(-1))
+                            });
+                            this.preferred = Some(CompactMode::Shell);
+                        }
+                        cx.notify();
+                        snap.done
+                    })
+                    .unwrap_or(true);
+                if done {
+                    break;
+                }
+            }
+            cx.background_executor()
+                .timer(Duration::from_secs(2))
+                .await;
+            this.update(cx, |this, cx| {
+                this.shell_hud = None;
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    pub(crate) fn cancel_shell(&mut self) {
+        if let Some(job) = self.shell_job.take() {
+            job.cancel();
+        }
+        self.shell_running = false;
+    }
+
+    pub(crate) fn history_step(&mut self, delta: isize) {
+        if !self.settings.terminal_history {
+            return;
+        }
+        let history = nook_core::shell::load_history();
+        if history.is_empty() {
+            return;
+        }
+        let next = match self.shell_history_idx {
+            Some(idx) => idx as isize + delta,
+            None if delta < 0 => history.len() as isize - 1,
+            None => return,
+        };
+        if next < 0 {
+            self.shell_history_idx = None;
+            self.shell_input.clear();
+            return;
+        }
+        let next = (next as usize).min(history.len().saturating_sub(1));
+        self.shell_history_idx = Some(next);
+        self.shell_input = history[next].clone();
     }
 
     pub(crate) fn add_timer(&mut self, seconds: u32) {
@@ -1494,6 +1701,15 @@ mod tests {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            shell_input: String::new(),
+            shell_output: String::new(),
+            shell_running: false,
+            shell_exit: None,
+            shell_hud: None,
+            shell_focused: false,
+            shell_focus: None,
+            shell_history_idx: None,
+            shell_job: None,
         }
     }
 
@@ -2107,5 +2323,27 @@ mod tests {
         assert!(island.blur > 0.5, "crossfade left the content sharp");
         let (dx, dy) = island.blur_offset().expect("crossfade needs a smear");
         assert!(dx > dy, "a still island should smear along its long axis");
+    }
+
+    #[test]
+    fn terminal_tab_is_opt_in() {
+        let mut island = test_island();
+        assert_eq!(island.shown_tabs(), vec![Tab::Widgets, Tab::Files]);
+        island.settings.terminal_enabled = true;
+        assert_eq!(
+            island.shown_tabs(),
+            vec![Tab::Widgets, Tab::Files, Tab::Terminal]
+        );
+        island.settings.show_files = false;
+        assert_eq!(island.shown_tabs(), vec![Tab::Widgets, Tab::Terminal]);
+    }
+
+    #[test]
+    fn shell_mode_stays_off_until_enabled() {
+        let mut island = test_island();
+        island.shell_running = true;
+        assert!(!island.available_modes().contains(&CompactMode::Shell));
+        island.settings.terminal_enabled = true;
+        assert!(island.available_modes().contains(&CompactMode::Shell));
     }
 }

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -227,10 +227,14 @@ pub(super) struct SettingsView {
     url_focus: FocusHandle,
     token_focus: FocusHandle,
     query_focus: FocusHandle,
+    shell_focus: FocusHandle,
+    timeout_focus: FocusHandle,
     url_draft: String,
     token_draft: String,
     token_revealed: bool,
     query_draft: String,
+    shell_draft: String,
+    timeout_draft: String,
     catalog: Vec<String>,
     catalog_error: Option<String>,
     catalog_loading: bool,
@@ -254,10 +258,14 @@ impl SettingsView {
             url_focus: cx.focus_handle(),
             token_focus: cx.focus_handle(),
             query_focus: cx.focus_handle(),
+            shell_focus: cx.focus_handle(),
+            timeout_focus: cx.focus_handle(),
             url_draft: settings.observe.prometheus_url,
             token_draft: settings.observe.metrics_token,
             token_revealed: false,
             query_draft: String::new(),
+            shell_draft: settings.terminal_shell.clone(),
+            timeout_draft: settings.terminal_timeout_secs.to_string(),
             catalog: Vec::new(),
             catalog_error: None,
             catalog_loading: false,
@@ -415,7 +423,7 @@ impl gpui::Render for SettingsView {
                 self.render_widgets(&settings, url_focused, token_focused, query_focused, cx)
                     .into_any_element()
             } else {
-                self.render_general(&settings, cx).into_any_element()
+                self.render_general(&settings, window, cx).into_any_element()
             })
     }
 }
@@ -518,7 +526,12 @@ impl SettingsView {
             )
     }
 
-    fn render_general(&self, settings: &AppSettings, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render_general(
+        &self,
+        settings: &AppSettings,
+        window: &gpui::Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
         Self::pane(
             "General",
             div()
@@ -569,6 +582,70 @@ impl SettingsView {
                         .into_any_element(),
                     ]),
                     Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
+                ))
+                .child(section(
+                    "Termi-Notch",
+                    settings_group(vec![
+                        toggle_row(
+                            "Enable one-shot shell",
+                            settings.terminal_enabled,
+                            cx,
+                            |s| s.terminal_enabled = !s.terminal_enabled,
+                        )
+                        .into_any_element(),
+                        field_row(
+                            "term-shell",
+                            "Shell",
+                            if self.shell_draft.is_empty() {
+                                "$SHELL"
+                            } else {
+                                self.shell_draft.as_str()
+                            },
+                            self.shell_draft.is_empty(),
+                            self.shell_focus.is_focused(window),
+                            &self.shell_focus,
+                            cx,
+                            |this, event, cx| {
+                                if SettingsView::apply_key(&mut this.shell_draft, event, cx) {
+                                    nook_core::settings::tweak_app_settings(|s| {
+                                        s.terminal_shell = this.shell_draft.trim().to_string();
+                                    });
+                                    cx.notify();
+                                }
+                            },
+                        )
+                        .into_any_element(),
+                        field_row(
+                            "term-timeout",
+                            "Timeout",
+                            &self.timeout_draft,
+                            false,
+                            self.timeout_focus.is_focused(window),
+                            &self.timeout_focus,
+                            cx,
+                            |this, event, cx| {
+                                if SettingsView::apply_key(&mut this.timeout_draft, event, cx) {
+                                    this.timeout_draft
+                                        .retain(|ch| ch.is_ascii_digit());
+                                    if let Ok(secs) = this.timeout_draft.parse::<u32>() {
+                                        nook_core::settings::tweak_app_settings(|s| {
+                                            s.terminal_timeout_secs = secs.clamp(1, 600);
+                                        });
+                                    }
+                                    cx.notify();
+                                }
+                            },
+                        )
+                        .into_any_element(),
+                        toggle_row(
+                            "Remember command history",
+                            settings.terminal_history,
+                            cx,
+                            |s| s.terminal_history = !s.terminal_history,
+                        )
+                        .into_any_element(),
+                    ]),
+                    Some("Typed in the island only. opennook://, the CLI, and Finder Services never run commands. Default off."),
                 )),
         )
     }

--- a/crates/nook/src/main.rs
+++ b/crates/nook/src/main.rs
@@ -14,16 +14,28 @@ actions!(nook, [Quit]);
 fn main() {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
-    Application::new()
-        .with_assets(icons::Assets)
-        .run(|cx: &mut App| {
-            gpui_component::init(cx);
-            nook_core::init();
-            platform::install();
-            platform::install_status_item();
-            cx.on_action(|_: &Quit, cx| cx.quit());
-            cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
-            open_island(cx);
-            cx.activate(false);
-        });
+    let app = Application::new().with_assets(icons::Assets);
+    // LaunchServices delivers opennook:// here. The callback is sync and may
+    // fire before the island exists, so we only enqueue — never exec a shell.
+    app.on_open_urls(|urls| {
+        nook_core::automation::ingest_open_urls(&urls);
+    });
+    app.run(|cx: &mut App| {
+        gpui_component::init(cx);
+        nook_core::init();
+        platform::install();
+        platform::install_status_item();
+        let task = cx.register_url_scheme("opennook");
+        cx.foreground_executor()
+            .spawn(async move {
+                if let Err(err) = task.await {
+                    log::debug!("register_url_scheme: {err}");
+                }
+            })
+            .detach();
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        open_island(cx);
+        cx.activate(false);
+    });
 }

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -74,7 +74,106 @@ fn install_macos() {
         }
         log::info!("notch constrainFrameRect installed on GPUIPanel");
         install_app_target();
+        install_services_provider();
     });
+}
+
+#[cfg(target_os = "macos")]
+static SERVICES_PROVIDER: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+/// Finder "Send to openNook" — same path bus as `opennook://tray/add`. Never shell.
+#[cfg(target_os = "macos")]
+fn install_services_provider() {
+    use objc2::runtime::{AnyClass, AnyObject, ClassBuilder, NSObject, Sel};
+    use objc2::{class, msg_send, sel, ClassType};
+    use std::sync::OnceLock;
+
+    static CLASS: OnceLock<&'static AnyClass> = OnceLock::new();
+    let cls = CLASS.get_or_init(|| {
+        if let Some(existing) = AnyClass::get(c"NookServicesProvider") {
+            return existing;
+        }
+        let mut builder = ClassBuilder::new(c"NookServicesProvider", NSObject::class())
+            .expect("NookServicesProvider");
+
+        extern "C-unwind" fn send_to_opennook(
+            _this: &NSObject,
+            _cmd: Sel,
+            pboard: *mut AnyObject,
+            _user_data: *mut AnyObject,
+            _error: *mut *mut AnyObject,
+        ) {
+            let paths = unsafe { read_service_paths(pboard) };
+            if !paths.is_empty() {
+                nook_core::automation::ingest_service_paths(paths);
+            }
+        }
+        unsafe {
+            builder.add_method(
+                sel!(sendToOpenNook:userData:error:),
+                send_to_opennook as extern "C-unwind" fn(_, _, _, _, _),
+            );
+        }
+        builder.register()
+    });
+
+    unsafe {
+        let provider: *mut AnyObject = msg_send![*cls, new];
+        if provider.is_null() {
+            log::error!("services provider alloc failed");
+            return;
+        }
+        let _: *mut AnyObject = msg_send![provider, retain];
+        SERVICES_PROVIDER.store(provider, Ordering::Relaxed);
+        let ns_app: *mut AnyObject = msg_send![class!(NSApplication), sharedApplication];
+        let _: () = msg_send![ns_app, setServicesProvider: provider];
+        ns_update_dynamic_services();
+        log::info!("NSServices provider installed (Send to openNook)");
+    }
+}
+
+#[cfg(target_os = "macos")]
+#[link(name = "AppKit", kind = "framework")]
+extern "C" {
+    fn NSUpdateDynamicServices();
+}
+
+#[cfg(target_os = "macos")]
+fn ns_update_dynamic_services() {
+    unsafe { NSUpdateDynamicServices() }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn read_service_paths(pboard: *mut objc2::runtime::AnyObject) -> Vec<std::path::PathBuf> {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    if pboard.is_null() {
+        return Vec::new();
+    }
+    let type_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSFilenamesPboardType".as_ptr()
+    ];
+    let list: *mut AnyObject = msg_send![pboard, propertyListForType: type_name];
+    if list.is_null() {
+        return Vec::new();
+    }
+    let count: usize = msg_send![list, count];
+    let mut paths = Vec::new();
+    for i in 0..count {
+        let item: *mut AnyObject = msg_send![list, objectAtIndex: i];
+        if item.is_null() {
+            continue;
+        }
+        let utf8: *const i8 = msg_send![item, UTF8String];
+        if utf8.is_null() {
+            continue;
+        }
+        let raw = std::ffi::CStr::from_ptr(utf8).to_string_lossy().into_owned();
+        paths.push(std::path::PathBuf::from(raw));
+    }
+    paths
 }
 
 /// Style + pin every GPUI island panel. Does not touch GPUI `Window`.

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -7,6 +7,7 @@ mod notes_editor;
 mod observe;
 mod reminders;
 mod speed;
+mod terminal;
 mod timers;
 
 pub(crate) use agents::{
@@ -18,4 +19,5 @@ pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};
 pub(crate) use observe::{observe_card, ObserveHover};
 pub(crate) use reminders::reminders_card;
 pub(crate) use speed::speed_card;
+pub(crate) use terminal::terminal_card;
 pub(crate) use timers::{compact_left as timer_compact_left, timer_card};

--- a/crates/nook/src/widgets/terminal.rs
+++ b/crates/nook/src/widgets/terminal.rs
@@ -1,0 +1,225 @@
+//! Termi-Notch expanded card: command input, mono scrollback, exit chip.
+//!
+//! Commands are typed here only. The URL scheme / CLI / Services paths never
+//! call into `nook_core::shell`.
+
+use crate::island::ui::{nook_icon_btn, nook_pane, scroll_body};
+use crate::island::Island;
+use crate::theme;
+use gpui::{
+    div, prelude::*, px, rgba, Context, CursorStyle, FontWeight, KeyDownEvent, MouseButton,
+    MouseDownEvent, SharedString, Window,
+};
+
+const MONO: &str = "SF Mono";
+
+pub(crate) fn terminal_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let running = island.shell_running;
+    let placeholder = island.shell_input.is_empty();
+    let prompt = if placeholder {
+        "type a command — never from a URL"
+    } else {
+        island.shell_input.as_str()
+    };
+    let chip = exit_chip(island);
+    let body = if island.shell_output.is_empty() && !running {
+        div()
+            .flex_1()
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(
+                div()
+                    .text_size(px(12.))
+                    .font_weight(FontWeight::MEDIUM)
+                    .text_color(theme::TERTIARY_LABEL)
+                    .child("One-shot login shell. Opt-in in Settings."),
+            )
+            .into_any_element()
+    } else {
+        scroll_body(
+            "term-scroll",
+            div()
+                .w_full()
+                .font_family(MONO)
+                .text_size(px(11.))
+                .line_height(px(14.))
+                .text_color(theme::LABEL)
+                .whitespace_nowrap()
+                .child(SharedString::from(island.shell_output.clone())),
+        )
+        .into_any_element()
+    };
+
+    nook_pane("nook-terminal")
+        .w_full()
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(8.))
+                .flex_shrink_0()
+                .child(command_field(prompt, placeholder, island, cx))
+                .child(if running {
+                    nook_icon_btn("x", "term-stop", cx, |this, _, _, cx| {
+                        this.cancel_shell();
+                        cx.notify();
+                    })
+                    .into_any_element()
+                } else {
+                    nook_icon_btn("play", "term-run", cx, |this, _, window, cx| {
+                        this.run_typed_shell(window, cx);
+                    })
+                    .into_any_element()
+                })
+                .when_some(chip, |d, chip| d.child(chip)),
+        )
+        .child(body)
+}
+
+fn command_field(
+    prompt: &str,
+    placeholder: bool,
+    island: &Island,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let focus = island.shell_focus.clone();
+    let mut field = div()
+        .id("term-input")
+        .flex_1()
+        .min_w(px(0.))
+        .h(px(26.))
+        .px(px(8.))
+        .rounded(px(6.))
+        .bg(theme::FILL)
+        .flex()
+        .items_center()
+        .cursor(CursorStyle::IBeam)
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _: &MouseDownEvent, window, cx| {
+                cx.stop_propagation();
+                this.shell_focused = true;
+                if let Some(focus) = this.shell_focus.clone() {
+                    window.focus(&focus);
+                }
+                cx.notify();
+            }),
+        )
+        .on_key_down(cx.listener(Island::on_shell_key))
+        .child(
+            div()
+                .w_full()
+                .overflow_hidden()
+                .text_ellipsis()
+                .whitespace_nowrap()
+                .font_family(MONO)
+                .text_size(px(12.))
+                .text_color(if placeholder {
+                    theme::TERTIARY_LABEL
+                } else {
+                    theme::LABEL
+                })
+                .child(SharedString::from(prompt.to_string())),
+        );
+    if let Some(focus) = focus {
+        field = field.track_focus(&focus);
+    }
+    field
+}
+
+fn exit_chip(island: &Island) -> Option<impl IntoElement> {
+    if island.shell_running {
+        return Some(
+            div()
+                .px(px(8.))
+                .h(px(20.))
+                .rounded_full()
+                .bg(rgba(0xffffff18))
+                .flex()
+                .items_center()
+                .child(
+                    div()
+                        .text_size(px(11.))
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme::SECONDARY_LABEL)
+                        .child("running"),
+                ),
+        );
+    }
+    let code = island.shell_exit?;
+    let ok = code == 0;
+    Some(
+        div()
+            .px(px(8.))
+            .h(px(20.))
+            .rounded_full()
+            .bg(if ok {
+                rgba(0x30d15833)
+            } else {
+                rgba(0xff453a33)
+            })
+            .flex()
+            .items_center()
+            .child(
+                div()
+                    .text_size(px(11.))
+                    .font_weight(FontWeight::SEMIBOLD)
+                    .text_color(if ok { theme::SUCCESS } else { theme::DESTRUCTIVE })
+                    .child(format!("exit {code}")),
+            ),
+    )
+}
+
+impl Island {
+    pub(crate) fn on_shell_key(
+        &mut self,
+        event: &KeyDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.settings.terminal_enabled {
+            return;
+        }
+        let ks = &event.keystroke;
+        if ks.modifiers.secondary() && ks.key == "v" {
+            if let Some(text) = cx.read_from_clipboard().and_then(|item| item.text()) {
+                self.shell_input.push_str(text.trim_end());
+                cx.notify();
+            }
+            return;
+        }
+        if ks.modifiers.platform || ks.modifiers.control {
+            return;
+        }
+        match ks.key.as_str() {
+            "enter" => self.run_typed_shell(_window, cx),
+            "escape" => {
+                if self.shell_running {
+                    self.cancel_shell();
+                    cx.notify();
+                }
+            }
+            "backspace" => {
+                self.shell_input.pop();
+                cx.notify();
+            }
+            "up" => {
+                self.history_step(-1);
+                cx.notify();
+            }
+            "down" => {
+                self.history_step(1);
+                cx.notify();
+            }
+            _ => {
+                if let Some(ch) = &ks.key_char {
+                    if !ch.chars().any(|c| c.is_control()) {
+                        self.shell_input.push_str(ch);
+                        cx.notify();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -33,6 +33,21 @@ fi
 cp "$BIN" "$APP/Contents/MacOS/openNook"
 chmod +x "$APP/Contents/MacOS/openNook"
 
+# CLI shim: same crate, separate bin. LaunchServices only sees the .app.
+CLI_SRC="$ROOT/target/${PROFILE}/nook-cli"
+if [[ -f "$CLI_SRC" ]]; then
+  cp "$CLI_SRC" "$APP/Contents/MacOS/nook"
+  chmod +x "$APP/Contents/MacOS/nook"
+else
+  echo "warning: nook-cli not built; skip Contents/MacOS/nook" >&2
+fi
+
+# Dev `cargo run` never receives opennook:// — register the bundle.
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+if [[ -x "$LSREGISTER" ]]; then
+  "$LSREGISTER" -f "$APP" || true
+fi
+
 # Bundle mediaremote-adapter (not linked; /usr/bin/perl loads the framework).
 if "$ROOT/scripts/build-mediaremote-adapter.sh"; then
   ditto "$ROOT/third_party/mediaremote-adapter/build/MediaRemoteAdapter.framework" \

--- a/scripts/installer.sh
+++ b/scripts/installer.sh
@@ -12,6 +12,16 @@ STAGE="$ROOT/target/dmg"
 "$ROOT/scripts/bundle.sh" release
 
 APP="$ROOT/target/OpenNook.app"
+
+# Local install extras (no-op on a Linux build host).
+if [[ -f "$APP/Contents/MacOS/nook" && -d /usr/local/bin ]]; then
+  ln -sf /Applications/openNook.app/Contents/MacOS/nook /usr/local/bin/nook || true
+fi
+echo "After copying openNook.app to /Applications:"
+echo "  ln -sf /Applications/openNook.app/Contents/MacOS/nook /usr/local/bin/nook"
+echo "  /System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /Applications/openNook.app"
+echo "Finder Services may need: /System/Library/CoreServices/pbs -update  (or a re-login)"
+
 rm -rf "$STAGE" "$DMG"
 mkdir -p "$STAGE"
 ditto "$APP" "$STAGE/openNook.app"


### PR DESCRIPTION
## WP13 — automation-entry

Automation entry points only. No other work packages.

### What landed
- **`opennook://` URL scheme** via `CFBundleURLTypes` + `Application::on_open_urls` + `App::register_url_scheme`.
  - Grammar: `tray/add?path=`, `tray/clear`, `timer/start?seconds=`, `expand`.
  - LaunchServices URLs enqueue `ExternalAction`s; the island drains them on the GPUI foreground executor.
  - **Never maps a URL to shell execution** (browsers can invoke custom schemes).
- **CLI shim** `nook-cli` → bundled as `Contents/MacOS/nook`. Percent-encodes paths and runs `/usr/bin/open -g`. Refuses `exec`/`shell`/`run` verbs.
- **Finder Services**: Info.plist `NSServices` (`NSPortName=openNook` matches `CFBundleName`) + `NookServicesProvider` `sendToOpenNook:userData:error:` feeding the same tray-add path.
- **Termi-Notch MVP** (pipe, not PTY): `nook-core::shell` login-shell spawn with process group, 256 KB cap, timeout, ANSI strip. Expanded Term tab + compact spinner/HUD. **Opt-in, default off.** Typed in the island only.

### Tests
`cargo test -p nook -p nook-core` — green (nook 83, nook-cli 2, nook-core 90).
Covers URL parse (including forbidden exec hosts) and tray-path validation (exists, file/dir, `..` canonicalize).

### Install notes
- `scripts/bundle.sh` copies the CLI and runs `lsregister -f` when present.
- Dev `cargo run` binaries never receive `opennook://` — the `.app` bundle must be registered.
- Finder Services may need `pbs -update` or a re-login after first install.

### Blockers / sharp edges (honest)
1. Scheme registration requires LaunchServices to see the `.app`.
2. NSServices cache lag (`pbs`); `NSPortName` must stay `openNook`.
3. Full interactive TTY is out of scope (pipe MVP only).
4. `$SHELL -lc` sources login rc; a slow `.zprofile` makes commands feel laggy.
5. macOS-only URL routing / Services / `open -g` cannot be live-verified on this Linux CI host.