### PR TITLE
WP11: Audio output / AirPlay picker (CoreAudio phase 1)

### DIFF
--- a/crates/nook-core/src/audio_devices.rs
+++ b/crates/nook-core/src/audio_devices.rs
@@ -7,7 +7,7 @@
 //! here — those targets never appear in the HAL until the route is active, and
 //! MediaRemote routing has been entitlement-blocked since macOS 15.4.
 //!
-//! Idle cost is zero: `AudioObjectAddPropertyListenerBlock` writes a snapshot
+//! Idle cost is zero: `AudioObjectAddPropertyListener` writes a snapshot
 //! and flips a dirty flag. The island tick consumes the flag; there is no
 //! sampling loop.
 
@@ -207,9 +207,9 @@ mod macos {
         is_output_capable, mark_default, output_channels_from_stream_config, publish, OutputDevice,
         OutputTransport, AVAILABLE,
     };
-    use block2::{Block, RcBlock};
     use std::ffi::c_void;
-    use std::sync::{Mutex, Once};
+    use std::sync::atomic::Ordering;
+    use std::sync::Once;
 
     type AudioObjectId = u32;
     type OsStatus = i32;
@@ -261,11 +261,16 @@ mod macos {
             data_size: u32,
             data: *const c_void,
         ) -> OsStatus;
-        fn AudioObjectAddPropertyListenerBlock(
+        fn AudioObjectAddPropertyListener(
             object: AudioObjectId,
             address: *const PropertyAddress,
-            queue: *mut c_void,
-            listener: *mut Block<dyn Fn(u32, *const PropertyAddress)>,
+            listener: unsafe extern "C" fn(
+                AudioObjectId,
+                u32,
+                *const PropertyAddress,
+                *mut c_void,
+            ) -> OsStatus,
+            client_data: *mut c_void,
         ) -> OsStatus;
     }
 
@@ -278,8 +283,6 @@ mod macos {
     }
 
     static STARTED: Once = Once::new();
-    static BLOCKS: Mutex<Vec<RcBlock<dyn Fn(u32, *const PropertyAddress)>>> =
-        Mutex::new(Vec::new());
 
     fn addr(selector: u32, scope: u32, element: u32) -> PropertyAddress {
         PropertyAddress {
@@ -496,38 +499,31 @@ mod macos {
         Ok(())
     }
 
-    fn listen(object: AudioObjectId, address: PropertyAddress, on_change: fn()) {
-        let block = RcBlock::new(move |_n: u32, _addrs: *const PropertyAddress| {
-            on_change();
-        });
+    unsafe extern "C" fn on_hal_change(
+        _object: AudioObjectId,
+        _n: u32,
+        _addrs: *const PropertyAddress,
+        _client: *mut c_void,
+    ) -> OsStatus {
+        refresh();
+        0
+    }
+
+    fn listen(object: AudioObjectId, address: PropertyAddress) {
         let status = unsafe {
-            let block_ref = &*block;
-            let block_ptr = block_ref as *const Block<dyn Fn(u32, *const PropertyAddress)>
-                as *mut Block<dyn Fn(u32, *const PropertyAddress)>;
-            AudioObjectAddPropertyListenerBlock(object, &address, std::ptr::null_mut(), block_ptr)
+            AudioObjectAddPropertyListener(object, &address, on_hal_change, std::ptr::null_mut())
         };
-        if status == 0 {
-            if let Ok(mut guard) = BLOCKS.lock() {
-                guard.push(block);
-            } else {
-                std::mem::forget(block);
-            }
-        } else {
+        if status != 0 {
             log::warn!("CoreAudio output-device listener failed ({status:#x})");
         }
     }
 
     pub(super) fn start() {
         STARTED.call_once(|| {
-            listen(
-                SYSTEM_OBJECT,
-                addr(DEVICES, SCOPE_GLOBAL, ELEMENT_MAIN),
-                refresh,
-            );
+            listen(SYSTEM_OBJECT, addr(DEVICES, SCOPE_GLOBAL, ELEMENT_MAIN));
             listen(
                 SYSTEM_OBJECT,
                 addr(DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
-                refresh,
             );
             refresh();
             AVAILABLE.store(true, Ordering::Relaxed);

--- a/crates/nook-core/src/audio_devices.rs
+++ b/crates/nook-core/src/audio_devices.rs
@@ -190,6 +190,7 @@ fn lock_mutex<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     m.lock().unwrap_or_else(|e| e.into_inner())
 }
 
+#[cfg(target_os = "macos")]
 fn publish(devices: Vec<OutputDevice>) {
     let slot = DEVICES.get_or_init(|| Mutex::new(Vec::new()));
     *lock_mutex(slot) = devices;

--- a/crates/nook-core/src/audio_devices.rs
+++ b/crates/nook-core/src/audio_devices.rs
@@ -1,0 +1,683 @@
+//! System audio output devices via the CoreAudio HAL.
+//!
+//! Phase 1 lists and switches the **default output** among devices that already
+//! exist as CoreAudio objects: built-in speakers, USB/DisplayPort, connected
+//! Bluetooth (AirPods), and an AirPlay route macOS has already made. Starting a
+//! system-wide route to a not-yet-connected HomePod or Apple TV is not possible
+//! here — those targets never appear in the HAL until the route is active, and
+//! MediaRemote routing has been entitlement-blocked since macOS 15.4.
+//!
+//! Idle cost is zero: `AudioObjectAddPropertyListenerBlock` writes a snapshot
+//! and flips a dirty flag. The island tick consumes the flag; there is no
+//! sampling loop.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+/// Caption shown under the picker so the AirPlay limit is not a surprise.
+pub const AIRPLAY_INITIATE_NOTE: &str = "HomePod and Apple TV appear only after macOS routes to them. Use Control Center to start AirPlay.";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputTransport {
+    BuiltIn,
+    Bluetooth,
+    Usb,
+    AirPlay,
+    DisplayPort,
+    Hdmi,
+    Thunderbolt,
+    Virtual,
+    Unknown,
+}
+
+impl OutputTransport {
+    /// HAL `kAudioDevicePropertyTransportType` FourCC.
+    pub fn from_code(code: u32) -> Self {
+        match &code.to_be_bytes() {
+            b"bltn" => Self::BuiltIn,
+            b"blue" | b"blea" => Self::Bluetooth,
+            b"usb " => Self::Usb,
+            b"airp" => Self::AirPlay,
+            b"dprt" => Self::DisplayPort,
+            b"hdmi" => Self::Hdmi,
+            b"thun" => Self::Thunderbolt,
+            b"virt" | b"grup" => Self::Virtual,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn icon(self) -> &'static str {
+        match self {
+            Self::AirPlay => "airplay",
+            Self::Bluetooth => "bluetooth",
+            Self::BuiltIn => "speaker",
+            Self::Usb | Self::Thunderbolt => "headphones",
+            Self::DisplayPort | Self::Hdmi => "monitor",
+            Self::Virtual | Self::Unknown => "volume-2",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::BuiltIn => "Built-in",
+            Self::Bluetooth => "Bluetooth",
+            Self::Usb => "USB",
+            Self::AirPlay => "AirPlay",
+            Self::DisplayPort => "DisplayPort",
+            Self::Hdmi => "HDMI",
+            Self::Thunderbolt => "Thunderbolt",
+            Self::Virtual => "Virtual",
+            Self::Unknown => "Output",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OutputDevice {
+    pub id: u32,
+    pub name: String,
+    pub transport: OutputTransport,
+    pub is_default: bool,
+}
+
+impl OutputDevice {
+    pub fn icon(&self) -> &'static str {
+        self.transport.icon()
+    }
+}
+
+/// True after CoreAudio listeners installed successfully.
+pub fn available() -> bool {
+    AVAILABLE.load(Ordering::Relaxed)
+}
+
+/// Last enumerated output devices. Empty off macOS or before [`start`].
+pub fn snapshot() -> Vec<OutputDevice> {
+    store().map(|m| lock_mutex(m).clone()).unwrap_or_default()
+}
+
+/// Current default output, if the snapshot has one.
+pub fn default_output() -> Option<OutputDevice> {
+    snapshot().into_iter().find(|d| d.is_default)
+}
+
+/// True if a listener rebuilt the snapshot since the last take.
+pub fn take_dirty() -> bool {
+    DIRTY.swap(false, Ordering::Relaxed)
+}
+
+/// Re-enumerate now (startup, listener, or the user opening the picker).
+pub fn refresh() {
+    #[cfg(target_os = "macos")]
+    macos::refresh();
+}
+
+/// Make `id` the default output (and the default system/alert output).
+pub fn set_default_output(id: u32) -> Result<(), String> {
+    if id == 0 {
+        return Err("invalid output device".into());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        return macos::set_default(id);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = id;
+        Err("audio output switching is only available on macOS".into())
+    }
+}
+
+/// Install HAL listeners. Safe to call more than once.
+pub fn start() {
+    #[cfg(target_os = "macos")]
+    macos::start();
+}
+
+/// A device is an output if its output-scope stream config has any channels.
+pub fn is_output_capable(channels: u32) -> bool {
+    channels > 0
+}
+
+/// Parse `kAudioDevicePropertyStreamConfiguration` bytes into a channel count.
+///
+/// `AudioBufferList` is `UInt32 mNumberBuffers` plus pointer-aligned
+/// `AudioBuffer` entries (`mNumberChannels`, `mDataByteSize`, `mData`).
+pub fn output_channels_from_stream_config(bytes: &[u8]) -> u32 {
+    if bytes.len() < 4 {
+        return 0;
+    }
+    let n_buffers = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]) as usize;
+    let first = stream_config_first_buffer_offset();
+    let stride = audio_buffer_size();
+    let mut channels = 0u32;
+    for i in 0..n_buffers {
+        let off = first + i * stride;
+        if off + 4 > bytes.len() {
+            break;
+        }
+        channels = channels.saturating_add(u32::from_ne_bytes([
+            bytes[off],
+            bytes[off + 1],
+            bytes[off + 2],
+            bytes[off + 3],
+        ]));
+    }
+    channels
+}
+
+/// Mark the matching id as default; everyone else is not.
+pub fn mark_default(devices: &mut [OutputDevice], default_id: u32) {
+    for device in devices {
+        device.is_default = device.id == default_id && default_id != 0;
+    }
+}
+
+fn stream_config_first_buffer_offset() -> usize {
+    std::mem::size_of::<u32>().next_multiple_of(std::mem::size_of::<usize>())
+}
+
+fn audio_buffer_size() -> usize {
+    // Two UInt32s + a pointer; matches CoreAudio's AudioBuffer on all LP64/ILP32.
+    8 + std::mem::size_of::<*mut ()>()
+}
+
+fn store() -> Option<&'static Mutex<Vec<OutputDevice>>> {
+    DEVICES.get()
+}
+
+fn lock_mutex<T>(m: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    m.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+fn publish(devices: Vec<OutputDevice>) {
+    let slot = DEVICES.get_or_init(|| Mutex::new(Vec::new()));
+    *lock_mutex(slot) = devices;
+    DIRTY.store(true, Ordering::Relaxed);
+}
+
+static DEVICES: OnceLock<Mutex<Vec<OutputDevice>>> = OnceLock::new();
+static DIRTY: AtomicBool = AtomicBool::new(false);
+static AVAILABLE: AtomicBool = AtomicBool::new(false);
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::{
+        is_output_capable, mark_default, output_channels_from_stream_config, publish, OutputDevice,
+        OutputTransport, AVAILABLE,
+    };
+    use block2::{Block, RcBlock};
+    use std::ffi::c_void;
+    use std::sync::{Mutex, Once};
+
+    type AudioObjectId = u32;
+    type OsStatus = i32;
+    type CfIndex = isize;
+
+    #[repr(C)]
+    #[derive(Clone, Copy)]
+    struct PropertyAddress {
+        selector: u32,
+        scope: u32,
+        element: u32,
+    }
+
+    const SYSTEM_OBJECT: AudioObjectId = 1;
+    const ELEMENT_MAIN: u32 = 0;
+    const SCOPE_GLOBAL: u32 = u32::from_be_bytes(*b"glob");
+    const SCOPE_OUTPUT: u32 = u32::from_be_bytes(*b"outp");
+    const DEVICES: u32 = u32::from_be_bytes(*b"dev#");
+    const DEFAULT_OUTPUT: u32 = u32::from_be_bytes(*b"dOut");
+    const DEFAULT_SYSTEM_OUTPUT: u32 = u32::from_be_bytes(*b"sOut");
+    const OBJECT_NAME: u32 = u32::from_be_bytes(*b"lnam");
+    const TRANSPORT: u32 = u32::from_be_bytes(*b"tran");
+    const STREAM_CONFIG: u32 = u32::from_be_bytes(*b"slay");
+    const CF_STRING_ENCODING_UTF8: u32 = 0x0800_0100;
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    unsafe extern "C" {
+        fn AudioObjectHasProperty(object: AudioObjectId, address: *const PropertyAddress) -> u8;
+        fn AudioObjectGetPropertyDataSize(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            data_size: *mut u32,
+        ) -> OsStatus;
+        fn AudioObjectGetPropertyData(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            data_size: *mut u32,
+            data: *mut c_void,
+        ) -> OsStatus;
+        fn AudioObjectSetPropertyData(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            data_size: u32,
+            data: *const c_void,
+        ) -> OsStatus;
+        fn AudioObjectAddPropertyListenerBlock(
+            object: AudioObjectId,
+            address: *const PropertyAddress,
+            queue: *mut c_void,
+            listener: *mut Block<dyn Fn(u32, *const PropertyAddress)>,
+        ) -> OsStatus;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFRelease(cf: *const c_void);
+        fn CFStringGetLength(s: *const c_void) -> CfIndex;
+        fn CFStringGetMaximumSizeForEncoding(len: CfIndex, encoding: u32) -> CfIndex;
+        fn CFStringGetCString(s: *const c_void, buf: *mut i8, size: CfIndex, encoding: u32) -> u8;
+    }
+
+    static STARTED: Once = Once::new();
+    static BLOCKS: Mutex<Vec<RcBlock<dyn Fn(u32, *const PropertyAddress)>>> =
+        Mutex::new(Vec::new());
+
+    fn addr(selector: u32, scope: u32, element: u32) -> PropertyAddress {
+        PropertyAddress {
+            selector,
+            scope,
+            element,
+        }
+    }
+
+    fn has_property(object: AudioObjectId, address: PropertyAddress) -> bool {
+        unsafe { AudioObjectHasProperty(object, &address) != 0 }
+    }
+
+    fn get_u32(object: AudioObjectId, address: PropertyAddress) -> Option<u32> {
+        if !has_property(object, address) {
+            return None;
+        }
+        let mut value = 0u32;
+        let mut size = std::mem::size_of::<u32>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                &mut value as *mut u32 as *mut c_void,
+            )
+        };
+        (status == 0).then_some(value)
+    }
+
+    fn set_u32(object: AudioObjectId, address: PropertyAddress, value: u32) -> OsStatus {
+        unsafe {
+            AudioObjectSetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                std::mem::size_of::<u32>() as u32,
+                &value as *const u32 as *const c_void,
+            )
+        }
+    }
+
+    fn property_bytes(object: AudioObjectId, address: PropertyAddress) -> Option<Vec<u8>> {
+        if !has_property(object, address) {
+            return None;
+        }
+        let mut size = 0u32;
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(object, &address, 0, std::ptr::null(), &mut size)
+        };
+        if status != 0 || size == 0 {
+            return None;
+        }
+        let mut buf = vec![0u8; size as usize];
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                object,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                buf.as_mut_ptr() as *mut c_void,
+            )
+        };
+        (status == 0).then_some(buf)
+    }
+
+    fn cfstring_to_string(cf: *const c_void) -> Option<String> {
+        if cf.is_null() {
+            return None;
+        }
+        let len = unsafe { CFStringGetLength(cf) };
+        if len < 0 {
+            return None;
+        }
+        let max = unsafe { CFStringGetMaximumSizeForEncoding(len, CF_STRING_ENCODING_UTF8) };
+        if max < 0 {
+            return None;
+        }
+        let mut buf = vec![0i8; (max as usize).saturating_add(1)];
+        let ok = unsafe {
+            CFStringGetCString(
+                cf,
+                buf.as_mut_ptr(),
+                buf.len() as CfIndex,
+                CF_STRING_ENCODING_UTF8,
+            )
+        };
+        if ok == 0 {
+            return None;
+        }
+        let bytes = buf
+            .iter()
+            .map(|b| *b as u8)
+            .take_while(|b| *b != 0)
+            .collect();
+        String::from_utf8(bytes).ok()
+    }
+
+    fn device_name(id: AudioObjectId) -> String {
+        let address = addr(OBJECT_NAME, SCOPE_GLOBAL, ELEMENT_MAIN);
+        if !has_property(id, address) {
+            return format!("Output {id}");
+        }
+        let mut cf: *const c_void = std::ptr::null();
+        let mut size = std::mem::size_of::<*const c_void>() as u32;
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                id,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                &mut cf as *mut *const c_void as *mut c_void,
+            )
+        };
+        if status != 0 || cf.is_null() {
+            return format!("Output {id}");
+        }
+        let name = cfstring_to_string(cf).unwrap_or_else(|| format!("Output {id}"));
+        unsafe { CFRelease(cf) };
+        if name.trim().is_empty() {
+            format!("Output {id}")
+        } else {
+            name
+        }
+    }
+
+    fn output_channels(id: AudioObjectId) -> u32 {
+        let bytes = property_bytes(id, addr(STREAM_CONFIG, SCOPE_OUTPUT, ELEMENT_MAIN));
+        bytes
+            .map(|b| output_channels_from_stream_config(&b))
+            .unwrap_or(0)
+    }
+
+    fn all_device_ids() -> Vec<AudioObjectId> {
+        let address = addr(DEVICES, SCOPE_GLOBAL, ELEMENT_MAIN);
+        let mut size = 0u32;
+        let status = unsafe {
+            AudioObjectGetPropertyDataSize(SYSTEM_OBJECT, &address, 0, std::ptr::null(), &mut size)
+        };
+        if status != 0 || size == 0 || size as usize % std::mem::size_of::<AudioObjectId>() != 0 {
+            return Vec::new();
+        }
+        let count = size as usize / std::mem::size_of::<AudioObjectId>();
+        let mut ids = vec![0u32; count];
+        let status = unsafe {
+            AudioObjectGetPropertyData(
+                SYSTEM_OBJECT,
+                &address,
+                0,
+                std::ptr::null(),
+                &mut size,
+                ids.as_mut_ptr() as *mut c_void,
+            )
+        };
+        if status != 0 {
+            return Vec::new();
+        }
+        ids.retain(|&id| id != 0);
+        ids
+    }
+
+    fn default_output_id() -> u32 {
+        get_u32(
+            SYSTEM_OBJECT,
+            addr(DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
+        )
+        .unwrap_or(0)
+    }
+
+    pub(super) fn refresh() {
+        let default_id = default_output_id();
+        let mut devices: Vec<OutputDevice> = all_device_ids()
+            .into_iter()
+            .filter(|&id| is_output_capable(output_channels(id)))
+            .map(|id| {
+                let transport = get_u32(id, addr(TRANSPORT, SCOPE_GLOBAL, ELEMENT_MAIN))
+                    .map(OutputTransport::from_code)
+                    .unwrap_or(OutputTransport::Unknown);
+                OutputDevice {
+                    id,
+                    name: device_name(id),
+                    transport,
+                    is_default: false,
+                }
+            })
+            .collect();
+        mark_default(&mut devices, default_id);
+        publish(devices);
+    }
+
+    pub(super) fn set_default(id: AudioObjectId) -> Result<(), String> {
+        if !is_output_capable(output_channels(id)) {
+            return Err("device has no output channels".into());
+        }
+        let status = set_u32(
+            SYSTEM_OBJECT,
+            addr(DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
+            id,
+        );
+        if status != 0 {
+            return Err(format!("AudioObjectSetPropertyData failed ({status:#x})"));
+        }
+        let _ = set_u32(
+            SYSTEM_OBJECT,
+            addr(DEFAULT_SYSTEM_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
+            id,
+        );
+        refresh();
+        Ok(())
+    }
+
+    fn listen(object: AudioObjectId, address: PropertyAddress, on_change: fn()) {
+        let block = RcBlock::new(move |_n: u32, _addrs: *const PropertyAddress| {
+            on_change();
+        });
+        let status = unsafe {
+            let block_ref = &*block;
+            let block_ptr = block_ref as *const Block<dyn Fn(u32, *const PropertyAddress)>
+                as *mut Block<dyn Fn(u32, *const PropertyAddress)>;
+            AudioObjectAddPropertyListenerBlock(object, &address, std::ptr::null_mut(), block_ptr)
+        };
+        if status == 0 {
+            if let Ok(mut guard) = BLOCKS.lock() {
+                guard.push(block);
+            } else {
+                std::mem::forget(block);
+            }
+        } else {
+            log::warn!("CoreAudio output-device listener failed ({status:#x})");
+        }
+    }
+
+    pub(super) fn start() {
+        STARTED.call_once(|| {
+            listen(
+                SYSTEM_OBJECT,
+                addr(DEVICES, SCOPE_GLOBAL, ELEMENT_MAIN),
+                refresh,
+            );
+            listen(
+                SYSTEM_OBJECT,
+                addr(DEFAULT_OUTPUT, SCOPE_GLOBAL, ELEMENT_MAIN),
+                refresh,
+            );
+            refresh();
+            AVAILABLE.store(true, Ordering::Relaxed);
+            log::info!("CoreAudio output-device listeners installed");
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fourcc(code: &[u8; 4]) -> u32 {
+        u32::from_be_bytes(*code)
+    }
+
+    fn pack_stream_config(channels: &[u32]) -> Vec<u8> {
+        let first = stream_config_first_buffer_offset();
+        let stride = audio_buffer_size();
+        let mut bytes = vec![0u8; first + channels.len() * stride];
+        let n = channels.len() as u32;
+        bytes[0..4].copy_from_slice(&n.to_ne_bytes());
+        for (i, ch) in channels.iter().enumerate() {
+            let off = first + i * stride;
+            bytes[off..off + 4].copy_from_slice(&ch.to_ne_bytes());
+        }
+        bytes
+    }
+
+    #[test]
+    fn transport_from_code_maps_fourcc() {
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"bltn")),
+            OutputTransport::BuiltIn
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"blue")),
+            OutputTransport::Bluetooth
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"blea")),
+            OutputTransport::Bluetooth
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"usb ")),
+            OutputTransport::Usb
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"airp")),
+            OutputTransport::AirPlay
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"dprt")),
+            OutputTransport::DisplayPort
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"hdmi")),
+            OutputTransport::Hdmi
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"thun")),
+            OutputTransport::Thunderbolt
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"virt")),
+            OutputTransport::Virtual
+        );
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"grup")),
+            OutputTransport::Virtual
+        );
+        assert_eq!(OutputTransport::from_code(0), OutputTransport::Unknown);
+        assert_eq!(
+            OutputTransport::from_code(fourcc(b"????")),
+            OutputTransport::Unknown
+        );
+    }
+
+    #[test]
+    fn transport_icons_and_labels_are_stable() {
+        assert_eq!(OutputTransport::AirPlay.icon(), "airplay");
+        assert_eq!(OutputTransport::Bluetooth.icon(), "bluetooth");
+        assert_eq!(OutputTransport::BuiltIn.icon(), "speaker");
+        assert_eq!(OutputTransport::AirPlay.label(), "AirPlay");
+        assert_eq!(OutputTransport::Unknown.label(), "Output");
+    }
+
+    #[test]
+    fn output_channels_from_stream_config_sums_buffers() {
+        assert_eq!(output_channels_from_stream_config(&[]), 0);
+        assert_eq!(output_channels_from_stream_config(&[0, 0]), 0);
+        assert_eq!(
+            output_channels_from_stream_config(&pack_stream_config(&[2])),
+            2
+        );
+        assert_eq!(
+            output_channels_from_stream_config(&pack_stream_config(&[2, 2])),
+            4
+        );
+        assert_eq!(
+            output_channels_from_stream_config(&pack_stream_config(&[0, 0])),
+            0
+        );
+    }
+
+    #[test]
+    fn is_output_capable_needs_a_channel() {
+        assert!(!is_output_capable(0));
+        assert!(is_output_capable(1));
+        assert!(is_output_capable(2));
+    }
+
+    #[test]
+    fn mark_default_flags_only_the_matching_id() {
+        let mut devices = vec![
+            OutputDevice {
+                id: 10,
+                name: "MacBook Speakers".into(),
+                transport: OutputTransport::BuiltIn,
+                is_default: true,
+            },
+            OutputDevice {
+                id: 20,
+                name: "AirPods Pro".into(),
+                transport: OutputTransport::Bluetooth,
+                is_default: true,
+            },
+        ];
+        mark_default(&mut devices, 20);
+        assert!(!devices[0].is_default);
+        assert!(devices[1].is_default);
+        mark_default(&mut devices, 0);
+        assert!(devices.iter().all(|d| !d.is_default));
+    }
+
+    #[test]
+    fn airplay_note_is_honest_about_initiate_limits() {
+        assert!(AIRPLAY_INITIATE_NOTE.contains("Control Center"));
+        assert!(AIRPLAY_INITIATE_NOTE.contains("HomePod"));
+    }
+
+    #[test]
+    fn setters_are_safe_off_macos() {
+        assert!(set_default_output(0).is_err());
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert!(!available());
+            assert!(snapshot().is_empty());
+            assert!(set_default_output(42).is_err());
+            assert!(default_output().is_none());
+            assert!(!take_dirty());
+        }
+    }
+}

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod agents;
 pub mod audio;
+pub mod audio_devices;
 pub mod browser_media;
 pub mod calendar;
 pub mod database;
@@ -62,6 +63,7 @@ pub fn init() {
         }
         audio::init_audio_state();
         audio::setup_audio_monitoring();
+        audio_devices::start();
         mouse::start_polling();
     });
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -167,6 +167,10 @@ pub struct AppSettings {
     /// Per-widget widths in Nook cells. Missing entries use [`WidgetModule::default_cells`].
     #[serde(default)]
     pub widget_widths: Vec<(WidgetModule, u8)>,
+    /// AirPlay / output-device picker on the expanded media card. CoreAudio
+    /// HAL only — cannot initiate a new AirPlay route to a HomePod / Apple TV.
+    #[serde(default = "default_true")]
+    pub audio_output_picker: bool,
     #[serde(default)]
     pub window: WindowSettings,
 }
@@ -239,6 +243,7 @@ impl Default for AppSettings {
             hide_when_maximized: false,
             island_color: None,
             widget_widths: Vec::new(),
+            audio_output_picker: true,
             window: WindowSettings::default(),
         }
     }
@@ -725,5 +730,15 @@ mod tests {
         let legacy: AppSettings =
             serde_json::from_str(r#"{"observe":{"metrics_token":"legacy-secret"}}"#).unwrap();
         assert_eq!(legacy.observe.metrics_token, "legacy-secret");
+    }
+
+    #[test]
+    fn audio_output_picker_defaults_on() {
+        let parsed: AppSettings = serde_json::from_str("{}").unwrap();
+        assert!(parsed.audio_output_picker);
+        assert_eq!(
+            parsed.audio_output_picker,
+            AppSettings::default().audio_output_picker
+        );
     }
 }

--- a/crates/nook/src/assets/icons/airplay.svg
+++ b/crates/nook/src/assets/icons/airplay.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M5 17H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2h-1"/>
+<path d="m12 15 5 6H7Z"/>
+</svg>

--- a/crates/nook/src/assets/icons/bluetooth.svg
+++ b/crates/nook/src/assets/icons/bluetooth.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="m7 7 10 10-5 5V2l5 5L7 17"/>
+</svg>

--- a/crates/nook/src/assets/icons/check.svg
+++ b/crates/nook/src/assets/icons/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M20 6 9 17l-5-5"/>
+</svg>

--- a/crates/nook/src/assets/icons/headphones.svg
+++ b/crates/nook/src/assets/icons/headphones.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M3 14h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-7a9 9 0 0 1 18 0v7a2 2 0 0 1-2 2h-1a2 2 0 0 1-2-2v-3a2 2 0 0 1 2-2h3"/>
+</svg>

--- a/crates/nook/src/assets/icons/monitor.svg
+++ b/crates/nook/src/assets/icons/monitor.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<rect width="20" height="14" x="2" y="3" rx="2"/>
+<line x1="8" x2="16" y1="21" y2="21"/>
+<line x1="12" x2="12" y1="17" y2="21"/>
+</svg>

--- a/crates/nook/src/assets/icons/speaker.svg
+++ b/crates/nook/src/assets/icons/speaker.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<rect width="16" height="20" x="4" y="2" rx="2"/>
+<path d="M12 6h.01"/>
+<circle cx="12" cy="14" r="4"/>
+<path d="M12 14h.01"/>
+</svg>

--- a/crates/nook/src/assets/icons/volume-2.svg
+++ b/crates/nook/src/assets/icons/volume-2.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M11 4.702a.705.705 0 0 0-1.203-.498L6.413 7.587A1.4 1.4 0 0 1 5.416 8H3a1 1 0 0 0-1 1v6a1 1 0 0 0 1 1h2.416a1.4 1.4 0 0 1 .997.413l3.383 3.384A.705.705 0 0 0 11 19.298z"/>
+<path d="M16 9a5 5 0 0 1 0 6"/>
+<path d="M19.364 18.364a9 9 0 0 0 0-12.728"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -53,6 +53,9 @@ impl Island {
     }
 
     fn compact_left(&self, mode: CompactMode, cx: &mut Context<Self>) -> AnyElement {
+        if let Some(name) = self.output_hud_label() {
+            return label(name.to_string(), theme::BODY, true).into_any_element();
+        }
         match mode {
             CompactMode::Media => {
                 album_chip(&self.now_playing, self.overlay_fade.value, cx).into_any_element()

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -97,10 +97,7 @@ impl Island {
             match module {
                 WidgetModule::Music if self.settings.show_media => add(
                     &mut kids,
-                    cell_pane(
-                        self.settings.cells_for(module),
-                        nook_media_pane(&self.now_playing, cx),
-                    ),
+                    cell_pane(self.settings.cells_for(module), nook_media_pane(self, cx)),
                 ),
                 WidgetModule::Calendar if self.settings.show_calendar => add(
                     &mut kids,

--- a/crates/nook/src/island/media.rs
+++ b/crates/nook/src/island/media.rs
@@ -241,7 +241,8 @@ const APP_BADGE: f32 = 22.0;
 const APP_BADGE_RADIUS: f32 = 5.0;
 
 /// Horizontal Now Playing strip for the Nook tab (art + metadata + transport).
-pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> impl IntoElement {
+pub(crate) fn nook_media_pane(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let np = &island.now_playing;
     let title = np.title.clone().unwrap_or_else(|| "Unknown Title".into());
     let artist = np.artist.clone().unwrap_or_else(|| "Unknown Artist".into());
     let album = np.album.clone().filter(|s| !s.is_empty());
@@ -258,6 +259,14 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
         .artwork_base64
         .as_deref()
         .and_then(|b64| artwork_element(b64, NOOK_ART, NOOK_ART_RADIUS));
+    let show_picker = island.output_picker_enabled();
+    let picker_open = island.output_picker_open && show_picker;
+    let picker_icon = island
+        .output_devices
+        .iter()
+        .find(|d| d.is_default)
+        .map(|d| d.icon())
+        .unwrap_or("airplay");
 
     div()
         .id("nook-media")
@@ -303,7 +312,9 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                         .child(app_badge(np.bundle_id.as_deref(), np.app_name.as_deref())),
                 ),
         )
-        .child(
+        .child(if picker_open {
+            output_picker_list(island, cx).into_any_element()
+        } else {
             div()
                 .flex()
                 .flex_col()
@@ -320,7 +331,7 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                     div()
                         .flex()
                         .items_center()
-                        .gap(px(18.))
+                        .gap(px(14.))
                         .mt(px(6.))
                         .child(nook_skip("skip-back", "nook-skip-back", cx, |_, _, _| {
                             nook_core::runtime().spawn(async {
@@ -332,10 +343,119 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                             nook_core::runtime().spawn(async {
                                 let _ = nook_core::audio::media_next_track().await;
                             });
-                        })),
+                        }))
+                        .when(show_picker, |d| {
+                            d.child(output_picker_btn(picker_icon, false, cx))
+                        }),
                 )
-                .child(nook_progress(progress, elapsed, duration, seekable, cx)),
+                .child(nook_progress(progress, elapsed, duration, seekable, cx))
+                .into_any_element()
+        })
+}
+
+fn output_picker_btn(icon: &'static str, open: bool, cx: &mut Context<Island>) -> impl IntoElement {
+    div()
+        .id("nook-output-picker")
+        .size(px(22.))
+        .flex()
+        .items_center()
+        .justify_center()
+        .opacity(if open { 1.0 } else { 0.9 })
+        .hover(|s| s.opacity(1.0))
+        .active(|s| s.opacity(0.75))
+        .cursor(CursorStyle::PointingHand)
+        .child(lucide_color(icon, 15.0, rgb(0xffffff)))
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(|this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                this.toggle_output_picker(cx);
+            }),
         )
+}
+
+fn output_picker_list(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let mut list = div()
+        .id("nook-output-list")
+        .flex()
+        .flex_col()
+        .min_w(px(0.))
+        .w(px(200.))
+        .h_full()
+        .overflow_hidden();
+    list = list.child(
+        div()
+            .flex()
+            .items_center()
+            .justify_between()
+            .mb(px(4.))
+            .child(
+                div()
+                    .text_color(rgba(0xffffff99))
+                    .text_size(px(theme::SUBHEADLINE.size))
+                    .line_height(px(theme::SUBHEADLINE.leading))
+                    .child("Output"),
+            )
+            .child(output_picker_btn("airplay", true, cx)),
+    );
+    if island.output_devices.is_empty() {
+        list = list.child(
+            div()
+                .text_color(rgba(0xffffff66))
+                .text_size(px(theme::SUBHEADLINE.size))
+                .child("No output devices"),
+        );
+    } else {
+        for device in &island.output_devices {
+            let id = device.id;
+            let name = device.name.clone();
+            let icon = device.icon();
+            let selected = device.is_default;
+            list = list.child(
+                div()
+                    .id(SharedString::from(format!("out-dev-{id}")))
+                    .flex()
+                    .items_center()
+                    .gap(px(6.))
+                    .h(px(22.))
+                    .rounded(px(4.))
+                    .px(px(2.))
+                    .when(selected, |d| d.bg(rgba(0xffffff18)))
+                    .hover(|s| s.bg(rgba(0xffffff22)))
+                    .cursor(CursorStyle::PointingHand)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                            cx.stop_propagation();
+                            this.select_output_device(id, cx);
+                        }),
+                    )
+                    .child(lucide_color(icon, 12.0, rgb(0xffffff)))
+                    .child(
+                        div()
+                            .flex_1()
+                            .min_w(px(0.))
+                            .overflow_hidden()
+                            .text_ellipsis()
+                            .text_color(rgb(0xffffff))
+                            .text_size(px(theme::SUBHEADLINE.size))
+                            .line_height(px(theme::SUBHEADLINE.leading))
+                            .child(name),
+                    )
+                    .when(selected, |d| {
+                        d.child(lucide_color("check", 12.0, rgb(0xffffff)))
+                    }),
+            );
+        }
+    }
+    list.child(
+        div()
+            .mt(px(4.))
+            .text_color(rgba(0xffffff55))
+            .text_size(px(9.))
+            .line_height(px(11.))
+            .child(nook_core::audio_devices::AIRPLAY_INITIATE_NOTE),
+    )
 }
 
 fn app_badge(bundle_id: Option<&str>, app_name: Option<&str>) -> AnyElement {

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -158,6 +158,11 @@ pub struct Island {
     pub(crate) mirror_on: bool,
     mirror_gen: u64,
     pub(crate) mirror_frame: Option<std::sync::Arc<gpui::RenderImage>>,
+    /// Output-device list for the media-card picker. Rebuilt when the HAL dirty flag flips.
+    pub(crate) output_devices: Vec<nook_core::audio_devices::OutputDevice>,
+    pub(crate) output_picker_open: bool,
+    output_hud_name: Option<String>,
+    output_hud_until: Option<Instant>,
 }
 
 struct PendingFileDrag {
@@ -256,6 +261,10 @@ impl Island {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            output_devices: nook_core::audio_devices::snapshot(),
+            output_picker_open: false,
+            output_hud_name: None,
+            output_hud_until: None,
         };
         // Start at the compact idle size so the first paint isn't a jump.
         let (w, h) = this.target_size();
@@ -340,6 +349,9 @@ impl Island {
                     }
                     if platform::take_open_settings() {
                         this.open_settings(cx);
+                        dirty = true;
+                    }
+                    if this.sync_output_devices() {
                         dirty = true;
                     }
                     let want_suppress = this.settings.hide_when_maximized
@@ -724,6 +736,86 @@ impl Island {
             });
         })
         .detach();
+    }
+
+    /// Consume the HAL dirty flag (and HUD expiry) without adding a timer.
+    fn sync_output_devices(&mut self) -> bool {
+        let mut dirty = false;
+        if !self.settings.audio_output_picker && self.output_picker_open {
+            self.output_picker_open = false;
+            dirty = true;
+        }
+        if !self.expanded && self.output_picker_open {
+            self.output_picker_open = false;
+            dirty = true;
+        }
+        if nook_core::audio_devices::take_dirty() {
+            let devices = nook_core::audio_devices::snapshot();
+            let old_id = self
+                .output_devices
+                .iter()
+                .find(|d| d.is_default)
+                .map(|d| d.id);
+            let had_list = !self.output_devices.is_empty();
+            let new_default = devices.iter().find(|d| d.is_default).cloned();
+            self.output_devices = devices;
+            if had_list {
+                if let Some(dev) = new_default {
+                    if Some(dev.id) != old_id {
+                        self.output_hud_name = Some(dev.name);
+                        self.output_hud_until = Some(Instant::now() + Duration::from_millis(1500));
+                    }
+                }
+            }
+            dirty = true;
+        }
+        if let Some(until) = self.output_hud_until {
+            if Instant::now() >= until {
+                self.output_hud_until = None;
+                self.output_hud_name = None;
+                dirty = true;
+            }
+        }
+        dirty
+    }
+
+    pub(crate) fn output_picker_enabled(&self) -> bool {
+        self.settings.audio_output_picker && nook_core::audio_devices::available()
+    }
+
+    pub(crate) fn output_hud_label(&self) -> Option<&str> {
+        let until = self.output_hud_until?;
+        if Instant::now() < until {
+            self.output_hud_name.as_deref()
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn toggle_output_picker(&mut self, cx: &mut Context<Self>) {
+        if !self.output_picker_enabled() {
+            self.output_picker_open = false;
+            cx.notify();
+            return;
+        }
+        if self.output_picker_open {
+            self.output_picker_open = false;
+        } else {
+            nook_core::audio_devices::refresh();
+            self.output_devices = nook_core::audio_devices::snapshot();
+            let _ = nook_core::audio_devices::take_dirty();
+            self.output_picker_open = true;
+        }
+        cx.notify();
+    }
+
+    pub(crate) fn select_output_device(&mut self, id: u32, cx: &mut Context<Self>) {
+        let _ = nook_core::audio_devices::set_default_output(id);
+        for device in &mut self.output_devices {
+            device.is_default = device.id == id;
+        }
+        self.output_picker_open = false;
+        cx.notify();
     }
 
     pub(crate) fn has_media(&self) -> bool {
@@ -1494,6 +1586,10 @@ mod tests {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            output_devices: Vec::new(),
+            output_picker_open: false,
+            output_hud_name: None,
+            output_hud_until: None,
         }
     }
 
@@ -1673,6 +1769,21 @@ mod tests {
         island.settings.show_files = false;
         island.settings.show_timers = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn output_hud_label_tracks_ttl() {
+        let mut island = test_island();
+        assert!(island.output_hud_label().is_none());
+        island.output_hud_name = Some("AirPods Pro".into());
+        island.output_hud_until = Some(Instant::now() + Duration::from_secs(2));
+        assert_eq!(island.output_hud_label(), Some("AirPods Pro"));
+        island.output_hud_until = Some(Instant::now() - Duration::from_millis(1));
+        assert!(island.output_hud_label().is_none());
+        island.settings.audio_output_picker = false;
+        island.output_picker_open = true;
+        assert!(island.sync_output_devices());
+        assert!(!island.output_picker_open);
     }
 
     #[test]

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -569,6 +569,17 @@ impl SettingsView {
                         .into_any_element(),
                     ]),
                     Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
+                ))
+                .child(section(
+                    "Sound",
+                    settings_group(vec![toggle_row(
+                        "Output picker on the media card",
+                        settings.audio_output_picker,
+                        cx,
+                        |s| s.audio_output_picker = !s.audio_output_picker,
+                    )
+                    .into_any_element()]),
+                    Some(nook_core::audio_devices::AIRPLAY_INITIATE_NOTE),
                 )),
         )
     }
@@ -1346,7 +1357,7 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Pinned metrics on the compact island and the expanded card.".into()
         }
         WidgetModule::Music => {
-            "Now Playing from MediaRemote on macOS, with an AppleScript fallback.".into()
+            "Now Playing from MediaRemote on macOS. The output picker lists CoreAudio devices; it cannot start AirPlay to a HomePod or Apple TV.".into()
         }
         WidgetModule::Files => "Drop zone and tray live on the Tray tab of the expanded island.".into(),
         WidgetModule::Timers => "Countdown presets and a compact ring while a timer is running.".into(),


### PR DESCRIPTION
## WP11 — airplay-output-picker

Phase 1 CoreAudio only. No other work packages. Self-contained: does **not** depend on unmerged WP02 `sysvol.rs`.

### What landed
- **NEW `nook-core::audio_devices`**: hand-rolled CoreAudio HAL bindings (`#[link(name = "CoreAudio")]`, no `coreaudio-sys`). Enumerate output-capable devices, read name + transport FourCC, switch `kAudioHardwarePropertyDefaultOutputDevice` (and system/alert output).
- **Event-driven**: `AudioObjectAddPropertyListenerBlock` on device list + default output. Callback rebuilds a snapshot and flips an `AtomicBool`; the existing island tick consumes it. No new timer.
- **Media card**: AirPlay/transport glyph on the expanded Now Playing pane. Opens an in-card list; rows call `set_default_output`. Compact face briefly shows the new device name after a default-output change.
- **Settings**: General → Sound → “Output picker on the media card” (default on). Hidden when HAL is unavailable (non-macOS / listener install failed).

### Honest AirPlay limit
This lists devices that **already exist as CoreAudio objects** (built-in, USB/DisplayPort, connected AirPods/Bluetooth, an AirPlay route macOS has already made). It **cannot start** a system-wide route to a not-yet-connected HomePod or Apple TV — those never appear in the HAL until the route is active, and MediaRemote routing is entitlement-blocked since macOS 15.4. The picker and Settings caption say so. Phase 2 (IOBluetooth reconnect / Bonjour listing) is out of scope.

### Tests
`cargo test -p nook -p nook-core` — green on Linux (nook **82**, nook-core **84**).

Pure helpers: transport FourCC map, `AudioBufferList` channel-count parse, `is_output_capable`, `mark_default`, settings default-on, compact HUD TTL, off-macOS setters are no-ops.

### Blockers / not verified here
1. HAL listeners and default-output switching need a macOS run — this host is Linux.
2. Initiating AirPlay remains blocked for unsigned/dev-signed apps. No Control Center UI-scripting fallback.
3. Switching default output mid-playback can glitch in some apps (system behavior).