### PR TITLE
WP15: Mechey keyboard sounds + LiquidMouse smooth scroll

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.13.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +593,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.13.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.3",
+ "shlex 1.3.0",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -851,6 +891,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1054,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "command-fds"
@@ -1214,6 +1270,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b4739a805a62757a83e5654fa3faabec0442666b263bb2287d5a8185bfd953"
+dependencies = [
+ "bindgen 0.72.1",
+]
+
+[[package]]
 name = "cosmic-text"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1310,29 @@ dependencies = [
  "unicode-linebreak",
  "unicode-script",
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -1338,6 +1437,12 @@ name = "ctor-proc-macro"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-url"
@@ -1767,6 +1872,12 @@ dependencies = [
  "smallvec",
  "zune-inflate",
 ]
+
+[[package]]
+name = "extended"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af9673d8203fcb076b19dfd17e38b3d4ae9f44959416ea532ce72415a6020365"
 
 [[package]]
 name = "fallible-iterator"
@@ -2304,7 +2415,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "ashpd 0.11.1",
  "async-task",
- "bindgen",
+ "bindgen 0.71.1",
  "blade-graphics",
  "blade-macros",
  "blade-util",
@@ -2507,7 +2618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cb8912ae17371725132d2b7eec6797a255accc95d58ee5c1134b529810f14b"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.71.1",
  "core-foundation 0.10.0",
  "core-video",
  "ctor",
@@ -3256,6 +3367,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "jobserver"
 version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3532,6 +3687,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3746,6 +3910,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.13.1",
+ "jni-sys 0.3.1",
+ "log",
+ "ndk-sys",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,6 +4023,7 @@ version = "0.3.0"
 dependencies = [
  "base64",
  "block2",
+ "cpal",
  "dirs 6.0.0",
  "futures-executor",
  "futures-util",
@@ -3843,6 +4037,7 @@ dependencies = [
  "security-framework",
  "serde",
  "serde_json",
+ "symphonia",
  "sysinfo 0.37.2",
  "tokio",
  "windows 0.52.0",
@@ -4012,6 +4207,28 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4219,6 +4436,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -6144,6 +6384,101 @@ dependencies = [
 ]
 
 [[package]]
+name = "symphonia"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773a4c030a19d9bfaa090f49746ff35c75dfddfa700df7a5939d5e076a57039"
+dependencies = [
+ "lazy_static",
+ "symphonia-codec-pcm",
+ "symphonia-codec-vorbis",
+ "symphonia-core",
+ "symphonia-format-ogg",
+ "symphonia-format-riff",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-codec-pcm"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e89d716c01541ad3ebe7c91ce4c8d38a7cf266a3f7b2f090b108fb0cb031d95"
+dependencies = [
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-codec-vorbis"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f025837c309cd69ffef572750b4a2257b59552c5399a5e49707cc5b1b85d1c73"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea00cc4f79b7f6bb7ff87eddc065a1066f3a43fe1875979056672c9ef948c2af"
+dependencies = [
+ "arrayvec",
+ "bitflags 1.3.2",
+ "bytemuck",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "symphonia-format-ogg"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b4955c67c1ed3aa8ae8428d04ca8397fbef6a19b2b051e73b5da8b1435639cb"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
+]
+
+[[package]]
+name = "symphonia-format-riff"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d7c3df0e7d94efb68401d81906eae73c02b40d5ec1a141962c592d0f11a96f"
+dependencies = [
+ "extended",
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-metadata"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36306ff42b9ffe6e5afc99d49e121e0bd62fe79b9db7b9681d48e29fa19e6b16"
+dependencies = [
+ "encoding_rs",
+ "lazy_static",
+ "log",
+ "symphonia-core",
+]
+
+[[package]]
+name = "symphonia-utils-xiph"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27c85ab799a338446b68eec77abf42e1a6f1bb490656e121c6e27bfbab9f16"
+dependencies = [
+ "symphonia-core",
+ "symphonia-metadata",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7306,6 +7641,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.57.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
@@ -7355,6 +7700,16 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
@@ -7562,6 +7917,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -7594,6 +7958,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -7655,6 +8034,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -7673,6 +8058,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -7688,6 +8079,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7721,6 +8118,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -7736,6 +8139,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7757,6 +8166,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -7772,6 +8187,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -24,6 +24,8 @@ objc2-foundation = "0.3"
 objc2-event-kit = { version = "0.3", features = ["EKEventStore", "EKEvent", "EKReminder", "EKCalendar"] }
 block2 = "0.6"
 security-framework = "3.7"
+cpal = "0.15"
+symphonia = { version = "0.5", default-features = false, features = ["ogg", "vorbis", "wav", "pcm"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.52", features = [

--- a/crates/nook-core/src/eventtap.rs
+++ b/crates/nook-core/src/eventtap.rs
@@ -249,24 +249,37 @@ unsafe fn prompt_accessibility_macos() -> bool {
         stringWithUTF8String: c"AXTrustedCheckOptionPrompt".as_ptr()
     ];
     let yes: *mut AnyObject = msg_send![class!(NSNumber), numberWithBool: true];
+    // `use objc2::*` shadows this module's `ffi` with `objc2::ffi`, which
+    // omits Accessibility. Call the local ApplicationServices declarations.
     if key.is_null() || yes.is_null() {
-        return ffi::AXIsProcessTrusted();
+        return self::ffi::AXIsProcessTrusted();
     }
     let options: *mut AnyObject =
         msg_send![class!(NSDictionary), dictionaryWithObject: yes, forKey: key];
     if options.is_null() {
-        return ffi::AXIsProcessTrusted();
+        return self::ffi::AXIsProcessTrusted();
     }
-    ffi::AXIsProcessTrustedWithOptions(options as *const std::ffi::c_void)
+    self::ffi::AXIsProcessTrustedWithOptions(options as *const std::ffi::c_void)
 }
 
+/// Opaque CFRunLoop pointer. `CFRunLoopStop` is documented as safe to call
+/// from another thread; the runloop thread owns the object lifetime.
 #[cfg(target_os = "macos")]
-static RUNLOOP: Mutex<Option<ffi::CFRunLoopRef>> = Mutex::new(None);
+#[derive(Clone, Copy)]
+struct SendCfPtr(ffi::CFRunLoopRef);
+
+// SAFETY: stored only as an identity for CFRunLoopStop / clear. Never
+// dereferenced as Rust data; the runloop thread creates and tears it down.
+#[cfg(target_os = "macos")]
+unsafe impl Send for SendCfPtr {}
+
+#[cfg(target_os = "macos")]
+static RUNLOOP: Mutex<Option<SendCfPtr>> = Mutex::new(None);
 
 #[cfg(target_os = "macos")]
 unsafe fn stop_runloop() {
     if let Ok(slot) = RUNLOOP.lock() {
-        if let Some(rl) = *slot {
+        if let Some(SendCfPtr(rl)) = *slot {
             ffi::CFRunLoopStop(rl);
         }
     }
@@ -276,7 +289,7 @@ unsafe fn stop_runloop() {
 unsafe fn runloop_thread(want_keys: bool, want_scroll: bool) {
     let rl = ffi::CFRunLoopGetCurrent();
     if let Ok(mut slot) = RUNLOOP.lock() {
-        *slot = Some(rl);
+        *slot = Some(SendCfPtr(rl));
     }
 
     let mut ports = Vec::new();
@@ -325,18 +338,16 @@ unsafe fn runloop_thread(want_keys: bool, want_scroll: bool) {
 
 #[cfg(target_os = "macos")]
 fn key_mask() -> u64 {
+    // Disabled-by-timeout / user-input are delivered to the callback
+    // regardless of mask; their type codes are not valid bit positions.
     (1u64 << ffi::kCGEventKeyDown)
         | (1u64 << ffi::kCGEventKeyUp)
         | (1u64 << ffi::kCGEventFlagsChanged)
-        | (1u64 << ffi::kCGEventTapDisabledByTimeout)
-        | (1u64 << ffi::kCGEventTapDisabledByUserInput)
 }
 
 #[cfg(target_os = "macos")]
 fn scroll_mask() -> u64 {
-    (1u64 << ffi::kCGEventScrollWheel)
-        | (1u64 << ffi::kCGEventTapDisabledByTimeout)
-        | (1u64 << ffi::kCGEventTapDisabledByUserInput)
+    1u64 << ffi::kCGEventScrollWheel
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/nook-core/src/eventtap.rs
+++ b/crates/nook-core/src/eventtap.rs
@@ -1,0 +1,646 @@
+//! Shared CGEventTap thread for Mechey (listen-only keys) and LiquidMouse
+//! (active scroll). Taps exist only while the matching setting is on —
+//! disabled means `CFMachPortInvalidate` and the runloop thread joins.
+
+#[cfg(target_os = "macos")]
+use std::sync::atomic::Ordering;
+use std::sync::{Mutex, OnceLock};
+#[cfg(target_os = "macos")]
+use std::thread;
+use std::thread::JoinHandle;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PermissionStatus {
+    Granted,
+    Denied,
+    Unsupported,
+}
+
+impl PermissionStatus {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Granted => "Granted",
+            Self::Denied => "Not granted",
+            Self::Unsupported => "macOS only",
+        }
+    }
+
+    pub fn granted(self) -> bool {
+        matches!(self, Self::Granted)
+    }
+}
+
+struct TapRuntime {
+    want_keys: bool,
+    want_scroll: bool,
+    handle: Option<JoinHandle<()>>,
+}
+
+fn runtime() -> &'static Mutex<TapRuntime> {
+    static RUNTIME: OnceLock<Mutex<TapRuntime>> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        Mutex::new(TapRuntime {
+            want_keys: false,
+            want_scroll: false,
+            handle: None,
+        })
+    })
+}
+
+/// Create or tear down taps from the current settings. No-op when unchanged.
+pub fn sync() {
+    let settings = crate::settings::get_app_settings();
+    let want_keys = settings.keysounds_enabled;
+    let want_scroll = settings.smooth_scroll_enabled || settings.reverse_mouse_scroll;
+    let mut guard = runtime().lock().unwrap_or_else(|e| e.into_inner());
+    let live = guard.handle.is_some();
+    let want_any = want_keys || want_scroll;
+    if guard.want_keys == want_keys && guard.want_scroll == want_scroll && live == want_any {
+        return;
+    }
+    stop_locked(&mut guard);
+    guard.want_keys = want_keys;
+    guard.want_scroll = want_scroll;
+    if !want_keys && !want_scroll {
+        return;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let keys = want_keys;
+        let scroll = want_scroll;
+        guard.handle = Some(
+            thread::Builder::new()
+                .name("nook-eventtap".into())
+                .spawn(move || unsafe { runloop_thread(keys, scroll) })
+                .expect("eventtap thread"),
+        );
+    }
+}
+
+fn stop_locked(guard: &mut TapRuntime) {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        stop_runloop();
+    }
+    if let Some(handle) = guard.handle.take() {
+        let _ = handle.join();
+    }
+}
+
+pub fn input_monitoring_status() -> PermissionStatus {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        match ffi::IOHIDCheckAccess(ffi::kIOHIDRequestTypeListenEvent) {
+            0 => PermissionStatus::Granted,
+            _ => PermissionStatus::Denied,
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        PermissionStatus::Unsupported
+    }
+}
+
+pub fn request_input_monitoring() -> bool {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        ffi::IOHIDRequestAccess(ffi::kIOHIDRequestTypeListenEvent)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn open_input_monitoring_settings() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = open::that(
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent",
+        );
+    }
+}
+
+pub fn accessibility_status() -> PermissionStatus {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        if ffi::AXIsProcessTrusted() {
+            PermissionStatus::Granted
+        } else {
+            PermissionStatus::Denied
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        PermissionStatus::Unsupported
+    }
+}
+
+pub fn request_accessibility() -> bool {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        prompt_accessibility_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn open_accessibility_settings() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = open::that(
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility",
+        );
+    }
+}
+
+pub fn is_secure_input() -> bool {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        ffi::IsSecureEventInputEnabled()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn frontmost_bundle_id() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        frontmost_bundle_id_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+pub fn running_conflict_ids() -> Vec<String> {
+    #[cfg(target_os = "macos")]
+    {
+        crate::scroll::CONFLICT_BUNDLES
+            .iter()
+            .filter(|id| bundle_is_running(id))
+            .map(|id| (*id).to_string())
+            .collect()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        Vec::new()
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn bundle_is_running(id: &str) -> bool {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use std::ffi::CString;
+    let Ok(c_id) = CString::new(id) else {
+        return false;
+    };
+    unsafe {
+        let ident: *mut AnyObject =
+            msg_send![class!(NSString), stringWithUTF8String: c_id.as_ptr()];
+        let apps: *mut AnyObject = msg_send![
+            class!(NSRunningApplication),
+            runningApplicationsWithBundleIdentifier: ident
+        ];
+        if apps.is_null() {
+            return false;
+        }
+        let count: usize = msg_send![apps, count];
+        count > 0
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn frontmost_bundle_id_macos() -> Option<String> {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use std::ffi::CStr;
+    let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+    if workspace.is_null() {
+        return None;
+    }
+    let app: *mut AnyObject = msg_send![workspace, frontmostApplication];
+    if app.is_null() {
+        return None;
+    }
+    let ident: *mut AnyObject = msg_send![app, bundleIdentifier];
+    if ident.is_null() {
+        return None;
+    }
+    let utf8: *const i8 = msg_send![ident, UTF8String];
+    if utf8.is_null() {
+        return None;
+    }
+    CStr::from_ptr(utf8).to_str().ok().map(str::to_string)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn prompt_accessibility_macos() -> bool {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    let key: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"AXTrustedCheckOptionPrompt".as_ptr()
+    ];
+    let yes: *mut AnyObject = msg_send![class!(NSNumber), numberWithBool: true];
+    if key.is_null() || yes.is_null() {
+        return ffi::AXIsProcessTrusted();
+    }
+    let options: *mut AnyObject =
+        msg_send![class!(NSDictionary), dictionaryWithObject: yes, forKey: key];
+    if options.is_null() {
+        return ffi::AXIsProcessTrusted();
+    }
+    ffi::AXIsProcessTrustedWithOptions(options as *const std::ffi::c_void)
+}
+
+#[cfg(target_os = "macos")]
+static RUNLOOP: Mutex<Option<ffi::CFRunLoopRef>> = Mutex::new(None);
+
+#[cfg(target_os = "macos")]
+unsafe fn stop_runloop() {
+    if let Ok(slot) = RUNLOOP.lock() {
+        if let Some(rl) = *slot {
+            ffi::CFRunLoopStop(rl);
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn runloop_thread(want_keys: bool, want_scroll: bool) {
+    let rl = ffi::CFRunLoopGetCurrent();
+    if let Ok(mut slot) = RUNLOOP.lock() {
+        *slot = Some(rl);
+    }
+
+    let mut ports = Vec::new();
+    if want_keys {
+        if let Some(port) = create_tap(
+            ffi::kCGEventTapOptionListenOnly,
+            key_mask(),
+            key_callback,
+            TapKind::Keys as usize,
+        ) {
+            if let Some(src) = attach(rl, port) {
+                ports.push((port, src));
+            }
+        } else {
+            log::info!("keyboard tap unavailable (Input Monitoring denied?)");
+        }
+    }
+    if want_scroll {
+        if let Some(port) = create_tap(
+            ffi::kCGEventTapOptionDefault,
+            scroll_mask(),
+            scroll_callback,
+            TapKind::Scroll as usize,
+        ) {
+            if let Some(src) = attach(rl, port) {
+                ports.push((port, src));
+            }
+        } else {
+            log::info!("scroll tap unavailable (Accessibility denied?)");
+        }
+    }
+
+    ffi::CFRunLoopRun();
+
+    for (port, src) in ports {
+        ffi::CGEventTapEnable(port, false);
+        ffi::CFRunLoopRemoveSource(rl, src, ffi::kCFRunLoopCommonModes);
+        ffi::CFMachPortInvalidate(port);
+        ffi::CFRelease(src);
+        ffi::CFRelease(port);
+    }
+    if let Ok(mut slot) = RUNLOOP.lock() {
+        *slot = None;
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn key_mask() -> u64 {
+    (1u64 << ffi::kCGEventKeyDown)
+        | (1u64 << ffi::kCGEventKeyUp)
+        | (1u64 << ffi::kCGEventFlagsChanged)
+        | (1u64 << ffi::kCGEventTapDisabledByTimeout)
+        | (1u64 << ffi::kCGEventTapDisabledByUserInput)
+}
+
+#[cfg(target_os = "macos")]
+fn scroll_mask() -> u64 {
+    (1u64 << ffi::kCGEventScrollWheel)
+        | (1u64 << ffi::kCGEventTapDisabledByTimeout)
+        | (1u64 << ffi::kCGEventTapDisabledByUserInput)
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone, Copy)]
+#[repr(usize)]
+enum TapKind {
+    Keys = 1,
+    Scroll = 2,
+}
+
+#[cfg(target_os = "macos")]
+static KEY_PORT: std::sync::atomic::AtomicPtr<std::ffi::c_void> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+#[cfg(target_os = "macos")]
+static SCROLL_PORT: std::sync::atomic::AtomicPtr<std::ffi::c_void> =
+    std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
+
+#[cfg(target_os = "macos")]
+unsafe fn create_tap(
+    options: u32,
+    mask: u64,
+    callback: ffi::CGEventTapCallBack,
+    kind: usize,
+) -> Option<ffi::CFMachPortRef> {
+    let port = ffi::CGEventTapCreate(
+        ffi::kCGSessionEventTap,
+        ffi::kCGHeadInsertEventTap,
+        options,
+        mask,
+        callback,
+        kind as *mut std::ffi::c_void,
+    );
+    if port.is_null() {
+        return None;
+    }
+    ffi::CGEventTapEnable(port, true);
+    if kind == TapKind::Keys as usize {
+        KEY_PORT.store(port, Ordering::SeqCst);
+    } else {
+        SCROLL_PORT.store(port, Ordering::SeqCst);
+    }
+    Some(port)
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn attach(rl: ffi::CFRunLoopRef, port: ffi::CFMachPortRef) -> Option<ffi::CFRunLoopSourceRef> {
+    let src = ffi::CFMachPortCreateRunLoopSource(std::ptr::null_mut(), port, 0);
+    if src.is_null() {
+        ffi::CFMachPortInvalidate(port);
+        ffi::CFRelease(port);
+        return None;
+    }
+    ffi::CFRunLoopAddSource(rl, src, ffi::kCFRunLoopCommonModes);
+    Some(src)
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn key_callback(
+    _proxy: ffi::CGEventTapProxy,
+    ty: u32,
+    event: ffi::CGEventRef,
+    _info: *mut std::ffi::c_void,
+) -> ffi::CGEventRef {
+    if ty == ffi::kCGEventTapDisabledByTimeout || ty == ffi::kCGEventTapDisabledByUserInput {
+        let port = KEY_PORT.load(Ordering::SeqCst);
+        if !port.is_null() {
+            ffi::CGEventTapEnable(port, true);
+        }
+        return event;
+    }
+    let keycode = ffi::CGEventGetIntegerValueField(event, ffi::kCGKeyboardEventKeycode) as u16;
+    let autorepeat = ffi::CGEventGetIntegerValueField(event, ffi::kCGKeyboardEventAutorepeat) != 0;
+    match ty {
+        ffi::kCGEventKeyDown => crate::keysounds::handle_key(keycode, true, autorepeat),
+        ffi::kCGEventKeyUp => crate::keysounds::handle_key(keycode, false, false),
+        ffi::kCGEventFlagsChanged => {
+            crate::keysounds::handle_key(keycode, modifier_is_down(event, keycode), false);
+        }
+        _ => {}
+    }
+    event
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn modifier_is_down(event: ffi::CGEventRef, keycode: u16) -> bool {
+    let flags = ffi::CGEventGetFlags(event);
+    match keycode {
+        56 | 60 => flags & ffi::kCGEventFlagMaskShift != 0,
+        59 | 62 => flags & ffi::kCGEventFlagMaskControl != 0,
+        58 | 61 => flags & ffi::kCGEventFlagMaskAlternate != 0,
+        54 | 55 => flags & ffi::kCGEventFlagMaskCommand != 0,
+        _ => flags != 0,
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe extern "C" fn scroll_callback(
+    _proxy: ffi::CGEventTapProxy,
+    ty: u32,
+    event: ffi::CGEventRef,
+    _info: *mut std::ffi::c_void,
+) -> ffi::CGEventRef {
+    if ty == ffi::kCGEventTapDisabledByTimeout || ty == ffi::kCGEventTapDisabledByUserInput {
+        let port = SCROLL_PORT.load(Ordering::SeqCst);
+        if !port.is_null() {
+            ffi::CGEventTapEnable(port, true);
+        }
+        return event;
+    }
+    if ty != ffi::kCGEventScrollWheel {
+        return event;
+    }
+    let tag = ffi::CGEventGetIntegerValueField(event, ffi::kCGEventSourceUserData);
+    if tag == crate::scroll::synthetic_tag() {
+        return event;
+    }
+    let settings = crate::settings::get_app_settings();
+    if !settings.smooth_scroll_enabled && !settings.reverse_mouse_scroll {
+        return event;
+    }
+    if let Some(bundle) = frontmost_bundle_id() {
+        if crate::scroll::is_excluded(&bundle, &settings.scroll_excluded_apps) {
+            return event;
+        }
+    }
+    let continuous =
+        ffi::CGEventGetIntegerValueField(event, ffi::kCGScrollWheelEventIsContinuous) != 0;
+    match crate::scroll::classify_wheel(continuous, false) {
+        crate::scroll::WheelKind::PassThrough | crate::scroll::WheelKind::Excluded => event,
+        crate::scroll::WheelKind::Smooth => {
+            if !settings.smooth_scroll_enabled {
+                if settings.reverse_mouse_scroll {
+                    reverse_event(event);
+                }
+                return event;
+            }
+            let dy = ffi::CGEventGetIntegerValueField(event, ffi::kCGScrollWheelEventDeltaAxis1);
+            let dx = ffi::CGEventGetIntegerValueField(event, ffi::kCGScrollWheelEventDeltaAxis2);
+            let flags = ffi::CGEventGetFlags(event);
+            let shift = flags & ffi::kCGEventFlagMaskShift != 0;
+            crate::scroll::ingest_wheel(dx as f64, dy as f64, shift);
+            std::ptr::null_mut()
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn reverse_event(event: ffi::CGEventRef) {
+    for field in [
+        ffi::kCGScrollWheelEventDeltaAxis1,
+        ffi::kCGScrollWheelEventDeltaAxis2,
+        ffi::kCGScrollWheelEventPointDeltaAxis1,
+        ffi::kCGScrollWheelEventPointDeltaAxis2,
+    ] {
+        let value = ffi::CGEventGetIntegerValueField(event, field);
+        ffi::CGEventSetIntegerValueField(event, field, -value);
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) mod ffi {
+    #![allow(non_camel_case_types, non_upper_case_globals, dead_code)]
+
+    use std::ffi::c_void;
+
+    pub type CGEventRef = *mut c_void;
+    pub type CFMachPortRef = *mut c_void;
+    pub type CFRunLoopSourceRef = *mut c_void;
+    pub type CFRunLoopRef = *mut c_void;
+    pub type CFAllocatorRef = *mut c_void;
+    pub type CFStringRef = *const c_void;
+    pub type CGEventTapProxy = *mut c_void;
+    pub type CGEventTapCallBack = unsafe extern "C" fn(
+        CGEventTapProxy,
+        u32,
+        CGEventRef,
+        *mut c_void,
+    ) -> CGEventRef;
+
+    pub const kCGSessionEventTap: u32 = 1;
+    pub const kCGHIDEventTap: u32 = 0;
+    pub const kCGHeadInsertEventTap: u32 = 0;
+    pub const kCGEventTapOptionDefault: u32 = 0;
+    pub const kCGEventTapOptionListenOnly: u32 = 1;
+
+    pub const kCGEventKeyDown: u32 = 10;
+    pub const kCGEventKeyUp: u32 = 11;
+    pub const kCGEventFlagsChanged: u32 = 12;
+    pub const kCGEventScrollWheel: u32 = 22;
+    pub const kCGEventTapDisabledByTimeout: u32 = 0xFFFF_FFFE;
+    pub const kCGEventTapDisabledByUserInput: u32 = 0xFFFF_FFFF;
+
+    pub const kCGKeyboardEventAutorepeat: u32 = 8;
+    pub const kCGKeyboardEventKeycode: u32 = 9;
+    pub const kCGScrollWheelEventDeltaAxis1: u32 = 11;
+    pub const kCGScrollWheelEventDeltaAxis2: u32 = 12;
+    pub const kCGScrollWheelEventIsContinuous: u32 = 88;
+    pub const kCGScrollWheelEventScrollPhase: u32 = 99;
+    pub const kCGScrollWheelEventPointDeltaAxis1: u32 = 96;
+    pub const kCGScrollWheelEventPointDeltaAxis2: u32 = 97;
+    pub const kCGScrollWheelEventMomentumPhase: u32 = 123;
+    pub const kCGEventSourceUserData: u32 = 42;
+    pub const kCGScrollEventUnitPixel: u32 = 0;
+
+    pub const kCGEventFlagMaskShift: u64 = 0x0002_0000;
+    pub const kCGEventFlagMaskControl: u64 = 0x0004_0000;
+    pub const kCGEventFlagMaskAlternate: u64 = 0x0008_0000;
+    pub const kCGEventFlagMaskCommand: u64 = 0x0010_0000;
+
+    pub const kIOHIDRequestTypeListenEvent: u32 = 1;
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        pub fn CGEventTapCreate(
+            tap: u32,
+            place: u32,
+            options: u32,
+            eventsOfInterest: u64,
+            callback: CGEventTapCallBack,
+            userInfo: *mut c_void,
+        ) -> CFMachPortRef;
+        pub fn CGEventTapEnable(tap: CFMachPortRef, enable: bool);
+        pub fn CGEventGetIntegerValueField(event: CGEventRef, field: u32) -> i64;
+        pub fn CGEventSetIntegerValueField(event: CGEventRef, field: u32, value: i64);
+        pub fn CGEventGetDoubleValueField(event: CGEventRef, field: u32) -> f64;
+        pub fn CGEventSetDoubleValueField(event: CGEventRef, field: u32, value: f64);
+        pub fn CGEventGetFlags(event: CGEventRef) -> u64;
+        pub fn CGEventCreateScrollWheelEvent2(
+            source: *mut c_void,
+            units: u32,
+            wheelCount: u32,
+            wheel1: i32,
+            wheel2: i32,
+            wheel3: i32,
+        ) -> CGEventRef;
+        pub fn CGEventPost(tap: u32, event: CGEventRef);
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        pub fn CFRelease(cf: *const c_void);
+        pub fn CFMachPortCreateRunLoopSource(
+            allocator: CFAllocatorRef,
+            port: CFMachPortRef,
+            order: i64,
+        ) -> CFRunLoopSourceRef;
+        pub fn CFMachPortInvalidate(port: CFMachPortRef);
+        pub fn CFRunLoopGetCurrent() -> CFRunLoopRef;
+        pub fn CFRunLoopAddSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
+        pub fn CFRunLoopRemoveSource(rl: CFRunLoopRef, source: CFRunLoopSourceRef, mode: CFStringRef);
+        pub fn CFRunLoopRunInMode(mode: CFStringRef, seconds: f64, returnAfterSourceHandled: bool) -> i32;
+        pub fn CFRunLoopRun();
+        pub fn CFRunLoopStop(rl: CFRunLoopRef);
+        pub static kCFRunLoopDefaultMode: CFStringRef;
+        pub static kCFRunLoopCommonModes: CFStringRef;
+    }
+
+    #[link(name = "IOKit", kind = "framework")]
+    extern "C" {
+        pub fn IOHIDCheckAccess(requestType: u32) -> u32;
+        pub fn IOHIDRequestAccess(requestType: u32) -> bool;
+    }
+
+    #[link(name = "Carbon", kind = "framework")]
+    extern "C" {
+        pub fn IsSecureEventInputEnabled() -> bool;
+    }
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        pub fn AXIsProcessTrusted() -> bool;
+        pub fn AXIsProcessTrustedWithOptions(options: *const c_void) -> bool;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permission_labels() {
+        assert_eq!(PermissionStatus::Granted.label(), "Granted");
+        assert_eq!(PermissionStatus::Denied.label(), "Not granted");
+        assert_eq!(PermissionStatus::Unsupported.label(), "macOS only");
+        assert!(PermissionStatus::Granted.granted());
+        assert!(!PermissionStatus::Denied.granted());
+    }
+
+    #[test]
+    fn sync_is_idle_when_features_are_off() {
+        crate::eventtap::sync();
+        let guard = runtime().lock().unwrap();
+        assert!(!guard.want_keys);
+        assert!(!guard.want_scroll);
+        assert!(guard.handle.is_none());
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn linux_reports_unsupported_permissions() {
+        assert_eq!(input_monitoring_status(), PermissionStatus::Unsupported);
+        assert_eq!(accessibility_status(), PermissionStatus::Unsupported);
+        assert!(!is_secure_input());
+        assert!(frontmost_bundle_id().is_none());
+        assert!(running_conflict_ids().is_empty());
+    }
+}

--- a/crates/nook-core/src/keysounds.rs
+++ b/crates/nook-core/src/keysounds.rs
@@ -1,0 +1,816 @@
+//! Mechey: mechanical keyboard sounds per keystroke.
+//!
+//! Builtin packs are synthesized PCM (CC0). User packs follow the Mechvibes
+//! `config.json` layout and live in `~/Library/Application Support/openNook-gpui/soundpacks`.
+//! The cpal output stream opens on the first key and closes after ~20 s idle.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+#[cfg(target_os = "macos")]
+use std::time::Duration;
+use std::time::Instant;
+
+const SAMPLE_RATE: u32 = 48_000;
+#[cfg(target_os = "macos")]
+const IDLE_CLOSE: Duration = Duration::from_secs(20);
+const PITCH_JITTER: f32 = 0.04;
+const GAIN_JITTER: f32 = 0.08;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ClickKind {
+    Key,
+    Space,
+    Enter,
+    Backspace,
+    Modifier,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SoundPackInfo {
+    pub id: String,
+    pub name: String,
+    pub builtin: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MechvibesPack {
+    pub name: String,
+    pub key_define_type: String,
+    pub sound: Option<String>,
+    pub defines: HashMap<u16, MechvibesDefine>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum MechvibesDefine {
+    /// Sprite sheet: `[offset_ms, duration_ms]`.
+    Sprite { offset_ms: f64, duration_ms: f64 },
+    /// Separate file per key.
+    File(String),
+}
+
+#[derive(Clone, Debug)]
+pub struct Voice {
+    pub samples: Arc<Vec<f32>>,
+    pub pos: f32,
+    pub step: f32,
+    pub gain: f32,
+}
+
+impl Voice {
+    pub fn done(&self) -> bool {
+        self.pos >= self.samples.len() as f32
+    }
+}
+
+/// Mix active voices into an interleaved buffer. Pure; used by the cpal
+/// callback and unit tests.
+pub fn mix_into(output: &mut [f32], channels: usize, voices: &mut Vec<Voice>) {
+    let channels = channels.max(1);
+    for frame in output.chunks_mut(channels) {
+        let mut sample = 0.0f32;
+        for voice in voices.iter_mut() {
+            let idx = voice.pos as usize;
+            if idx < voice.samples.len() {
+                sample += voice.samples[idx] * voice.gain;
+                voice.pos += voice.step;
+            }
+        }
+        let sample = sample.clamp(-1.0, 1.0);
+        for ch in frame.iter_mut() {
+            *ch = sample;
+        }
+    }
+    voices.retain(|voice| !voice.done());
+}
+
+/// Tiny synthesized switch: noise burst + damped sine. Distinct enough for
+/// space / enter / backspace / modifiers without bundling recordings.
+pub fn synthesize_click(kind: ClickKind, sample_rate: u32, down: bool) -> Vec<f32> {
+    let (ms, freq, noise, gain) = match (kind, down) {
+        (ClickKind::Space, true) => (14.0, 180.0, 0.35, 0.85),
+        (ClickKind::Space, false) => (9.0, 160.0, 0.2, 0.45),
+        (ClickKind::Enter, true) => (12.0, 420.0, 0.4, 0.8),
+        (ClickKind::Enter, false) => (8.0, 380.0, 0.22, 0.4),
+        (ClickKind::Backspace, true) => (10.0, 720.0, 0.45, 0.7),
+        (ClickKind::Backspace, false) => (7.0, 640.0, 0.25, 0.35),
+        (ClickKind::Modifier, true) => (8.0, 260.0, 0.2, 0.5),
+        (ClickKind::Modifier, false) => (6.0, 240.0, 0.12, 0.25),
+        (ClickKind::Key, true) => (8.0, 980.0, 0.55, 0.65),
+        (ClickKind::Key, false) => (5.5, 860.0, 0.3, 0.32),
+    };
+    let n = ((sample_rate as f32) * ms / 1000.0) as usize;
+    let sr = sample_rate as f32;
+    (0..n)
+        .map(|i| {
+            let t = i as f32 / sr;
+            let env = (-t * 90.0).exp();
+            let sine = (2.0 * std::f32::consts::PI * freq * t).sin();
+            let nse = crate_hash(i as u64) * 2.0 - 1.0;
+            (sine * (1.0 - noise) + nse * noise) * env * gain
+        })
+        .collect()
+}
+
+fn crate_hash(i: u64) -> f32 {
+    let mut x = i.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    x ^= x >> 32;
+    ((x & 0xFFFF_FFFF) as f32) / (u32::MAX as f32)
+}
+
+pub fn click_kind_for_cg(keycode: u16) -> ClickKind {
+    match keycode {
+        49 => ClickKind::Space,
+        36 | 76 => ClickKind::Enter,
+        51 | 117 => ClickKind::Backspace,
+        54 | 55 | 56 | 57 | 58 | 59 | 60 | 61 | 62 | 63 => ClickKind::Modifier,
+        _ => ClickKind::Key,
+    }
+}
+
+/// ANSI CGKeyCode → JS/DOM keyCode used by Mechvibes `defines`.
+pub fn js_keycode_for_cg(cg: u16) -> Option<u16> {
+    Some(match cg {
+        0 => 65,   // A
+        1 => 83,   // S
+        2 => 68,   // D
+        3 => 70,   // F
+        4 => 72,   // H
+        5 => 71,   // G
+        6 => 90,   // Z
+        7 => 88,   // X
+        8 => 67,   // C
+        9 => 86,   // V
+        11 => 66,  // B
+        12 => 81,  // Q
+        13 => 87,  // W
+        14 => 69,  // E
+        15 => 82,  // R
+        16 => 89,  // Y
+        17 => 84,  // T
+        18 => 49,  // 1
+        19 => 50,  // 2
+        20 => 51,  // 3
+        21 => 52,  // 4
+        22 => 54,  // 6
+        23 => 53,  // 5
+        24 => 187, // =
+        25 => 57,  // 9
+        26 => 55,  // 7
+        27 => 189, // -
+        28 => 56,  // 8
+        29 => 48,  // 0
+        30 => 221, // ]
+        31 => 79,  // O
+        32 => 85,  // U
+        33 => 219, // [
+        34 => 73,  // I
+        35 => 80,  // P
+        36 => 13,  // Return
+        37 => 76,  // L
+        38 => 74,  // J
+        39 => 222, // '
+        40 => 75,  // K
+        41 => 186, // ;
+        42 => 220, // \
+        43 => 188, // ,
+        44 => 191, // /
+        45 => 78,  // N
+        46 => 77,  // M
+        47 => 190, // .
+        48 => 9,   // Tab
+        49 => 32,  // Space
+        50 => 192, // `
+        51 => 8,   // Delete
+        53 => 27,  // Escape
+        54 => 93,  // RCommand
+        55 => 91,  // LCommand
+        56 => 16,  // Shift
+        57 => 20,  // Caps
+        58 => 18,  // Option
+        59 => 17,  // Control
+        60 => 16,  // RShift
+        61 => 18,  // ROption
+        62 => 17,  // RControl
+        63 => 93,  // Fn-ish
+        64 => 121, // F17
+        65 => 110, // keypad .
+        67 => 106, // keypad *
+        69 => 107, // keypad +
+        71 => 12,  // keypad clear
+        75 => 111, // keypad /
+        76 => 13,  // keypad enter
+        78 => 109, // keypad -
+        82 => 96,  // keypad 0
+        83 => 97,
+        84 => 98,
+        85 => 99,
+        86 => 100,
+        87 => 101,
+        88 => 102,
+        89 => 103,
+        91 => 104,
+        92 => 105,
+        96 => 112, // F5
+        97 => 113, // F6
+        98 => 114, // F7
+        99 => 115, // F3
+        100 => 116,
+        101 => 117,
+        103 => 119,
+        109 => 120,
+        111 => 122,
+        118 => 114, // F4
+        120 => 112, // F2
+        122 => 112, // F1 (JS 112)
+        123 => 37,  // Left
+        124 => 39,  // Right
+        125 => 40,  // Down
+        126 => 38,  // Up
+        _ => return None,
+    })
+}
+
+#[derive(Deserialize)]
+struct RawMechvibes {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    key_define_type: Option<String>,
+    #[serde(default)]
+    sound: Option<String>,
+    #[serde(default)]
+    defines: HashMap<String, RawDefine>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RawDefine {
+    Sprite(Vec<f64>),
+    File(String),
+    Null,
+}
+
+/// Parse a Mechvibes `config.json`. Keys are JS keyCodes.
+pub fn parse_mechvibes(json: &str) -> Result<MechvibesPack, String> {
+    let raw: RawMechvibes =
+        serde_json::from_str(json).map_err(|err| format!("mechvibes config: {err}"))?;
+    let mut defines = HashMap::new();
+    for (key, value) in raw.defines {
+        let Ok(code) = key.parse::<u16>() else {
+            continue;
+        };
+        match value {
+            RawDefine::Sprite(pair) if pair.len() >= 2 => {
+                defines.insert(
+                    code,
+                    MechvibesDefine::Sprite {
+                        offset_ms: pair[0],
+                        duration_ms: pair[1],
+                    },
+                );
+            }
+            RawDefine::File(path) if !path.is_empty() => {
+                defines.insert(code, MechvibesDefine::File(path));
+            }
+            _ => {}
+        }
+    }
+    Ok(MechvibesPack {
+        name: raw.name.unwrap_or_else(|| "Untitled".into()),
+        key_define_type: raw
+            .key_define_type
+            .unwrap_or_else(|| "single".into())
+            .to_ascii_lowercase(),
+        sound: raw.sound,
+        defines,
+    })
+}
+
+pub fn soundpacks_dir() -> PathBuf {
+    crate::app_data_dir().join("soundpacks")
+}
+
+pub fn list_packs() -> Vec<SoundPackInfo> {
+    let mut packs = vec![
+        SoundPackInfo {
+            id: "nook-click".into(),
+            name: "Nook Click".into(),
+            builtin: true,
+        },
+        SoundPackInfo {
+            id: "nook-thock".into(),
+            name: "Nook Thock".into(),
+            builtin: true,
+        },
+    ];
+    if let Ok(entries) = std::fs::read_dir(soundpacks_dir()) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_dir() {
+                continue;
+            }
+            let id = entry.file_name().to_string_lossy().into_owned();
+            if packs.iter().any(|p| p.id == id) {
+                continue;
+            }
+            let name = std::fs::read_to_string(path.join("config.json"))
+                .ok()
+                .and_then(|json| parse_mechvibes(&json).ok())
+                .map(|pack| pack.name)
+                .unwrap_or_else(|| id.clone());
+            packs.push(SoundPackInfo {
+                id,
+                name,
+                builtin: false,
+            });
+        }
+    }
+    packs
+}
+
+struct SampleBank {
+    id: String,
+    down: HashMap<u16, Arc<Vec<f32>>>,
+    up: HashMap<u16, Arc<Vec<f32>>>,
+    fallback_down: Arc<Vec<f32>>,
+    fallback_up: Arc<Vec<f32>>,
+}
+
+impl SampleBank {
+    fn builtin(id: &str) -> Self {
+        let thock = id == "nook-thock";
+        let kinds = [
+            ClickKind::Key,
+            ClickKind::Space,
+            ClickKind::Enter,
+            ClickKind::Backspace,
+            ClickKind::Modifier,
+        ];
+        let mut down = HashMap::new();
+        let mut up = HashMap::new();
+        for kind in kinds {
+            let mut d = synthesize_click(kind, SAMPLE_RATE, true);
+            let mut u = synthesize_click(kind, SAMPLE_RATE, false);
+            if thock {
+                for s in d.iter_mut().chain(u.iter_mut()) {
+                    *s *= 1.15;
+                }
+            }
+            let d = Arc::new(d);
+            let u = Arc::new(u);
+            for code in codes_for_kind(kind) {
+                down.insert(code, d.clone());
+                up.insert(code, u.clone());
+            }
+        }
+        Self {
+            id: id.to_string(),
+            fallback_down: down.get(&0).cloned().unwrap_or_else(|| Arc::new(vec![])),
+            fallback_up: up.get(&0).cloned().unwrap_or_else(|| Arc::new(vec![])),
+            down,
+            up,
+        }
+    }
+
+    fn sample(&self, keycode: u16, down: bool) -> Arc<Vec<f32>> {
+        let map = if down { &self.down } else { &self.up };
+        map.get(&keycode)
+            .cloned()
+            .unwrap_or_else(|| {
+                if down {
+                    self.fallback_down.clone()
+                } else {
+                    self.fallback_up.clone()
+                }
+            })
+    }
+}
+
+fn codes_for_kind(kind: ClickKind) -> Vec<u16> {
+    match kind {
+        ClickKind::Space => vec![49],
+        ClickKind::Enter => vec![36, 76],
+        ClickKind::Backspace => vec![51, 117],
+        ClickKind::Modifier => vec![54, 55, 56, 57, 58, 59, 60, 61, 62, 63],
+        ClickKind::Key => vec![0],
+    }
+}
+
+struct Mixer {
+    bank: SampleBank,
+    voices: Vec<Voice>,
+    last_play: Instant,
+}
+
+fn mixer() -> &'static Mutex<Mixer> {
+    static MIXER: OnceLock<Mutex<Mixer>> = OnceLock::new();
+    MIXER.get_or_init(|| {
+        Mutex::new(Mixer {
+            bank: SampleBank::builtin("nook-click"),
+            voices: Vec::new(),
+            last_play: Instant::now(),
+        })
+    })
+}
+
+/// Reload the bank when the pack setting changes. Cheap for builtins.
+pub fn sync() {
+    let settings = crate::settings::get_app_settings();
+    if let Ok(mut mix) = mixer().lock() {
+        if mix.bank.id != settings.keysound_pack {
+            mix.bank = load_bank(&settings.keysound_pack);
+        }
+    }
+    if !settings.keysounds_enabled {
+        stop_stream();
+    }
+}
+
+fn load_bank(id: &str) -> SampleBank {
+    if id == "nook-thock" || id == "nook-click" || id.is_empty() {
+        return SampleBank::builtin(if id.is_empty() { "nook-click" } else { id });
+    }
+    match load_user_bank(id) {
+        Ok(bank) => bank,
+        Err(err) => {
+            log::warn!("keysound pack '{id}' failed ({err}); using builtin");
+            SampleBank::builtin("nook-click")
+        }
+    }
+}
+
+fn load_user_bank(id: &str) -> Result<SampleBank, String> {
+    let dir = soundpacks_dir().join(id);
+    let json = std::fs::read_to_string(dir.join("config.json"))
+        .map_err(|err| format!("read config: {err}"))?;
+    let pack = parse_mechvibes(&json)?;
+    let mut down = HashMap::new();
+    let fallback = Arc::new(synthesize_click(ClickKind::Key, SAMPLE_RATE, true));
+    let fallback_up = Arc::new(synthesize_click(ClickKind::Key, SAMPLE_RATE, false));
+
+    if pack.key_define_type == "single" {
+        if let Some(sound) = &pack.sound {
+            let pcm = decode_audio(&dir.join(sound))?;
+            for (js, define) in &pack.defines {
+                if let MechvibesDefine::Sprite {
+                    offset_ms,
+                    duration_ms,
+                } = define
+                {
+                    let slice = sprite_slice(&pcm, SAMPLE_RATE, *offset_ms, *duration_ms);
+                    if let Some(cg) = cg_for_js(*js) {
+                        down.insert(cg, Arc::new(slice));
+                    }
+                }
+            }
+        }
+    } else {
+        for (js, define) in &pack.defines {
+            if let MechvibesDefine::File(name) = define {
+                if let Ok(pcm) = decode_audio(&dir.join(name)) {
+                    if let Some(cg) = cg_for_js(*js) {
+                        down.insert(cg, Arc::new(pcm));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(SampleBank {
+        id: id.to_string(),
+        fallback_down: fallback,
+        fallback_up: fallback_up.clone(),
+        down,
+        up: HashMap::new(),
+    })
+}
+
+fn sprite_slice(pcm: &[f32], rate: u32, offset_ms: f64, duration_ms: f64) -> Vec<f32> {
+    let start = ((offset_ms / 1000.0) * rate as f64).round() as usize;
+    let len = ((duration_ms / 1000.0) * rate as f64).round() as usize;
+    let end = (start + len).min(pcm.len());
+    if start >= pcm.len() {
+        return Vec::new();
+    }
+    pcm[start..end].to_vec()
+}
+
+fn cg_for_js(js: u16) -> Option<u16> {
+    (0u16..=126).find(|cg| js_keycode_for_cg(*cg) == Some(js))
+}
+
+fn decode_audio(path: &Path) -> Result<Vec<f32>, String> {
+    #[cfg(target_os = "macos")]
+    {
+        decode_audio_macos(path)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = path;
+        Err("audio decode is macOS-only".into())
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn decode_audio_macos(path: &Path) -> Result<Vec<f32>, String> {
+    use std::fs::File;
+    use symphonia::core::audio::SampleBuffer;
+    use symphonia::core::codecs::DecoderOptions;
+    use symphonia::core::formats::FormatOptions;
+    use symphonia::core::io::MediaSourceStream;
+    use symphonia::core::meta::MetadataOptions;
+    use symphonia::core::probe::Hint;
+
+    let file = File::open(path).map_err(|err| err.to_string())?;
+    let mss = MediaSourceStream::new(Box::new(file), Default::default());
+    let mut hint = Hint::new();
+    if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
+        hint.with_extension(ext);
+    }
+    let probed = symphonia::default::get_probe()
+        .format(&hint, mss, &FormatOptions::default(), &MetadataOptions::default())
+        .map_err(|err| err.to_string())?;
+    let mut format = probed.format;
+    let track = format
+        .default_track()
+        .ok_or_else(|| "no audio track".to_string())?;
+    let track_id = track.id;
+    let mut decoder = symphonia::default::get_codecs()
+        .make(&track.codec_params, &DecoderOptions::default())
+        .map_err(|err| err.to_string())?;
+    let mut out = Vec::new();
+    let mut sample_buf = None;
+    loop {
+        let packet = match format.next_packet() {
+            Ok(p) => p,
+            Err(_) => break,
+        };
+        if packet.track_id() != track_id {
+            continue;
+        }
+        let Ok(decoded) = decoder.decode(&packet) else {
+            continue;
+        };
+        if sample_buf.is_none() {
+            let spec = *decoded.spec();
+            sample_buf = Some(SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
+        }
+        if let Some(buf) = sample_buf.as_mut() {
+            buf.copy_interleaved_ref(decoded);
+            let spec_channels = buf.spec().channels.count().max(1);
+            let samples = buf.samples();
+            for frame in samples.chunks(spec_channels) {
+                let mono = frame.iter().sum::<f32>() / spec_channels as f32;
+                out.push(mono);
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Tap callback: enqueue a one-shot. Skips autorepeat and secure input.
+pub fn handle_key(keycode: u16, down: bool, autorepeat: bool) {
+    if autorepeat || !crate::settings::get_app_settings().keysounds_enabled {
+        return;
+    }
+    if crate::eventtap::is_secure_input() {
+        return;
+    }
+    play_keycode(keycode, down);
+}
+
+pub fn play_test() {
+    play_keycode(0, true);
+}
+
+fn play_keycode(keycode: u16, down: bool) {
+    let settings = crate::settings::get_app_settings();
+    let volume = settings.keysound_volume.clamp(0.0, 1.0);
+    let mut mix = mixer().lock().unwrap_or_else(|e| e.into_inner());
+    if mix.bank.id != settings.keysound_pack {
+        mix.bank = load_bank(&settings.keysound_pack);
+    }
+    let samples = mix.bank.sample(keycode, down);
+    if samples.is_empty() {
+        return;
+    }
+    let pitch = 1.0 + jitter(PITCH_JITTER);
+    let gain = volume * (1.0 + jitter(GAIN_JITTER));
+    mix.voices.push(Voice {
+        samples,
+        pos: 0.0,
+        step: pitch,
+        gain,
+    });
+    mix.last_play = Instant::now();
+    drop(mix);
+    ensure_stream();
+}
+
+fn jitter(span: f32) -> f32 {
+    let now = now_bits();
+    let unit = ((now.wrapping_mul(0x9E37_79B9) >> 16) as f32) / (u16::MAX as f32);
+    (unit * 2.0 - 1.0) * span
+}
+
+fn now_bits() -> u32 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(1)
+}
+
+static STREAM_ON: AtomicBool = AtomicBool::new(false);
+static LAST_MIX_MS: AtomicU64 = AtomicU64::new(0);
+
+fn unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn ensure_stream() {
+    LAST_MIX_MS.store(unix_ms(), Ordering::Relaxed);
+    if STREAM_ON
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::thread::Builder::new()
+            .name("nook-keysounds".into())
+            .spawn(stream_thread)
+            .expect("keysound stream");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        STREAM_ON.store(false, Ordering::SeqCst);
+    }
+}
+
+fn stop_stream() {
+    STREAM_ON.store(false, Ordering::SeqCst);
+}
+
+#[cfg(target_os = "macos")]
+fn stream_thread() {
+    use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
+
+    let host = cpal::default_host();
+    let Ok(device) = host.default_output_device().ok_or(()) else {
+        STREAM_ON.store(false, Ordering::SeqCst);
+        return;
+    };
+    let Ok(config) = device.default_output_config() else {
+        STREAM_ON.store(false, Ordering::SeqCst);
+        return;
+    };
+    let channels = config.channels() as usize;
+    let err_fn = |err| log::debug!("keysound stream: {err}");
+    let stream = match config.sample_format() {
+        cpal::SampleFormat::F32 => device.build_output_stream(
+            &config.into(),
+            move |data: &mut [f32], _| {
+                let mut mix = mixer().lock().unwrap_or_else(|e| e.into_inner());
+                mix_into(data, channels, &mut mix.voices);
+                if !mix.voices.is_empty() {
+                    LAST_MIX_MS.store(unix_ms(), Ordering::Relaxed);
+                }
+            },
+            err_fn,
+            None,
+        ),
+        _ => {
+            STREAM_ON.store(false, Ordering::SeqCst);
+            return;
+        }
+    };
+    let Ok(stream) = stream else {
+        STREAM_ON.store(false, Ordering::SeqCst);
+        return;
+    };
+    if stream.play().is_err() {
+        STREAM_ON.store(false, Ordering::SeqCst);
+        return;
+    }
+    while STREAM_ON.load(Ordering::Relaxed) {
+        std::thread::sleep(Duration::from_millis(500));
+        let idle = unix_ms().saturating_sub(LAST_MIX_MS.load(Ordering::Relaxed));
+        if idle > IDLE_CLOSE.as_millis() as u64 {
+            break;
+        }
+        if !crate::settings::get_app_settings().keysounds_enabled {
+            break;
+        }
+    }
+    drop(stream);
+    STREAM_ON.store(false, Ordering::SeqCst);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mechvibes_sprite_pack_parses() {
+        let json = r#"{
+            "name": "Cream",
+            "key_define_type": "single",
+            "sound": "sound.ogg",
+            "defines": {
+                "65": [0, 80],
+                "32": [120, 90],
+                "13": "enter.ogg",
+                "nope": [1, 2]
+            }
+        }"#;
+        let pack = parse_mechvibes(json).unwrap();
+        assert_eq!(pack.name, "Cream");
+        assert_eq!(pack.key_define_type, "single");
+        assert_eq!(pack.sound.as_deref(), Some("sound.ogg"));
+        assert_eq!(
+            pack.defines.get(&65),
+            Some(&MechvibesDefine::Sprite {
+                offset_ms: 0.0,
+                duration_ms: 80.0
+            })
+        );
+        assert_eq!(
+            pack.defines.get(&13),
+            Some(&MechvibesDefine::File("enter.ogg".into()))
+        );
+        assert!(!pack.defines.contains_key(&0));
+    }
+
+    #[test]
+    fn cg_to_js_covers_letters_and_specials() {
+        assert_eq!(js_keycode_for_cg(0), Some(65)); // A
+        assert_eq!(js_keycode_for_cg(1), Some(83)); // S
+        assert_eq!(js_keycode_for_cg(49), Some(32)); // Space
+        assert_eq!(js_keycode_for_cg(36), Some(13)); // Return
+        assert_eq!(js_keycode_for_cg(51), Some(8)); // Delete
+        assert_eq!(js_keycode_for_cg(53), Some(27)); // Escape
+        assert_eq!(js_keycode_for_cg(200), None);
+    }
+
+    #[test]
+    fn click_kinds_match_special_keys() {
+        assert_eq!(click_kind_for_cg(49), ClickKind::Space);
+        assert_eq!(click_kind_for_cg(36), ClickKind::Enter);
+        assert_eq!(click_kind_for_cg(51), ClickKind::Backspace);
+        assert_eq!(click_kind_for_cg(55), ClickKind::Modifier);
+        assert_eq!(click_kind_for_cg(0), ClickKind::Key);
+    }
+
+    #[test]
+    fn synthesize_and_mix_is_finite() {
+        let click = Arc::new(synthesize_click(ClickKind::Key, 8_000, true));
+        assert!(click.len() > 10);
+        assert!(click.iter().all(|s| s.is_finite()));
+        let mut voices = vec![Voice {
+            samples: click,
+            pos: 0.0,
+            step: 1.0,
+            gain: 0.5,
+        }];
+        let mut out = vec![0.0f32; 64];
+        mix_into(&mut out, 2, &mut voices);
+        assert!(out.iter().any(|s| *s != 0.0));
+        assert!(out.iter().all(|s| s.abs() <= 1.0));
+    }
+
+    #[test]
+    fn mix_retains_only_live_voices() {
+        let samples = Arc::new(vec![0.5f32, 0.25]);
+        let mut voices = vec![Voice {
+            samples,
+            pos: 0.0,
+            step: 1.0,
+            gain: 1.0,
+        }];
+        let mut out = vec![0.0f32; 8];
+        mix_into(&mut out, 1, &mut voices);
+        assert!(voices.is_empty());
+    }
+
+    #[test]
+    fn builtin_pack_list_is_stable() {
+        let packs = list_packs();
+        assert!(packs.iter().any(|p| p.id == "nook-click" && p.builtin));
+        assert!(packs.iter().any(|p| p.id == "nook-thock" && p.builtin));
+    }
+
+    #[test]
+    fn sprite_slice_clamps() {
+        let pcm = vec![1.0, 2.0, 3.0, 4.0];
+        let slice = sprite_slice(&pcm, 1000, 1.0, 10.0);
+        assert_eq!(slice, vec![2.0, 3.0, 4.0]);
+        assert!(sprite_slice(&pcm, 1000, 50.0, 10.0).is_empty());
+    }
+}

--- a/crates/nook-core/src/keysounds.rs
+++ b/crates/nook-core/src/keysounds.rs
@@ -543,6 +543,9 @@ fn decode_audio_macos(path: &Path) -> Result<Vec<f32>, String> {
         .map_err(|err| err.to_string())?;
     let mut out = Vec::new();
     let mut sample_buf = None;
+    // SampleBuffer in symphonia 0.5 has no spec(); channels live on the
+    // decoded AudioBufferRef (and codec params), captured before the copy.
+    let mut channels = 1usize;
     loop {
         let packet = match format.next_packet() {
             Ok(p) => p,
@@ -556,14 +559,14 @@ fn decode_audio_macos(path: &Path) -> Result<Vec<f32>, String> {
         };
         if sample_buf.is_none() {
             let spec = *decoded.spec();
+            channels = spec.channels.count().max(1);
             sample_buf = Some(SampleBuffer::<f32>::new(decoded.capacity() as u64, spec));
         }
         if let Some(buf) = sample_buf.as_mut() {
             buf.copy_interleaved_ref(decoded);
-            let spec_channels = buf.spec().channels.count().max(1);
             let samples = buf.samples();
-            for frame in samples.chunks(spec_channels) {
-                let mono = frame.iter().sum::<f32>() / spec_channels as f32;
+            for frame in samples.chunks(channels) {
+                let mono = frame.iter().sum::<f32>() / channels as f32;
                 out.push(mono);
             }
         }

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -8,8 +8,10 @@ pub mod audio;
 pub mod browser_media;
 pub mod calendar;
 pub mod database;
+pub mod eventtap;
 pub mod files;
 pub mod haptics;
+pub mod keysounds;
 #[cfg(target_os = "macos")]
 mod mediaremote;
 pub mod models;
@@ -18,6 +20,7 @@ pub mod notch;
 pub mod notes;
 pub mod observe;
 pub mod occupancy;
+pub mod scroll;
 pub mod settings;
 pub mod utils;
 pub mod widgets;
@@ -63,5 +66,6 @@ pub fn init() {
         audio::init_audio_state();
         audio::setup_audio_monitoring();
         mouse::start_polling();
+        eventtap::sync();
     });
 }

--- a/crates/nook-core/src/scroll.rs
+++ b/crates/nook-core/src/scroll.rs
@@ -1,0 +1,476 @@
+//! LiquidMouse: smooth scrolling for discrete wheel mice.
+//!
+//! Trackpads and Magic Mouse already emit continuous pixel events
+//! (`kCGScrollWheelEventIsContinuous != 0`) and pass through untouched.
+//! Wheel mice emit line ticks; those are swallowed and replayed as decaying
+//! pixel deltas with trackpad-style phase / momentum-phase sequencing.
+//!
+//! Per-individual-device settings need private sender IDs and are not
+//! shipped — mouse-vs-trackpad is the public, robust split.
+
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::thread;
+use std::time::Duration;
+
+/// Bundle ids that already own the scroll path. Detected so Settings can warn.
+pub const CONFLICT_BUNDLES: &[&str] = &[
+    "com.caldis.Mos",
+    "com.lujjjh.LinearMouse",
+    "com.macmousefix.MacMouseFix",
+    "com.macmousefix.Mac-Mouse-Fix",
+    "com.pilotmoon.scroll-reverser",
+    "com.logitech.LogiOptions",
+    "com.logitech.manager.daemon",
+    "com.logitech.lh21",
+];
+
+/// Suggested exclusions: games, VMs, remotes that want raw wheel ticks.
+pub const DEFAULT_EXCLUSIONS: &[&str] = &[
+    "com.apple.ScreenSharing",
+    "com.utmapp.UTM",
+    "org.virtualbox.app.VirtualBox",
+    "com.vmware.fusion",
+    "com.parallels.desktop.console",
+    "com.valvesoftware.steam",
+];
+
+const PIXEL_PER_LINE: f64 = 36.0;
+const VELOCITY_EPS: f64 = 8.0;
+const FRAME_DT: f64 = 1.0 / 120.0;
+const SYNTHETIC_TAG: i64 = 0x4F4E4B15;
+
+/// How a wheel event should be handled. Pure; no AppKit.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WheelKind {
+    /// Trackpad / Magic Mouse / already-continuous. Leave it alone.
+    PassThrough,
+    /// Discrete mouse in an excluded (or conflicting) app.
+    Excluded,
+    /// Discrete mouse we own.
+    Smooth,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScrollEmitPhase {
+    Began,
+    Changed,
+    MomentumBegin,
+    MomentumContinue,
+    MomentumEnd,
+}
+
+impl ScrollEmitPhase {
+    pub fn scroll_phase(self) -> i64 {
+        match self {
+            Self::Began => 1,
+            Self::Changed => 2,
+            Self::MomentumBegin | Self::MomentumContinue | Self::MomentumEnd => 0,
+        }
+    }
+
+    pub fn momentum_phase(self) -> i64 {
+        match self {
+            Self::Began | Self::Changed => 0,
+            Self::MomentumBegin => 1,
+            Self::MomentumContinue => 2,
+            Self::MomentumEnd => 3,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum GesturePhase {
+    Idle,
+    Active,
+    Coasting,
+}
+
+/// Exponential-decay interpolator. Driven from the tap (ingest) and a
+/// 120 Hz animator thread (step) that parks the moment velocity dies.
+#[derive(Clone, Debug)]
+pub struct ScrollGesture {
+    vx: f64,
+    vy: f64,
+    phase: GesturePhase,
+    emitted: bool,
+}
+
+impl Default for ScrollGesture {
+    fn default() -> Self {
+        Self {
+            vx: 0.0,
+            vy: 0.0,
+            phase: GesturePhase::Idle,
+            emitted: false,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ScrollFrame {
+    pub dx: f64,
+    pub dy: f64,
+    pub phase: ScrollEmitPhase,
+}
+
+impl ScrollGesture {
+    pub fn is_idle(&self) -> bool {
+        matches!(self.phase, GesturePhase::Idle)
+    }
+
+    /// Feed a discrete line delta. `speed` is the settings multiplier.
+    pub fn ingest(&mut self, dx_lines: f64, dy_lines: f64, speed: f64, reverse: bool) {
+        let sign = if reverse { -1.0 } else { 1.0 };
+        let gain = PIXEL_PER_LINE * speed.max(0.05) * sign;
+        self.vx += dx_lines * gain * 8.0;
+        self.vy += dy_lines * gain * 8.0;
+        self.phase = GesturePhase::Active;
+    }
+
+    /// Advance by `dt` seconds. `duration` is the decay time constant.
+    /// Returns `None` once the gesture has fully stopped (including the
+    /// terminal MomentumEnd frame).
+    pub fn step(&mut self, dt: f64, duration: f64) -> Option<ScrollFrame> {
+        if matches!(self.phase, GesturePhase::Idle) {
+            return None;
+        }
+        let tau = duration.clamp(0.05, 2.0);
+        let decay = (-dt / tau).exp();
+        let dx = self.vx * dt;
+        let dy = self.vy * dt;
+        self.vx *= decay;
+        self.vy *= decay;
+
+        let still = self.vx.hypot(self.vy) >= VELOCITY_EPS;
+        let phase = match self.phase {
+            GesturePhase::Idle => return None,
+            GesturePhase::Active if !self.emitted => {
+                self.emitted = true;
+                ScrollEmitPhase::Began
+            }
+            GesturePhase::Active => ScrollEmitPhase::Changed,
+            GesturePhase::Coasting if !still => ScrollEmitPhase::MomentumEnd,
+            GesturePhase::Coasting if self.emitted => ScrollEmitPhase::MomentumContinue,
+            GesturePhase::Coasting => ScrollEmitPhase::MomentumBegin,
+        };
+
+        if matches!(self.phase, GesturePhase::Active) && !still {
+            self.phase = GesturePhase::Coasting;
+            self.emitted = false;
+        } else if matches!(phase, ScrollEmitPhase::MomentumEnd) {
+            *self = Self::default();
+        } else if matches!(self.phase, GesturePhase::Coasting) && !self.emitted {
+            self.emitted = true;
+        }
+
+        Some(ScrollFrame { dx, dy, phase })
+    }
+
+    /// Mark the physical wheel as quiet so the next steps emit momentum.
+    pub fn release(&mut self) {
+        if matches!(self.phase, GesturePhase::Active) {
+            self.phase = GesturePhase::Coasting;
+            self.emitted = false;
+        }
+    }
+}
+
+/// Classify a scroll event. Trackpad (`is_continuous`) always passes.
+pub fn classify_wheel(is_continuous: bool, excluded: bool) -> WheelKind {
+    if is_continuous {
+        WheelKind::PassThrough
+    } else if excluded {
+        WheelKind::Excluded
+    } else {
+        WheelKind::Smooth
+    }
+}
+
+pub fn is_excluded(bundle_id: &str, extra: &[String]) -> bool {
+    let id = bundle_id.trim();
+    if id.is_empty() {
+        return false;
+    }
+    extra.iter().any(|item| item == id) || DEFAULT_EXCLUSIONS.iter().any(|item| *item == id)
+}
+
+/// Shift+wheel becomes horizontal (macOS convention).
+pub fn apply_shift(dx: f64, dy: f64, shift: bool) -> (f64, f64) {
+    if shift && dy.abs() > dx.abs() {
+        (dy, 0.0)
+    } else {
+        (dx, dy)
+    }
+}
+
+pub fn conflict_labels(running: &[String]) -> Vec<String> {
+    running
+        .iter()
+        .filter(|id| CONFLICT_BUNDLES.contains(&id.as_str()))
+        .cloned()
+        .collect()
+}
+
+// --- live animator (macOS posts; other platforms just step the model) ---
+
+struct Engine {
+    gesture: Mutex<ScrollGesture>,
+    wake: Condvar,
+    running: AtomicBool,
+    last_ingest_ms: AtomicU64,
+}
+
+fn engine() -> &'static Engine {
+    static ENGINE: OnceLock<Engine> = OnceLock::new();
+    ENGINE.get_or_init(|| Engine {
+        gesture: Mutex::new(ScrollGesture::default()),
+        wake: Condvar::new(),
+        running: AtomicBool::new(false),
+        last_ingest_ms: AtomicU64::new(0),
+    })
+}
+
+fn now_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+/// Called from the scroll tap. Starts the animator on the first tick.
+pub fn ingest_wheel(dx_lines: f64, dy_lines: f64, shift: bool) {
+    let settings = crate::settings::get_app_settings();
+    if !settings.smooth_scroll_enabled && !settings.reverse_mouse_scroll {
+        return;
+    }
+    let (dx, dy) = apply_shift(dx_lines, dy_lines, shift);
+    let mut guard = engine().gesture.lock().unwrap_or_else(|e| e.into_inner());
+    guard.ingest(dx, dy, settings.scroll_speed as f64, settings.reverse_mouse_scroll);
+    engine().last_ingest_ms.store(now_ms(), Ordering::Relaxed);
+    engine().wake.notify_one();
+    drop(guard);
+    ensure_animator();
+}
+
+pub fn note_wheel_quiet() {
+    if let Ok(mut guard) = engine().gesture.lock() {
+        guard.release();
+    }
+}
+
+fn ensure_animator() {
+    if engine()
+        .running
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
+    thread::Builder::new()
+        .name("nook-scroll".into())
+        .spawn(animator_loop)
+        .expect("scroll animator");
+}
+
+fn animator_loop() {
+    let engine = engine();
+    loop {
+        let settings = crate::settings::get_app_settings();
+        let duration = settings.scroll_duration as f64;
+        let frame = {
+            let mut guard = engine.gesture.lock().unwrap_or_else(|e| e.into_inner());
+            if guard.is_idle() {
+                let (next, timeout) = engine
+                    .wake
+                    .wait_timeout(guard, Duration::from_millis(250))
+                    .unwrap_or_else(|e| e.into_inner());
+                guard = next;
+                if guard.is_idle() {
+                    if timeout.timed_out() {
+                        engine.running.store(false, Ordering::SeqCst);
+                        if engine
+                            .gesture
+                            .lock()
+                            .map(|g| g.is_idle())
+                            .unwrap_or(true)
+                        {
+                            return;
+                        }
+                        engine.running.store(true, Ordering::SeqCst);
+                    }
+                    continue;
+                }
+            }
+            let quiet = now_ms().saturating_sub(engine.last_ingest_ms.load(Ordering::Relaxed)) > 40;
+            if quiet {
+                guard.release();
+            }
+            guard.step(FRAME_DT, duration)
+        };
+        if let Some(frame) = frame {
+            post_pixel_frame(frame);
+        }
+        thread::sleep(Duration::from_secs_f64(FRAME_DT));
+    }
+}
+
+fn post_pixel_frame(frame: ScrollFrame) {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        post_pixel_frame_macos(frame);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = frame;
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn post_pixel_frame_macos(frame: ScrollFrame) {
+    use super::eventtap::ffi::{
+        CGEventCreateScrollWheelEvent2, CGEventPost, CGEventSetDoubleValueField,
+        CGEventSetIntegerValueField, CFRelease, kCGEventSourceUserData,
+        kCGHIDEventTap, kCGScrollEventUnitPixel, kCGScrollWheelEventIsContinuous,
+        kCGScrollWheelEventMomentumPhase, kCGScrollWheelEventPointDeltaAxis1,
+        kCGScrollWheelEventPointDeltaAxis2, kCGScrollWheelEventScrollPhase,
+    };
+
+    let dy = frame.dy.round() as i32;
+    let dx = frame.dx.round() as i32;
+    if dy == 0 && dx == 0 && !matches!(frame.phase, ScrollEmitPhase::MomentumEnd) {
+        return;
+    }
+    let event = CGEventCreateScrollWheelEvent2(
+        std::ptr::null_mut(),
+        kCGScrollEventUnitPixel,
+        2,
+        dy,
+        dx,
+        0,
+    );
+    if event.is_null() {
+        return;
+    }
+    CGEventSetIntegerValueField(event, kCGScrollWheelEventIsContinuous, 1);
+    CGEventSetIntegerValueField(event, kCGScrollWheelEventScrollPhase, frame.phase.scroll_phase());
+    CGEventSetIntegerValueField(
+        event,
+        kCGScrollWheelEventMomentumPhase,
+        frame.phase.momentum_phase(),
+    );
+    CGEventSetDoubleValueField(event, kCGScrollWheelEventPointDeltaAxis1, frame.dy);
+    CGEventSetDoubleValueField(event, kCGScrollWheelEventPointDeltaAxis2, frame.dx);
+    CGEventSetIntegerValueField(event, kCGEventSourceUserData, SYNTHETIC_TAG);
+    CGEventPost(kCGHIDEventTap, event);
+    CFRelease(event);
+}
+
+pub fn synthetic_tag() -> i64 {
+    SYNTHETIC_TAG
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trackpad_always_passes() {
+        assert_eq!(classify_wheel(true, false), WheelKind::PassThrough);
+        assert_eq!(classify_wheel(true, true), WheelKind::PassThrough);
+        assert_eq!(classify_wheel(false, false), WheelKind::Smooth);
+        assert_eq!(classify_wheel(false, true), WheelKind::Excluded);
+    }
+
+    #[test]
+    fn shift_swaps_vertical_to_horizontal() {
+        assert_eq!(apply_shift(0.0, 3.0, true), (3.0, 0.0));
+        assert_eq!(apply_shift(2.0, 0.0, true), (2.0, 0.0));
+        assert_eq!(apply_shift(0.0, 3.0, false), (0.0, 3.0));
+    }
+
+    #[test]
+    fn exclusion_matches_defaults_and_extras() {
+        assert!(is_excluded("com.utmapp.UTM", &[]));
+        assert!(is_excluded("games.mine", &["games.mine".into()]));
+        assert!(!is_excluded("com.apple.Safari", &[]));
+        assert!(!is_excluded("", &["x".into()]));
+    }
+
+    #[test]
+    fn velocity_decays_and_stops() {
+        let mut g = ScrollGesture::default();
+        assert!(g.is_idle());
+        g.ingest(0.0, 1.0, 1.0, false);
+        assert!(!g.is_idle());
+
+        let first = g.step(FRAME_DT, 0.35).expect("began");
+        assert_eq!(first.phase, ScrollEmitPhase::Began);
+        assert!(first.dy > 0.0);
+
+        let mut saw_changed = false;
+        for _ in 0..8 {
+            if let Some(frame) = g.step(FRAME_DT, 0.35) {
+                if frame.phase == ScrollEmitPhase::Changed {
+                    saw_changed = true;
+                }
+            }
+        }
+        assert!(saw_changed, "active frames should report Changed");
+
+        g.release();
+        let mut saw_end = false;
+        for _ in 0..200 {
+            match g.step(FRAME_DT, 0.2) {
+                Some(frame) if frame.phase == ScrollEmitPhase::MomentumEnd => {
+                    saw_end = true;
+                    break;
+                }
+                Some(_) => {}
+                None => break,
+            }
+        }
+        assert!(saw_end);
+        assert!(g.is_idle());
+        assert!(g.step(FRAME_DT, 0.35).is_none());
+    }
+
+    #[test]
+    fn reverse_negates_ingest() {
+        let mut fwd = ScrollGesture::default();
+        let mut rev = ScrollGesture::default();
+        fwd.ingest(0.0, 1.0, 1.0, false);
+        rev.ingest(0.0, 1.0, 1.0, true);
+        let a = fwd.step(FRAME_DT, 0.35).unwrap();
+        let b = rev.step(FRAME_DT, 0.35).unwrap();
+        assert!(a.dy > 0.0);
+        assert!(b.dy < 0.0);
+        assert!((a.dy + b.dy).abs() < 1e-9);
+    }
+
+    #[test]
+    fn faster_speed_makes_larger_pixels() {
+        let mut slow = ScrollGesture::default();
+        let mut fast = ScrollGesture::default();
+        slow.ingest(0.0, 1.0, 0.5, false);
+        fast.ingest(0.0, 1.0, 2.0, false);
+        let a = slow.step(FRAME_DT, 0.35).unwrap();
+        let b = fast.step(FRAME_DT, 0.35).unwrap();
+        assert!(b.dy > a.dy * 3.0);
+    }
+
+    #[test]
+    fn conflict_filter() {
+        let running = vec!["com.apple.Safari".into(), "com.caldis.Mos".into()];
+        assert_eq!(conflict_labels(&running), vec!["com.caldis.Mos".to_string()]);
+    }
+
+    #[test]
+    fn emit_phases_match_coregraphics_constants() {
+        assert_eq!(ScrollEmitPhase::Began.scroll_phase(), 1);
+        assert_eq!(ScrollEmitPhase::Changed.scroll_phase(), 2);
+        assert_eq!(ScrollEmitPhase::MomentumBegin.momentum_phase(), 1);
+        assert_eq!(ScrollEmitPhase::MomentumContinue.momentum_phase(), 2);
+        assert_eq!(ScrollEmitPhase::MomentumEnd.momentum_phase(), 3);
+    }
+}

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -167,6 +167,33 @@ pub struct AppSettings {
     /// Per-widget widths in Nook cells. Missing entries use [`WidgetModule::default_cells`].
     #[serde(default)]
     pub widget_widths: Vec<(WidgetModule, u8)>,
+    /// Mechey: mechanical keyboard sounds. Opt-in; needs Input Monitoring.
+    #[serde(default)]
+    pub keysounds_enabled: bool,
+    /// Builtin pack id (`nook-click` / `nook-thock`) or a user folder name.
+    #[serde(default = "default_keysound_pack")]
+    pub keysound_pack: String,
+    /// 0..=1 playback gain.
+    #[serde(default = "default_keysound_volume")]
+    pub keysound_volume: f32,
+    /// LiquidMouse: smooth pixel scrolling for discrete wheel mice.
+    #[serde(default)]
+    pub smooth_scroll_enabled: bool,
+    /// Pixel multiplier applied to each wheel notch (0.25..=4).
+    #[serde(default = "default_scroll_speed")]
+    pub scroll_speed: f32,
+    /// Exponential-decay time constant in seconds (0.08..=1.2).
+    #[serde(default = "default_scroll_duration")]
+    pub scroll_duration: f32,
+    /// Negate discrete-mouse wheel deltas (Scroll Reverser).
+    #[serde(default)]
+    pub reverse_mouse_scroll: bool,
+    /// Frontmost bundle ids that skip the scroll tap (games, VMs, remotes).
+    #[serde(default)]
+    pub scroll_excluded_apps: Vec<String>,
+    /// Reserved: per-device overrides need private sender IDs (phase 2).
+    #[serde(default)]
+    pub scroll_device_overrides: std::collections::BTreeMap<String, ScrollDeviceOverride>,
     #[serde(default)]
     pub window: WindowSettings,
 }
@@ -217,6 +244,31 @@ fn default_true() -> bool {
     true
 }
 
+fn default_keysound_pack() -> String {
+    "nook-click".into()
+}
+
+fn default_keysound_volume() -> f32 {
+    0.7
+}
+
+fn default_scroll_speed() -> f32 {
+    1.0
+}
+
+fn default_scroll_duration() -> f32 {
+    0.35
+}
+
+/// Best-effort per-device scroll knobs. Unused until sender-ID matching ships.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct ScrollDeviceOverride {
+    #[serde(default)]
+    pub reverse: Option<bool>,
+    #[serde(default)]
+    pub speed: Option<f32>,
+}
+
 impl Default for AppSettings {
     fn default() -> Self {
         Self {
@@ -239,6 +291,15 @@ impl Default for AppSettings {
             hide_when_maximized: false,
             island_color: None,
             widget_widths: Vec::new(),
+            keysounds_enabled: false,
+            keysound_pack: default_keysound_pack(),
+            keysound_volume: default_keysound_volume(),
+            smooth_scroll_enabled: false,
+            scroll_speed: default_scroll_speed(),
+            scroll_duration: default_scroll_duration(),
+            reverse_mouse_scroll: false,
+            scroll_excluded_apps: Vec::new(),
+            scroll_device_overrides: std::collections::BTreeMap::new(),
             window: WindowSettings::default(),
         }
     }
@@ -499,6 +560,8 @@ pub fn update_app_settings(settings: AppSettings) {
     }
     SETTINGS_GEN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     persist();
+    crate::eventtap::sync();
+    crate::keysounds::sync();
 }
 
 /// Bumped on every [`update_app_settings`]. Hot loops compare this before
@@ -725,5 +788,19 @@ mod tests {
         let legacy: AppSettings =
             serde_json::from_str(r#"{"observe":{"metrics_token":"legacy-secret"}}"#).unwrap();
         assert_eq!(legacy.observe.metrics_token, "legacy-secret");
+    }
+
+    #[test]
+    fn input_feel_flags_default_off() {
+        let parsed: AppSettings = serde_json::from_str("{}").unwrap();
+        assert!(!parsed.keysounds_enabled);
+        assert!(!parsed.smooth_scroll_enabled);
+        assert!(!parsed.reverse_mouse_scroll);
+        assert_eq!(parsed.keysound_pack, "nook-click");
+        assert!((parsed.keysound_volume - 0.7).abs() < f32::EPSILON);
+        assert!((parsed.scroll_speed - 1.0).abs() < f32::EPSILON);
+        assert!((parsed.scroll_duration - 0.35).abs() < f32::EPSILON);
+        assert!(parsed.scroll_excluded_apps.is_empty());
+        assert!(parsed.scroll_device_overrides.is_empty());
     }
 }

--- a/crates/nook/src/assets/icons/keyboard.svg
+++ b/crates/nook/src/assets/icons/keyboard.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<rect width="20" height="16" x="2" y="4" rx="2" ry="2"/>
+<path d="M6 8h.001"/><path d="M10 8h.001"/><path d="M14 8h.001"/><path d="M18 8h.001"/>
+<path d="M8 12h.001"/><path d="M12 12h.001"/><path d="M16 12h.001"/>
+<path d="M7 16h10"/>
+</svg>

--- a/crates/nook/src/assets/icons/mouse.svg
+++ b/crates/nook/src/assets/icons/mouse.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<rect x="5" y="2" width="14" height="20" rx="7"/>
+<path d="M12 6v4"/>
+</svg>

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -57,12 +57,16 @@ fn desktop_wallpaper_image() -> Option<std::sync::Arc<Image>> {
 enum SettingsCategory {
     General = 0,
     Widgets = 1,
+    Keyboard = 2,
+    Scrolling = 3,
 }
 
 impl SettingsCategory {
     fn from_u8(v: u8) -> Self {
         match v {
             1 => Self::Widgets,
+            2 => Self::Keyboard,
+            3 => Self::Scrolling,
             _ => Self::General,
         }
     }
@@ -71,6 +75,8 @@ impl SettingsCategory {
         match self {
             Self::General => "General",
             Self::Widgets => "Widgets",
+            Self::Keyboard => "Keyboard",
+            Self::Scrolling => "Scrolling",
         }
     }
 
@@ -78,6 +84,8 @@ impl SettingsCategory {
         match self {
             Self::General => "settings",
             Self::Widgets => "layout-grid",
+            Self::Keyboard => "keyboard",
+            Self::Scrolling => "mouse",
         }
     }
 }
@@ -221,6 +229,29 @@ fn create_width_slider(
     (slider, subscription)
 }
 
+fn create_float_slider(
+    min: f32,
+    max: f32,
+    step: f32,
+    value: f32,
+    cx: &mut Context<SettingsView>,
+    write: impl Fn(f32) + 'static,
+) -> (Entity<SliderState>, Subscription) {
+    let slider = cx.new(|_| {
+        SliderState::new()
+            .min(min)
+            .max(max)
+            .step(step)
+            .default_value(value)
+    });
+    let subscription = cx.subscribe(&slider, move |_, _, event: &SliderEvent, cx| {
+        let SliderEvent::Change(value) = event;
+        write(value.start());
+        cx.notify();
+    });
+    (slider, subscription)
+}
+
 pub(super) struct SettingsView {
     category: SettingsCategory,
     module: WidgetModule,
@@ -237,6 +268,14 @@ pub(super) struct SettingsView {
     width_slider: Entity<SliderState>,
     width_slider_config: (WidgetModule, u8, u8),
     _width_slider_subscription: Subscription,
+    volume_slider: Entity<SliderState>,
+    _volume_slider_subscription: Subscription,
+    scroll_speed_slider: Entity<SliderState>,
+    _scroll_speed_slider_subscription: Subscription,
+    scroll_duration_slider: Entity<SliderState>,
+    _scroll_duration_slider_subscription: Subscription,
+    exclude_focus: FocusHandle,
+    exclude_draft: String,
     placement_drag: bool,
     placement_bounds: Rc<RefCell<Option<Bounds<Pixels>>>>,
 }
@@ -248,22 +287,66 @@ impl SettingsView {
         let min = module.min_cells();
         let max = settings.max_cells_for(module).max(min);
         let (width_slider, width_slider_subscription) = create_width_slider(module, &settings, cx);
+        let (volume_slider, volume_slider_subscription) = create_float_slider(
+            0.0,
+            1.0,
+            0.05,
+            settings.keysound_volume.clamp(0.0, 1.0),
+            cx,
+            |value| {
+                nook_core::settings::tweak_app_settings(|s| {
+                    s.keysound_volume = value.clamp(0.0, 1.0);
+                });
+            },
+        );
+        let (scroll_speed_slider, scroll_speed_subscription) = create_float_slider(
+            0.25,
+            3.0,
+            0.05,
+            settings.scroll_speed.clamp(0.25, 3.0),
+            cx,
+            |value| {
+                nook_core::settings::tweak_app_settings(|s| {
+                    s.scroll_speed = value.clamp(0.25, 3.0);
+                });
+            },
+        );
+        let (scroll_duration_slider, scroll_duration_subscription) = create_float_slider(
+            0.1,
+            1.0,
+            0.05,
+            settings.scroll_duration.clamp(0.1, 1.0),
+            cx,
+            |value| {
+                nook_core::settings::tweak_app_settings(|s| {
+                    s.scroll_duration = value.clamp(0.1, 1.0);
+                });
+            },
+        );
         Self {
             category: SettingsCategory::from_u8(LAST_CATEGORY.load(Ordering::Relaxed)),
             module,
             url_focus: cx.focus_handle(),
             token_focus: cx.focus_handle(),
             query_focus: cx.focus_handle(),
+            exclude_focus: cx.focus_handle(),
             url_draft: settings.observe.prometheus_url,
             token_draft: settings.observe.metrics_token,
             token_revealed: false,
             query_draft: String::new(),
+            exclude_draft: String::new(),
             catalog: Vec::new(),
             catalog_error: None,
             catalog_loading: false,
             width_slider,
             width_slider_config: (module, min, max),
             _width_slider_subscription: width_slider_subscription,
+            volume_slider,
+            _volume_slider_subscription: volume_slider_subscription,
+            scroll_speed_slider,
+            _scroll_speed_slider_subscription: scroll_speed_subscription,
+            scroll_duration_slider,
+            _scroll_duration_slider_subscription: scroll_duration_subscription,
             placement_drag: false,
             placement_bounds: Rc::new(RefCell::new(None)),
         }
@@ -390,6 +473,7 @@ impl gpui::Render for SettingsView {
         let url_focused = self.url_focus.is_focused(window);
         let token_focused = self.token_focus.is_focused(window);
         let query_focused = self.query_focus.is_focused(window);
+        let exclude_focused = self.exclude_focus.is_focused(window);
 
         div()
             .id("settings-root")
@@ -411,11 +495,15 @@ impl gpui::Render for SettingsView {
             })
             .child(self.sidebar(cx))
             .child(div().w(px(1.)).h_full().bg(hairline()))
-            .child(if self.category == SettingsCategory::Widgets {
-                self.render_widgets(&settings, url_focused, token_focused, query_focused, cx)
-                    .into_any_element()
-            } else {
-                self.render_general(&settings, cx).into_any_element()
+            .child(match self.category {
+                SettingsCategory::Widgets => self
+                    .render_widgets(&settings, url_focused, token_focused, query_focused, cx)
+                    .into_any_element(),
+                SettingsCategory::Keyboard => self.render_keyboard(&settings, cx).into_any_element(),
+                SettingsCategory::Scrolling => self
+                    .render_scrolling(&settings, exclude_focused, cx)
+                    .into_any_element(),
+                SettingsCategory::General => self.render_general(&settings, cx).into_any_element(),
             })
     }
 }
@@ -436,6 +524,8 @@ impl SettingsView {
             .gap(px(2.))
             .child(self.sidebar_item(SettingsCategory::General, cx))
             .child(self.sidebar_item(SettingsCategory::Widgets, cx))
+            .child(self.sidebar_item(SettingsCategory::Keyboard, cx))
+            .child(self.sidebar_item(SettingsCategory::Scrolling, cx))
     }
 
     fn sidebar_item(&self, category: SettingsCategory, cx: &mut Context<Self>) -> impl IntoElement {
@@ -571,6 +661,303 @@ impl SettingsView {
                     Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
                 )),
         )
+    }
+
+    fn render_keyboard(&self, settings: &AppSettings, cx: &mut Context<Self>) -> impl IntoElement {
+        let listen = nook_core::eventtap::input_monitoring_status();
+        let packs = nook_core::keysounds::list_packs();
+        let mut pack_rows = Vec::new();
+        for pack in packs {
+            let selected = settings.keysound_pack == pack.id;
+            let id = pack.id.clone();
+            pack_rows.push(
+                settings_row(SharedString::from(format!("pack-{}", pack.id)))
+                    .cursor(CursorStyle::PointingHand)
+                    .on_mouse_down(
+                        MouseButton::Left,
+                        cx.listener(move |_, _, _, cx| {
+                            let id = id.clone();
+                            nook_core::settings::tweak_app_settings(|s| s.keysound_pack = id);
+                            cx.notify();
+                        }),
+                    )
+                    .child(label(pack.name, theme::BODY, true))
+                    .child(label(
+                        if selected { "Selected" } else { " " },
+                        theme::SUBHEADLINE,
+                        false,
+                    ))
+                    .into_any_element(),
+            );
+        }
+        Self::pane(
+            "Keyboard Sounds",
+            div()
+                .id("keyboard-pane")
+                .flex()
+                .flex_col()
+                .gap(px(16.))
+                .child(section(
+                    "Mechey",
+                    settings_group(vec![
+                        toggle_row(
+                            "Play sounds while typing",
+                            settings.keysounds_enabled,
+                            cx,
+                            |s| {
+                                s.keysounds_enabled = !s.keysounds_enabled;
+                                if s.keysounds_enabled
+                                    && !nook_core::eventtap::input_monitoring_status().granted()
+                                {
+                                    nook_core::eventtap::request_input_monitoring();
+                                }
+                            },
+                        )
+                        .into_any_element(),
+                        permission_row("Input Monitoring", listen).into_any_element(),
+                        action_row(
+                            "listen-prompt",
+                            "Request Input Monitoring",
+                            "Prompt",
+                            cx,
+                            |_, _, cx| {
+                                nook_core::eventtap::request_input_monitoring();
+                                cx.notify();
+                            },
+                        )
+                        .into_any_element(),
+                        action_row(
+                            "listen-open",
+                            "Privacy settings",
+                            "Open",
+                            cx,
+                            |_, _, _| {
+                                nook_core::eventtap::open_input_monitoring_settings();
+                            },
+                        )
+                        .into_any_element(),
+                    ]),
+                    Some("Opt-in. The key tap is created only while this is on. Password fields stay silent (secure input). Ad-hoc signing can drop the grant after each rebuild."),
+                ))
+                .child(section(
+                    "Pack",
+                    settings_group({
+                        let mut rows = pack_rows;
+                        rows.push(
+                            self.float_slider_row(
+                                "keysound-volume",
+                                "Volume",
+                                settings.keysound_volume,
+                                &self.volume_slider,
+                                format!("{:.0}%", settings.keysound_volume * 100.0),
+                            )
+                            .into_any_element(),
+                        );
+                        rows.push(
+                            action_row("keysound-test", "Preview this pack", "Test", cx, |_, _, cx| {
+                                nook_core::keysounds::play_test();
+                                cx.notify();
+                            })
+                            .into_any_element(),
+                        );
+                        rows
+                    }),
+                    Some("Drop Mechvibes packs (config.json + OGG) into Application Support/openNook-gpui/soundpacks. Builtin clicks are original CC0 tones, not switch recordings."),
+                )),
+        )
+    }
+
+    fn render_scrolling(
+        &self,
+        settings: &AppSettings,
+        exclude_focused: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let ax = nook_core::eventtap::accessibility_status();
+        let conflicts = nook_core::eventtap::running_conflict_ids();
+        let mut rows = vec![
+            toggle_row(
+                "Smooth scrolling for mice",
+                settings.smooth_scroll_enabled,
+                cx,
+                |s| {
+                    s.smooth_scroll_enabled = !s.smooth_scroll_enabled;
+                    if s.smooth_scroll_enabled
+                        && !nook_core::eventtap::accessibility_status().granted()
+                    {
+                        nook_core::eventtap::request_accessibility();
+                    }
+                },
+            )
+            .into_any_element(),
+            toggle_row(
+                "Reverse mouse wheel",
+                settings.reverse_mouse_scroll,
+                cx,
+                |s| {
+                    s.reverse_mouse_scroll = !s.reverse_mouse_scroll;
+                    if s.reverse_mouse_scroll
+                        && !nook_core::eventtap::accessibility_status().granted()
+                    {
+                        nook_core::eventtap::request_accessibility();
+                    }
+                },
+            )
+            .into_any_element(),
+            permission_row("Accessibility", ax).into_any_element(),
+            action_row(
+                "scroll-ax-prompt",
+                "Request Accessibility",
+                "Prompt",
+                cx,
+                |_, _, cx| {
+                    nook_core::eventtap::request_accessibility();
+                    cx.notify();
+                },
+            )
+            .into_any_element(),
+            action_row(
+                "scroll-ax-open",
+                "Privacy settings",
+                "Open",
+                cx,
+                |_, _, _| {
+                    nook_core::eventtap::open_accessibility_settings();
+                },
+            )
+            .into_any_element(),
+            self.float_slider_row(
+                "scroll-speed",
+                "Speed",
+                settings.scroll_speed,
+                &self.scroll_speed_slider,
+                format!("{:.2}×", settings.scroll_speed),
+            )
+            .into_any_element(),
+            self.float_slider_row(
+                "scroll-duration",
+                "Coast",
+                settings.scroll_duration,
+                &self.scroll_duration_slider,
+                format!("{:.0} ms", settings.scroll_duration * 1000.0),
+            )
+            .into_any_element(),
+        ];
+        if !conflicts.is_empty() {
+            rows.push(
+                status_row(
+                    "Also running",
+                    "Mos / LinearMouse / similar — expect conflicts",
+                )
+                .into_any_element(),
+            );
+        }
+        let mut exclude_rows = vec![field_row(
+            "scroll-exclude",
+            "Add",
+            if self.exclude_draft.is_empty() {
+                "com.example.app"
+            } else {
+                &self.exclude_draft
+            },
+            self.exclude_draft.is_empty(),
+            exclude_focused,
+            &self.exclude_focus,
+            cx,
+            |this, event, cx| {
+                if Self::apply_key(&mut this.exclude_draft, event, cx) {
+                    cx.notify();
+                }
+                if event.keystroke.key == "enter" {
+                    let id = this.exclude_draft.trim().to_string();
+                    if !id.is_empty() {
+                        nook_core::settings::tweak_app_settings(|s| {
+                            if !s.scroll_excluded_apps.iter().any(|item| item == &id) {
+                                s.scroll_excluded_apps.push(id);
+                            }
+                        });
+                        this.exclude_draft.clear();
+                    }
+                    cx.notify();
+                }
+            },
+        )
+        .into_any_element()];
+        for bundle in &settings.scroll_excluded_apps {
+            let id = bundle.clone();
+            exclude_rows.push(
+                settings_row(SharedString::from(format!("ex-{id}")))
+                    .child(label(id.clone(), theme::BODY, true))
+                    .child(push_button(
+                        SharedString::from(format!("rm-{id}")),
+                        "Remove",
+                        cx,
+                        move |_, _, cx| {
+                            let id = id.clone();
+                            nook_core::settings::tweak_app_settings(|s| {
+                                s.scroll_excluded_apps.retain(|item| item != &id);
+                            });
+                            cx.notify();
+                        },
+                    ))
+                    .into_any_element(),
+            );
+        }
+
+        Self::pane(
+            "Scrolling",
+            div()
+                .id("scrolling-pane")
+                .flex()
+                .flex_col()
+                .gap(px(16.))
+                .child(section(
+                    "LiquidMouse",
+                    settings_group(rows),
+                    Some("Trackpads pass through (IsContinuous). Wheel mice get pixel momentum. The tap exists only while a toggle is on. Per-device overrides are not shipped — they need private sender IDs."),
+                ))
+                .child(section(
+                    "Excluded apps",
+                    settings_group(exclude_rows),
+                    Some("Games, VMs, and remotes should stay on the raw wheel. Built-in defaults already cover UTM, VMware, Parallels, VirtualBox, Steam, and Screen Sharing."),
+                )),
+        )
+    }
+
+    fn float_slider_row(
+        &self,
+        id: &'static str,
+        title: &'static str,
+        value: f32,
+        slider: &Entity<SliderState>,
+        caption: String,
+    ) -> impl IntoElement {
+        let _ = value;
+        settings_row(id)
+            .child(label(title, theme::BODY, true))
+            .child(
+                div()
+                    .id(SharedString::from(format!("{id}-slider")))
+                    .flex_1()
+                    .h(px(theme::HIT_MIN))
+                    .px(px(8.))
+                    .flex()
+                    .items_center()
+                    .child(
+                        Slider::new(slider)
+                            .bg(theme::accent())
+                            .text_color(rgb(0xffffff)),
+                    ),
+            )
+            .child(
+                div().w(px(52.)).flex().justify_end().child(
+                    div()
+                        .text_size(px(theme::BODY.size))
+                        .font_weight(FontWeight::MEDIUM)
+                        .text_color(theme::SECONDARY_LABEL)
+                        .child(caption),
+                ),
+            )
     }
 
     fn color_row(&self, settings: &AppSettings, cx: &mut Context<Self>) -> impl IntoElement {
@@ -1437,6 +1824,35 @@ fn action_row(
         ))
 }
 
+fn status_row(title: &'static str, value: &'static str) -> impl IntoElement {
+    settings_row(title)
+        .child(label(title, theme::BODY, true))
+        .child(label(value, theme::SUBHEADLINE, false))
+}
+
+fn permission_row(title: &'static str, status: nook_core::eventtap::PermissionStatus) -> impl IntoElement {
+    let (text, color) = match status {
+        nook_core::eventtap::PermissionStatus::Granted => ("Granted", theme::SUCCESS),
+        nook_core::eventtap::PermissionStatus::Denied => ("Not granted", theme::DESTRUCTIVE),
+        nook_core::eventtap::PermissionStatus::Unsupported => ("macOS only", theme::TERTIARY_LABEL),
+    };
+    settings_row(title)
+        .child(label(title, theme::BODY, true))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(6.))
+                .child(div().size(px(7.)).rounded_full().bg(color))
+                .child(
+                    div()
+                        .text_size(px(theme::SUBHEADLINE.size))
+                        .text_color(color)
+                        .child(text),
+                ),
+        )
+}
+
 fn toggle_row(
     label_text: &'static str,
     on: bool,
@@ -1737,8 +2153,12 @@ mod tests {
     #[test]
     fn nav_enums_round_trip() {
         assert_eq!(SettingsCategory::from_u8(1), SettingsCategory::Widgets);
+        assert_eq!(SettingsCategory::from_u8(2), SettingsCategory::Keyboard);
+        assert_eq!(SettingsCategory::from_u8(3), SettingsCategory::Scrolling);
         assert_eq!(SettingsCategory::from_u8(0), SettingsCategory::General);
         assert_eq!(SettingsCategory::from_u8(99), SettingsCategory::General);
+        assert_eq!(SettingsCategory::Keyboard.title(), "Keyboard");
+        assert_eq!(SettingsCategory::Scrolling.title(), "Scrolling");
         assert_eq!(WidgetModule::from_u8(0), WidgetModule::Calendar);
         assert_eq!(WidgetModule::from_u8(99), WidgetModule::Calendar);
     }


### PR DESCRIPTION
## WP15 — input-feel

Mechey keyboard sounds + LiquidMouse smooth scroll. Branched from `origin/main`. No other WPs.

### What landed
- **Shared `eventtap.rs`**: CFRunLoop thread owns both taps. Listen-only key tap (Input Monitoring) and active scroll tap (Accessibility). Taps are created only while the matching setting is on; disable invalidates the port and joins the thread.
- **`keysounds.rs`**: Mechvibes `config.json` parser + CGKeyCode↔JS keyCode table, synthesized CC0 builtin packs (`nook-click` / `nook-thock`), user packs under Application Support. cpal mixer opens on the first key and closes after ~20s idle. Autorepeat and secure input are silent.
- **`scroll.rs`**: Mouse-vs-trackpad via `kCGScrollWheelEventIsContinuous`. Trackpads pass through. Wheel mice are swallowed and replayed as decaying pixel deltas with Began/Changed/momentum phases. Reverse-mouse is a sign flip on that path. Per-app exclusion list + conflict-bundle warning (Mos / LinearMouse / etc.).
- **Settings**: Keyboard and Scrolling sidebar sections with green/red permission rows. Both features default **off**.

### Not in this PR
- Per-individual-device overrides (`scroll_device_overrides` is reserved; needs private sender IDs).
- Bundled third-party switch recordings (licensing). Builtin tones are original CC0 synthesis; users can drop Mechvibes packs themselves.

### Tests
`cargo test -p nook -p nook-core` — **81 + 95 green** (Linux CI). Pure coverage: pack parse, CG↔JS map, mixer, velocity/phase, classify `IsContinuous`, defaults-off.

### Blockers / caveats
1. **TCC + unsigned builds**: Input Monitoring and Accessibility grants are keyed to the signing identity. Ad-hoc signatures change every build, so users may need to re-grant after updates. A stable Developer ID (or persistent self-signed identity) is effectively required to ship these.
2. **macOS-only runtime**: Event taps, cpal stream, and OGG decode are `cfg(target_os = "macos")`. Linux tests cover the pure models only.
3. **Secure input** mutes Mechey by OS design (password fields, Terminal Secure Keyboard Entry).
4. Coexistence with Mos / LinearMouse / Logi Options+ / Scroll Reverser will fight over the scroll path; Settings warns when those bundles are running.