### PR TITLE
WP17: Live motion art (animated album covers)

### DIFF
--- a/crates/nook-core/src/agents.rs
+++ b/crates/nook-core/src/agents.rs
@@ -10,6 +10,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+#[cfg(target_os = "macos")]
+use sysinfo::Pid;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 /// CPU % above which a descendant process counts as doing real work. The
@@ -153,6 +155,45 @@ fn process_system() -> &'static Mutex<System> {
 }
 
 fn scan_processes() -> HashMap<u32, ProcInfo> {
+    #[cfg(target_os = "macos")]
+    {
+        scan_processes_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        scan_processes_all()
+    }
+}
+
+fn proc_from_sysinfo(pid_u32: u32, proc_: &sysinfo::Process) -> Option<ProcInfo> {
+    let name = proc_.name().to_string_lossy().into_owned();
+    let argv: Vec<String> = if proc_.cmd().is_empty() {
+        if name.is_empty() {
+            return None;
+        }
+        vec![name.clone()]
+    } else {
+        proc_
+            .cmd()
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect()
+    };
+    Some(ProcInfo {
+        pid: pid_u32,
+        ppid: proc_.parent().map(|p| p.as_u32()).unwrap_or(0),
+        cpu_pct: proc_.cpu_usage(),
+        name,
+        argv,
+        cwd: proc_.cwd().map(PathBuf::from),
+        exe: proc_.exe().map(PathBuf::from),
+        start_time: proc_.start_time(),
+    })
+}
+
+/// Full-table refresh. Used off macOS, where the process list is small and
+/// there is no `proc_pidpath` two-stage split.
+fn scan_processes_all() -> HashMap<u32, ProcInfo> {
     let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
     // argv (KERN_PROCARGS2 sysctl) and the exe path are fixed at exec time, so
     // OnlyIfNotSet fetches them once per new pid instead of re-reading them
@@ -172,35 +213,119 @@ fn scan_processes() -> HashMap<u32, ProcInfo> {
 
     let mut map = HashMap::new();
     for (pid, proc_) in sys.processes() {
-        let pid_u32 = pid.as_u32();
-        let name = proc_.name().to_string_lossy().into_owned();
-        let argv: Vec<String> = if proc_.cmd().is_empty() {
-            if name.is_empty() {
-                continue;
-            }
-            vec![name.clone()]
-        } else {
-            proc_
-                .cmd()
-                .iter()
-                .map(|s| s.to_string_lossy().into_owned())
-                .collect()
-        };
-        map.insert(
-            pid_u32,
-            ProcInfo {
-                pid: pid_u32,
-                ppid: proc_.parent().map(|p| p.as_u32()).unwrap_or(0),
-                cpu_pct: proc_.cpu_usage(),
-                name,
-                argv,
-                cwd: proc_.cwd().map(PathBuf::from),
-                exe: proc_.exe().map(PathBuf::from),
-                start_time: proc_.start_time(),
-            },
-        );
+        if let Some(info) = proc_from_sysinfo(pid.as_u32(), proc_) {
+            map.insert(info.pid, info);
+        }
     }
     map
+}
+
+/// macOS two-stage scan: list every pid with a cheap `proc_pidpath` (exe
+/// OnlyIfNotSet), then fetch argv / cwd / cpu only for agent candidates and
+/// their descendants. Avoids KERN_PROCARGS2 on hundreds of unrelated pids.
+#[cfg(target_os = "macos")]
+fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
+    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing()
+            .without_tasks()
+            .with_exe(UpdateKind::OnlyIfNotSet),
+    );
+
+    let sidecar: HashSet<u32> = grok_sessions()
+        .keys()
+        .chain(claude_sessions().keys())
+        .copied()
+        .collect();
+
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut seeds = Vec::new();
+    for (pid, proc_) in sys.processes() {
+        let pid_u32 = pid.as_u32();
+        let ppid = proc_.parent().map(|p| p.as_u32()).unwrap_or(0);
+        children.entry(ppid).or_default().push(pid_u32);
+        let name = proc_.name().to_string_lossy();
+        let exe = proc_
+            .exe()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if is_scan_seed(&exe, &name) || sidecar.contains(&pid_u32) {
+            seeds.push(pid_u32);
+        }
+    }
+
+    let mut detail = HashSet::new();
+    let mut stack = seeds;
+    while let Some(pid) = stack.pop() {
+        if detail.insert(pid) {
+            if let Some(kids) = children.get(&pid) {
+                stack.extend(kids.iter().copied());
+            }
+        }
+    }
+    if detail.is_empty() {
+        return HashMap::new();
+    }
+
+    let pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&pids),
+        true,
+        ProcessRefreshKind::nothing()
+            .without_tasks()
+            .with_cpu()
+            .with_cmd(UpdateKind::OnlyIfNotSet)
+            .with_cwd(UpdateKind::Always)
+            .with_exe(UpdateKind::OnlyIfNotSet),
+    );
+
+    let mut map = HashMap::new();
+    for pid in detail {
+        let Some(proc_) = sys.process(Pid::from_u32(pid)) else {
+            continue;
+        };
+        if let Some(info) = proc_from_sysinfo(pid, proc_) {
+            map.insert(info.pid, info);
+        }
+    }
+    map
+}
+
+/// Stage-1 filter: exe path or `comm` looks like an agent or a wrapper that
+/// may hide the real binary in argv (`node …/claude`).
+fn is_scan_seed(path: &str, comm: &str) -> bool {
+    if grok_install_path(path) {
+        return true;
+    }
+    if is_wrapper_comm(comm) || is_wrapper_comm(path.rsplit('/').next().unwrap_or(path)) {
+        return true;
+    }
+    [
+        AgentKind::Cursor,
+        AgentKind::OpenCode,
+        AgentKind::Claude,
+        AgentKind::Codex,
+        AgentKind::Fx,
+        AgentKind::Grok,
+        AgentKind::Aider,
+        AgentKind::Gemini,
+    ]
+    .into_iter()
+    .any(|kind| {
+        kind.binaries()
+            .iter()
+            .any(|bin| token_has_binary(path, bin) || token_has_binary(comm, bin))
+    })
+}
+
+fn is_wrapper_comm(name: &str) -> bool {
+    const WRAPPERS: &[&str] = &["node", "bun", "deno", "ruby", "perl", "npx", "python", "python3"];
+    let base = name.rsplit(['/', '\\']).next().unwrap_or(name);
+    let base = base.strip_suffix(".exe").unwrap_or(base);
+    let lower = base.to_ascii_lowercase();
+    WRAPPERS.iter().any(|w| lower == *w) || lower.starts_with("python")
 }
 
 fn assemble(procs: &HashMap<u32, ProcInfo>) -> Vec<AgentSession> {
@@ -1086,6 +1211,22 @@ mod tests {
             ),
             Some(AgentKind::Cursor)
         );
+    }
+
+    #[test]
+    fn scan_seed_matches_agent_paths_and_wrappers() {
+        assert!(is_scan_seed("/usr/local/bin/claude", "claude"));
+        assert!(is_scan_seed(
+            "/Users/a/.local/share/claude/versions/2.1.121",
+            "claude"
+        ));
+        assert!(is_scan_seed("/bin/cursor-agent", "cursor-agent"));
+        assert!(is_scan_seed("/opt/homebrew/bin/node", "node"));
+        assert!(is_scan_seed("/usr/bin/python3.12", "Python"));
+        assert!(is_scan_seed("/Users/a/.grok/bin/agent", "agent"));
+        assert!(!is_scan_seed("/usr/bin/grep", "grep"));
+        assert!(!is_scan_seed("/Applications/Safari.app/Contents/MacOS/Safari", "Safari"));
+        assert!(!is_scan_seed("/usr/sbin/syslogd", "syslogd"));
     }
 
     #[test]

--- a/crates/nook-core/src/agents.rs
+++ b/crates/nook-core/src/agents.rs
@@ -220,19 +220,48 @@ fn scan_processes_all() -> HashMap<u32, ProcInfo> {
     map
 }
 
-/// macOS two-stage scan: list every pid with a cheap `proc_pidpath` (exe
-/// OnlyIfNotSet), then fetch argv / cwd / cpu only for agent candidates and
-/// their descendants. Avoids KERN_PROCARGS2 on hundreds of unrelated pids.
+/// Cached argv/cwd/exe for a live pid. Invalidated when start_time changes
+/// (pid reuse) or the pid disappears.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Debug, PartialEq)]
+struct CachedDetail {
+    start_time: u64,
+    name: String,
+    argv: Vec<String>,
+    cwd: Option<PathBuf>,
+    exe: Option<PathBuf>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn cache_lookup<'a>(
+    cache: &'a HashMap<u32, CachedDetail>,
+    pid: u32,
+    start_time: u64,
+) -> Option<&'a CachedDetail> {
+    let hit = cache.get(&pid)?;
+    (start_time > 0 && hit.start_time == start_time).then_some(hit)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn prune_detail_cache(cache: &mut HashMap<u32, CachedDetail>, live: &HashSet<u32>) {
+    cache.retain(|pid, _| live.contains(pid));
+}
+
+#[cfg(target_os = "macos")]
+fn detail_cache() -> &'static Mutex<HashMap<u32, CachedDetail>> {
+    static CACHE: OnceLock<Mutex<HashMap<u32, CachedDetail>>> = OnceLock::new();
+    CACHE.get_or_init(Mutex::default)
+}
+
+/// macOS two-stage scan: `proc_listallpids` + `proc_pidpath` / `PROC_PIDTBSDINFO`
+/// first (cheap), then argv (KERN_PROCARGS2) and cwd only for agent candidates
+/// and their descendants, and only when `(pid, start_time)` is not cached.
 #[cfg(target_os = "macos")]
 fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
-    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::All,
-        true,
-        ProcessRefreshKind::nothing()
-            .without_tasks()
-            .with_exe(UpdateKind::OnlyIfNotSet),
-    );
+    let stage = list_stage1();
+    if stage.is_empty() {
+        return scan_processes_all();
+    }
 
     let sidecar: HashSet<u32> = grok_sessions()
         .keys()
@@ -241,19 +270,14 @@ fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
         .collect();
 
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut by_pid: HashMap<u32, Stage1> = HashMap::new();
     let mut seeds = Vec::new();
-    for (pid, proc_) in sys.processes() {
-        let pid_u32 = pid.as_u32();
-        let ppid = proc_.parent().map(|p| p.as_u32()).unwrap_or(0);
-        children.entry(ppid).or_default().push(pid_u32);
-        let name = proc_.name().to_string_lossy();
-        let exe = proc_
-            .exe()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        if is_scan_seed(&exe, &name) || sidecar.contains(&pid_u32) {
-            seeds.push(pid_u32);
+    for info in stage {
+        children.entry(info.ppid).or_default().push(info.pid);
+        if is_scan_seed(&info.path, &info.comm) || sidecar.contains(&info.pid) {
+            seeds.push(info.pid);
         }
+        by_pid.insert(info.pid, info);
     }
 
     let mut detail = HashSet::new();
@@ -266,31 +290,233 @@ fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
         }
     }
     if detail.is_empty() {
+        let mut cache = detail_cache().lock().unwrap_or_else(|e| e.into_inner());
+        cache.clear();
         return HashMap::new();
     }
 
-    let pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::Some(&pids),
-        true,
-        ProcessRefreshKind::nothing()
-            .without_tasks()
-            .with_cpu()
-            .with_cmd(UpdateKind::OnlyIfNotSet)
-            .with_cwd(UpdateKind::Always)
-            .with_exe(UpdateKind::OnlyIfNotSet),
-    );
+    let mut cache = detail_cache().lock().unwrap_or_else(|e| e.into_inner());
+    let mut hits: HashMap<u32, CachedDetail> = HashMap::new();
+    let mut misses = Vec::new();
+    for pid in &detail {
+        let start = by_pid.get(pid).map(|s| s.start_time).unwrap_or(0);
+        if let Some(hit) = cache_lookup(&cache, *pid, start) {
+            hits.insert(*pid, hit.clone());
+        } else {
+            misses.push(*pid);
+        }
+    }
+
+    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
+    let cpu_kind = ProcessRefreshKind::nothing().without_tasks().with_cpu();
+    let all_pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
+    sys.refresh_processes_specifics(ProcessesToUpdate::Some(&all_pids), true, cpu_kind);
+    if !misses.is_empty() {
+        let miss_pids: Vec<Pid> = misses.iter().copied().map(Pid::from_u32).collect();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&miss_pids),
+            true,
+            ProcessRefreshKind::nothing()
+                .without_tasks()
+                .with_cpu()
+                .with_cmd(UpdateKind::OnlyIfNotSet)
+                .with_cwd(UpdateKind::OnlyIfNotSet)
+                .with_exe(UpdateKind::OnlyIfNotSet),
+        );
+    }
 
     let mut map = HashMap::new();
     for pid in detail {
+        let stage = by_pid.get(&pid);
+        let start = stage.map(|s| s.start_time).unwrap_or(0);
+        let ppid = stage.map(|s| s.ppid).unwrap_or(0);
+        let cpu_pct = sys
+            .process(Pid::from_u32(pid))
+            .map(|p| p.cpu_usage())
+            .unwrap_or(0.0);
+        if let Some(hit) = hits.get(&pid) {
+            map.insert(
+                pid,
+                ProcInfo {
+                    pid,
+                    ppid,
+                    cpu_pct,
+                    name: hit.name.clone(),
+                    argv: hit.argv.clone(),
+                    cwd: hit.cwd.clone(),
+                    exe: hit.exe.clone(),
+                    start_time: hit.start_time,
+                },
+            );
+            continue;
+        }
         let Some(proc_) = sys.process(Pid::from_u32(pid)) else {
             continue;
         };
-        if let Some(info) = proc_from_sysinfo(pid, proc_) {
-            map.insert(info.pid, info);
+        let Some(mut info) = proc_from_sysinfo(pid, proc_) else {
+            continue;
+        };
+        if info.start_time == 0 {
+            info.start_time = start;
         }
+        if info.ppid == 0 {
+            info.ppid = ppid;
+        }
+        cache.insert(
+            pid,
+            CachedDetail {
+                start_time: info.start_time,
+                name: info.name.clone(),
+                argv: info.argv.clone(),
+                cwd: info.cwd.clone(),
+                exe: info.exe.clone(),
+            },
+        );
+        map.insert(pid, info);
     }
+    prune_detail_cache(&mut cache, &map.keys().copied().collect());
     map
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+struct Stage1 {
+    pid: u32,
+    ppid: u32,
+    start_time: u64,
+    path: String,
+    comm: String,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct ProcBsdInfo {
+    pbi_flags: u32,
+    pbi_status: u32,
+    pbi_xstatus: u32,
+    pbi_pid: u32,
+    pbi_ppid: u32,
+    pbi_uid: u32,
+    pbi_gid: u32,
+    pbi_ruid: u32,
+    pbi_rgid: u32,
+    pbi_svuid: u32,
+    pbi_svgid: u32,
+    rfu_1: u32,
+    pbi_comm: [u8; 16],
+    pbi_name: [u8; 32],
+    pbi_nfiles: u32,
+    pbi_pgid: u32,
+    pbi_pjobc: u32,
+    e_tdev: u32,
+    e_tpgid: u32,
+    pbi_nice: i32,
+    pbi_start_tvsec: u64,
+    pbi_start_tvusec: u64,
+}
+
+#[cfg(target_os = "macos")]
+const PROC_PIDTBSDINFO: i32 = 3;
+
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn proc_listallpids(buffer: *mut std::ffi::c_void, buffersize: i32) -> i32;
+    fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, buffersize: u32) -> i32;
+    fn proc_pidinfo(
+        pid: i32,
+        flavor: i32,
+        arg: u64,
+        buffer: *mut std::ffi::c_void,
+        buffersize: i32,
+    ) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn c_name(buf: &[u8]) -> String {
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..end]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn list_all_pids() -> Vec<i32> {
+    unsafe {
+        let hint = proc_listallpids(std::ptr::null_mut(), 0);
+        if hint <= 0 {
+            return Vec::new();
+        }
+        let mut buf = vec![0i32; hint as usize + 64];
+        let bytes = (buf.len() * std::mem::size_of::<i32>()) as i32;
+        let n = proc_listallpids(buf.as_mut_ptr() as *mut std::ffi::c_void, bytes);
+        if n <= 0 {
+            return Vec::new();
+        }
+        buf.truncate(n as usize);
+        buf.retain(|&p| p > 0);
+        buf
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn pid_path(pid: i32) -> String {
+    let mut buf = [0u8; 4096];
+    let n = unsafe {
+        proc_pidpath(
+            pid,
+            buf.as_mut_ptr() as *mut std::ffi::c_void,
+            buf.len() as u32,
+        )
+    };
+    if n <= 0 {
+        return String::new();
+    }
+    String::from_utf8_lossy(&buf[..n as usize]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn pid_bsdinfo(pid: i32) -> Option<ProcBsdInfo> {
+    let mut info = ProcBsdInfo::default();
+    let sz = std::mem::size_of::<ProcBsdInfo>() as i32;
+    let n = unsafe {
+        proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut std::ffi::c_void,
+            sz,
+        )
+    };
+    (n == sz).then_some(info)
+}
+
+#[cfg(target_os = "macos")]
+fn list_stage1() -> Vec<Stage1> {
+    list_all_pids()
+        .into_iter()
+        .filter_map(|pid| {
+            let bsd = pid_bsdinfo(pid)?;
+            let path = pid_path(pid);
+            let comm = {
+                let name = c_name(&bsd.pbi_name);
+                if name.is_empty() {
+                    c_name(&bsd.pbi_comm)
+                } else {
+                    name
+                }
+            };
+            Some(Stage1 {
+                pid: if bsd.pbi_pid != 0 {
+                    bsd.pbi_pid
+                } else {
+                    pid as u32
+                },
+                ppid: bsd.pbi_ppid,
+                start_time: bsd.pbi_start_tvsec,
+                path,
+                comm,
+            })
+        })
+        .collect()
 }
 
 /// Stage-1 filter: exe path or `comm` looks like an agent or a wrapper that
@@ -1115,17 +1341,16 @@ fn activate(_pid: u32) -> bool {
     false
 }
 
-/// How long the island should wait between scans: quick while sessions are
-/// live (status changes matter), relaxed once none have been seen for a
-/// while — a newly started agent then appears within one slow tick, which is
-/// fine for a status glance and keeps the recurring process-table walk off
-/// the battery.
+/// How long the island should wait between scans: 2s while a session was
+/// seen recently, 5s once none are active — a newly started agent then
+/// appears within one slow tick, which is fine for a status glance and
+/// keeps the recurring process-table walk off the battery.
 pub fn poll_interval() -> Duration {
     let last = LAST_AGENT_SEEN.load(std::sync::atomic::Ordering::Relaxed);
     if unix_secs().saturating_sub(last) < 30 {
         Duration::from_secs(2)
     } else {
-        Duration::from_secs(6)
+        Duration::from_secs(5)
     }
 }
 
@@ -1227,6 +1452,37 @@ mod tests {
         assert!(!is_scan_seed("/usr/bin/grep", "grep"));
         assert!(!is_scan_seed("/Applications/Safari.app/Contents/MacOS/Safari", "Safari"));
         assert!(!is_scan_seed("/usr/sbin/syslogd", "syslogd"));
+    }
+
+    #[test]
+    fn argv_cache_hits_only_matching_start_time() {
+        let mut cache = HashMap::new();
+        cache.insert(
+            7,
+            CachedDetail {
+                start_time: 100,
+                name: "claude".into(),
+                argv: vec!["claude".into()],
+                cwd: None,
+                exe: None,
+            },
+        );
+        assert!(cache_lookup(&cache, 7, 100).is_some());
+        assert!(cache_lookup(&cache, 7, 101).is_none());
+        assert!(cache_lookup(&cache, 7, 0).is_none());
+        assert!(cache_lookup(&cache, 8, 100).is_none());
+        let live = HashSet::from([8u32]);
+        prune_detail_cache(&mut cache, &live);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn poll_interval_is_5s_when_no_recent_session() {
+        let prev = LAST_AGENT_SEEN.swap(0, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(poll_interval(), Duration::from_secs(5));
+        LAST_AGENT_SEEN.store(unix_secs(), std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(poll_interval(), Duration::from_secs(2));
+        LAST_AGENT_SEEN.store(prev, std::sync::atomic::Ordering::Relaxed);
     }
 
     #[test]

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -308,12 +308,75 @@ fn safari_artwork_url<'a>(page_url: &str, artwork_url: &'a str) -> Option<&'a st
 /// waiting out its idle cadence.
 static MEDIA_EVENT: AtomicBool = AtomicBool::new(false);
 
+/// Launch Services snapshot of the AppleScript fallback players, refreshed
+/// from `NSWorkspace` launch/terminate notifications instead of walking the
+/// process table. Bit0 = primed, bit1 = Spotify, bit2 = Music, bit3 = Safari.
+static MEDIA_APPS: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+const MEDIA_APPS_PRIMED: u8 = 1 << 0;
+const MEDIA_APP_SPOTIFY: u8 = 1 << 1;
+const MEDIA_APP_MUSIC: u8 = 1 << 2;
+const MEDIA_APP_SAFARI: u8 = 1 << 3;
+
 pub fn note_media_event() {
     MEDIA_EVENT.store(true, Ordering::Relaxed);
 }
 
 pub fn take_media_event() -> bool {
     MEDIA_EVENT.swap(false, Ordering::Relaxed)
+}
+
+/// Record that a media-capable app launched or quit. Unknown bundle ids are
+/// ignored so the workspace observers can be wired to every app event.
+pub fn note_media_app_running(bundle_id: &str, running: bool) {
+    let bit = match bundle_id {
+        "com.spotify.client" => MEDIA_APP_SPOTIFY,
+        "com.apple.Music" => MEDIA_APP_MUSIC,
+        "com.apple.Safari" => MEDIA_APP_SAFARI,
+        _ => return,
+    };
+    let mut packed = MEDIA_APPS.load(Ordering::Relaxed) | MEDIA_APPS_PRIMED;
+    if running {
+        packed |= bit;
+    } else {
+        packed &= !bit;
+    }
+    MEDIA_APPS.store(packed, Ordering::Relaxed);
+}
+
+/// `(spotify, music, safari)` from the launch/terminate cache, priming via
+/// `NSRunningApplication` once if no observer has run yet.
+#[cfg(target_os = "macos")]
+fn media_players_running() -> (bool, bool, bool) {
+    let packed = MEDIA_APPS.load(Ordering::Relaxed);
+    if packed & MEDIA_APPS_PRIMED == 0 {
+        return prime_media_apps();
+    }
+    (
+        packed & MEDIA_APP_SPOTIFY != 0,
+        packed & MEDIA_APP_MUSIC != 0,
+        packed & MEDIA_APP_SAFARI != 0,
+    )
+}
+
+/// Seed the media-app bits from Launch Services. Called from
+/// `install_media_observers` so the first AppleScript poll does not race.
+#[cfg(target_os = "macos")]
+pub fn prime_media_apps() -> (bool, bool, bool) {
+    let spotify = app_running(c"com.spotify.client");
+    let music = app_running(c"com.apple.Music");
+    let safari = app_running(c"com.apple.Safari");
+    let mut packed = MEDIA_APPS_PRIMED;
+    if spotify {
+        packed |= MEDIA_APP_SPOTIFY;
+    }
+    if music {
+        packed |= MEDIA_APP_MUSIC;
+    }
+    if safari {
+        packed |= MEDIA_APP_SAFARI;
+    }
+    MEDIA_APPS.store(packed, Ordering::Relaxed);
+    (spotify, music, safari)
 }
 
 /// Whether an app with this bundle id is running, via Launch Services.
@@ -365,11 +428,7 @@ pub async fn get_now_playing() -> NowPlayingData {
         // Services' in-process app list — no walk of the whole process table
         // (the sysinfo refresh this replaces enumerated every pid on the
         // system each poll, a measurable slice of idle CPU).
-        let (spotify_running, music_running, safari_running) = (
-            app_running(c"com.spotify.client"),
-            app_running(c"com.apple.Music"),
-            app_running(c"com.apple.Safari"),
-        );
+        let (spotify_running, music_running, safari_running) = media_players_running();
 
         // If no relevant apps are running, return early with no overhead
         if !spotify_running && !music_running && !safari_running {
@@ -1402,6 +1461,22 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn media_app_running_cache_ignores_unrelated_bundles() {
+        note_media_app_running("com.apple.finder", true);
+        note_media_app_running("com.spotify.client", true);
+        note_media_app_running("com.apple.Music", false);
+        note_media_app_running("com.apple.Safari", true);
+        let packed = MEDIA_APPS.load(Ordering::Relaxed);
+        assert_ne!(packed & MEDIA_APPS_PRIMED, 0);
+        assert_ne!(packed & MEDIA_APP_SPOTIFY, 0);
+        assert_eq!(packed & MEDIA_APP_MUSIC, 0);
+        assert_ne!(packed & MEDIA_APP_SAFARI, 0);
+        note_media_app_running("com.spotify.client", false);
+        let packed = MEDIA_APPS.load(Ordering::Relaxed);
+        assert_eq!(packed & MEDIA_APP_SPOTIFY, 0);
     }
 
     #[test]

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -143,6 +143,7 @@ async fn now_playing_from_adapter(track: crate::mediaremote::AdapterTrack) -> No
         audio_levels: Some(get_audio_levels_internal()),
         app_name: track.app_name,
         bundle_id: track.bundle_id,
+        motion_artwork_url: None,
     };
     save_last_played(&data);
     data
@@ -545,6 +546,7 @@ pub async fn get_now_playing() -> NowPlayingData {
                         "safari" => Some("com.apple.Safari".into()),
                         _ => None,
                     },
+                    motion_artwork_url: None,
                 };
 
                 save_last_played(&data);
@@ -631,6 +633,7 @@ pub async fn get_now_playing() -> NowPlayingData {
                     audio_levels: Some(get_audio_levels_internal()),
                     app_name: Some("System".to_string()),
                     bundle_id: None,
+                    motion_artwork_url: None,
                 })
             })();
 
@@ -754,6 +757,7 @@ pub async fn get_now_playing() -> NowPlayingData {
                                 audio_levels: Some(get_audio_levels_internal()),
                                 app_name: Some(name.replace("org.mpris.MediaPlayer2.", "")),
                                 bundle_id: None,
+                                motion_artwork_url: None,
                             };
                             save_last_played(&data);
                             return data;

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -25,6 +25,8 @@ pub fn init_audio_state() {
     let _ = AUDIO_LEVELS.set(std::sync::Mutex::new(vec![0.15; 6]));
     let _ = TRACK_CACHE.set(std::sync::Mutex::new((None, None, None)));
     let _ = LAST_PLAYED.set(std::sync::Mutex::new(None));
+    #[cfg(target_os = "macos")]
+    crate::mediaremote::ensure_stream();
 }
 
 fn lock_mutex<T>(m: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
@@ -337,7 +339,8 @@ fn app_running(bundle_id: &std::ffi::CStr) -> bool {
 /// Get currently playing music information.
 ///
 /// On macOS this prefers MediaRemote via [mediaremote-adapter]
-/// (`get --now`), which works for any now-playing app on 15.4+.
+/// (live `stream` cell, `get --now` only as primer / fallback),
+/// which works for any now-playing app on 15.4+.
 /// AppleScript (Spotify / Music / Safari) is the fallback.
 ///
 /// [mediaremote-adapter]: https://github.com/ungive/mediaremote-adapter

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -2,6 +2,9 @@ use crate::models::NowPlayingData;
 use crate::utils::fetch_artwork_from_url;
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::Notify;
 
 /// Global state for audio levels (updated by audio monitoring thread)
 static AUDIO_LEVELS: std::sync::OnceLock<std::sync::Mutex<Vec<f64>>> = std::sync::OnceLock::new();
@@ -317,12 +320,38 @@ const MEDIA_APP_SPOTIFY: u8 = 1 << 1;
 const MEDIA_APP_MUSIC: u8 = 1 << 2;
 const MEDIA_APP_SAFARI: u8 = 1 << 3;
 
+static MEDIA_WAKE: OnceLock<Notify> = OnceLock::new();
+
+fn media_wake() -> &'static Notify {
+    MEDIA_WAKE.get_or_init(Notify::new)
+}
+
 pub fn note_media_event() {
     MEDIA_EVENT.store(true, Ordering::Relaxed);
+    media_wake().notify_waiters();
 }
 
 pub fn take_media_event() -> bool {
     MEDIA_EVENT.swap(false, Ordering::Relaxed)
+}
+
+/// Park until a playback-change poke or `timeout`.
+///
+/// The island now-playing loop uses this so idle is one timer, not a 250 ms
+/// poll of the event flag. Subscribe before checking the flag so a poke that
+/// lands in between cannot be missed.
+pub async fn wait_media_or_timeout(timeout: Duration) {
+    let notified = media_wake().notified();
+    tokio::pin!(notified);
+    if MEDIA_EVENT.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    tokio::select! {
+        _ = notified => {
+            let _ = MEDIA_EVENT.swap(false, Ordering::Relaxed);
+        }
+        _ = tokio::time::sleep(timeout) => {}
+    }
 }
 
 /// Record that a media-capable app launched or quit. Unknown bundle ids are
@@ -1488,5 +1517,41 @@ mod tests {
             ),
             Some("https://music.youtube.com/favicon.ico")
         );
+    }
+
+    static MEDIA_WAIT_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn wait_media_returns_when_event_already_set() {
+        let _g = MEDIA_WAIT_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = take_media_event();
+        note_media_event();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let start = std::time::Instant::now();
+        rt.block_on(wait_media_or_timeout(Duration::from_secs(3)));
+        assert!(start.elapsed() < Duration::from_millis(250));
+    }
+
+    #[test]
+    fn wait_media_wakes_on_note() {
+        let _g = MEDIA_WAIT_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = take_media_event();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let start = std::time::Instant::now();
+        rt.block_on(async {
+            let waiter = wait_media_or_timeout(Duration::from_secs(3));
+            let poker = async {
+                tokio::time::sleep(Duration::from_millis(15)).await;
+                note_media_event();
+            };
+            tokio::join!(waiter, poker);
+        });
+        assert!(start.elapsed() < Duration::from_millis(500));
     }
 }

--- a/crates/nook-core/src/database.rs
+++ b/crates/nook-core/src/database.rs
@@ -74,6 +74,17 @@ fn migrate(conn: &Connection) -> Result<()> {
         [],
     )?;
 
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS motion_artwork (
+            cache_key TEXT PRIMARY KEY,
+            m3u8 TEXT,
+            preview TEXT,
+            hit INTEGER NOT NULL DEFAULT 0,
+            fetched_at INTEGER NOT NULL
+        )",
+        [],
+    )?;
+
     Ok(())
 }
 

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,7 +10,6 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
-#[cfg(target_os = "macos")]
 mod mediaremote;
 pub mod models;
 pub mod mouse;

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
+#[cfg(any(target_os = "macos", test))]
 mod mediaremote;
 pub mod models;
 pub mod mouse;

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod haptics;
 #[cfg(any(target_os = "macos", test))]
 mod mediaremote;
 pub mod models;
+pub mod motion_artwork;
 pub mod mouse;
 pub mod notch;
 pub mod notes;

--- a/crates/nook-core/src/mediaremote.rs
+++ b/crates/nook-core/src/mediaremote.rs
@@ -11,10 +11,14 @@
 //!
 //! [mediaremote-adapter]: https://github.com/ungive/mediaremote-adapter
 
-use serde_json::Value;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::sync::OnceLock;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, Once, OnceLock};
+use std::time::{Duration, Instant};
 
 /// MediaRemote `MRCommand` / adapter `MRACommand` IDs.
 #[derive(Debug, Clone, Copy)]
@@ -180,6 +184,247 @@ fn find_media_control() -> Option<PathBuf> {
     None
 }
 
+fn adapter_supports_stream() -> bool {
+    matches!(backend(), Some(Backend::Adapter { .. }))
+}
+
+struct StreamState {
+    merged: Value,
+    track: Option<AdapterTrack>,
+    elapsed_base: Option<f64>,
+    elapsed_at: Instant,
+    playing: bool,
+    primed: bool,
+}
+
+impl StreamState {
+    fn fresh() -> Self {
+        Self {
+            merged: Value::Object(Map::new()),
+            track: None,
+            elapsed_base: None,
+            elapsed_at: Instant::now(),
+            playing: false,
+            primed: false,
+        }
+    }
+}
+
+fn stream_state() -> &'static Mutex<StreamState> {
+    static STATE: OnceLock<Mutex<StreamState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(StreamState::fresh()))
+}
+
+static STREAM_CHANGED: AtomicBool = AtomicBool::new(false);
+static STREAM_ALIVE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Deserialize)]
+struct StreamEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    diff: bool,
+    #[serde(default)]
+    payload: Value,
+}
+
+/// Spawn the long-lived adapter `stream --diff` child (once). No-op for the
+/// debug `media-control` backend and when the adapter is missing.
+pub fn ensure_stream() {
+    if !adapter_supports_stream() {
+        return;
+    }
+    static STARTED: Once = Once::new();
+    STARTED.call_once(|| {
+        let _ = std::thread::Builder::new()
+            .name("nook-mr-stream".into())
+            .spawn(stream_supervisor);
+    });
+}
+
+/// Latest snapshot from the live stream, with `elapsed_time` interpolated
+/// from the last event while playing. `None` if the stream has not produced
+/// a snapshot yet (caller should one-shot `get --now`).
+pub fn latest_now_playing() -> Option<Option<AdapterTrack>> {
+    let Ok(state) = stream_state().lock() else {
+        return None;
+    };
+    if !state.primed {
+        return None;
+    }
+    Some(interpolated_track(&state))
+}
+
+pub fn take_stream_changed() -> bool {
+    STREAM_CHANGED.swap(false, Ordering::Relaxed)
+}
+
+pub fn stream_is_live() -> bool {
+    STREAM_ALIVE.load(Ordering::Relaxed)
+}
+
+fn interpolated_track(state: &StreamState) -> Option<AdapterTrack> {
+    let mut track = state.track.clone()?;
+    if state.playing {
+        if let Some(base) = state.elapsed_base.or(track.elapsed_time) {
+            let mut elapsed = base + state.elapsed_at.elapsed().as_secs_f64();
+            if let Some(duration) = track.duration {
+                elapsed = elapsed.min(duration.max(0.0));
+            }
+            track.elapsed_time = Some(elapsed);
+        }
+    }
+    Some(track)
+}
+
+fn merge_diff(target: &mut Value, diff: Value) {
+    let Value::Object(diff_map) = diff else {
+        if !diff.is_null() {
+            *target = diff;
+        }
+        return;
+    };
+    if !target.is_object() {
+        *target = Value::Object(Map::new());
+    }
+    let Some(map) = target.as_object_mut() else {
+        return;
+    };
+    for (k, v) in diff_map {
+        if v.is_null() {
+            map.remove(&k);
+        } else {
+            map.insert(k, v);
+        }
+    }
+}
+
+fn apply_payload(diff: bool, payload: Value) {
+    let mut state = stream_state().lock().unwrap_or_else(|e| e.into_inner());
+    if diff {
+        merge_diff(&mut state.merged, payload);
+    } else {
+        state.merged = match payload {
+            Value::Object(map) => Value::Object(map),
+            Value::Null => Value::Object(Map::new()),
+            other => other,
+        };
+    }
+    let json = serde_json::to_string(&state.merged).unwrap_or_else(|_| "{}".into());
+    let track = parse_get_output(&json).ok().flatten();
+    state.playing = track.as_ref().map(|t| t.is_playing).unwrap_or(false);
+    state.elapsed_base = track.as_ref().and_then(|t| t.elapsed_time);
+    state.elapsed_at = Instant::now();
+    state.track = track;
+    state.primed = true;
+    STREAM_CHANGED.store(true, Ordering::Relaxed);
+    drop(state);
+    crate::audio::note_media_event();
+}
+
+fn apply_stream_event(line: &str) -> bool {
+    let ev: StreamEvent = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(err) => {
+            log::debug!("MediaRemote stream JSON: {err}");
+            return false;
+        }
+    };
+    if ev.kind != "data" {
+        return false;
+    }
+    apply_payload(ev.diff, ev.payload);
+    true
+}
+
+fn apply_primer_stdout(stdout: &str) {
+    let trimmed = stdout.trim();
+    let payload = if trimmed.is_empty() || trimmed == "null" {
+        Value::Object(Map::new())
+    } else {
+        serde_json::from_str(trimmed).unwrap_or_else(|_| Value::Object(Map::new()))
+    };
+    apply_payload(false, payload);
+}
+
+fn stream_supervisor() {
+    if let Ok(out) = run(&["get", "--now"]) {
+        apply_primer_stdout(&out);
+    }
+    let mut backoff = Duration::from_millis(200);
+    loop {
+        match spawn_stream_child() {
+            Ok(mut child) => {
+                STREAM_ALIVE.store(true, Ordering::Relaxed);
+                backoff = Duration::from_millis(200);
+                let _ = read_stream(&mut child);
+                STREAM_ALIVE.store(false, Ordering::Relaxed);
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            Err(err) => {
+                log::debug!("MediaRemote stream spawn failed: {err}");
+            }
+        }
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_secs(8));
+    }
+}
+
+fn spawn_stream_child() -> Result<std::process::Child, String> {
+    let Some(Backend::Adapter {
+        perl,
+        script,
+        framework,
+    }) = backend()
+    else {
+        return Err("MediaRemote stream needs the adapter backend".into());
+    };
+    Command::new(perl)
+        .arg(script)
+        .arg(framework)
+        .arg("stream")
+        .arg("--diff")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn MediaRemote stream: {e}"))
+}
+
+fn read_stream(child: &mut std::process::Child) -> bool {
+    let Some(stdout) = child.stdout.take() else {
+        return false;
+    };
+    let pid = child.id();
+    let first = std::sync::Arc::new(AtomicBool::new(false));
+    let first_flag = first.clone();
+    let _ = std::thread::Builder::new()
+        .name("nook-mr-watchdog".into())
+        .spawn(move || {
+            std::thread::sleep(Duration::from_secs(3));
+            if !first_flag.load(Ordering::Relaxed) {
+                let _ = Command::new("/bin/kill").arg(pid.to_string()).status();
+            }
+        });
+    let reader = BufReader::new(stdout);
+    let mut saw_line = false;
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            break;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if !saw_line {
+            saw_line = true;
+            first.store(true, Ordering::Relaxed);
+        }
+        apply_stream_event(&line);
+    }
+    saw_line
+}
+
 fn run(args: &[&str]) -> Result<String, String> {
     let backend = backend().ok_or_else(|| "MediaRemote adapter not available".to_string())?;
     let mut cmd = match backend {
@@ -211,7 +456,13 @@ fn run(args: &[&str]) -> Result<String, String> {
 }
 
 /// `adapter_get` / `get --now`. `Ok(None)` means no now-playing item (`null`).
+/// Prefers the live `stream` cell when the supervisor has primed it so a
+/// poll never forks perl. One-shot `get --now` remains the startup primer
+/// and the debug `media-control` path.
 pub fn get_now_playing() -> Result<Option<AdapterTrack>, String> {
+    if let Some(cached) = latest_now_playing() {
+        return Ok(cached);
+    }
     let stdout = run(&["get", "--now"])?;
     parse_get_output(&stdout)
 }
@@ -442,6 +693,94 @@ mod tests {
     #[test]
     fn release_build_has_no_ambient_backend_fallback() {
         assert!(development_backend().is_none());
+    }
+
+    static STREAM_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn reset_stream() {
+        let mut state = stream_state().lock().unwrap_or_else(|e| e.into_inner());
+        *state = StreamState::fresh();
+        STREAM_CHANGED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn stream_full_replace_then_diff_merge() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        assert!(apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{
+                "title":"Helpless","artist":"The Staves","playing":true,
+                "duration":214.2,"elapsedTime":12,
+                "bundleIdentifier":"com.spotify.client"
+            }}"#
+        ));
+        let track = latest_now_playing().unwrap().unwrap();
+        assert_eq!(track.title.as_deref(), Some("Helpless"));
+        let elapsed = track.elapsed_time.unwrap();
+        assert!(elapsed >= 12.0 && elapsed < 12.2, "elapsed={elapsed}");
+        assert!(track.is_playing);
+
+        assert!(apply_stream_event(
+            r#"{"type":"data","diff":true,"payload":{"elapsedTime":40,"playing":false}}"#
+        ));
+        let track = latest_now_playing().unwrap().unwrap();
+        assert_eq!(track.title.as_deref(), Some("Helpless"));
+        assert_eq!(track.elapsed_time, Some(40.0));
+        assert!(!track.is_playing);
+        assert!(take_stream_changed());
+    }
+
+    #[test]
+    fn stream_empty_payload_is_idle() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"X","playing":true,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        apply_stream_event(r#"{"type":"data","diff":false,"payload":{}}"#);
+        assert!(latest_now_playing().unwrap().is_none());
+    }
+
+    #[test]
+    fn stream_diff_null_removes_key() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","artist":"B","playing":true,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        apply_stream_event(r#"{"type":"data","diff":true,"payload":{"title":null}}"#);
+        assert!(latest_now_playing().unwrap().is_none());
+    }
+
+    #[test]
+    fn elapsed_interpolates_while_playing() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","playing":true,"elapsedTime":10,"duration":100,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        let elapsed = latest_now_playing()
+            .unwrap()
+            .unwrap()
+            .elapsed_time
+            .unwrap();
+        assert!(elapsed >= 10.03, "elapsed={elapsed}");
+        assert!(elapsed < 11.0, "elapsed={elapsed}");
+    }
+
+    #[test]
+    fn elapsed_does_not_advance_when_paused() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","playing":false,"elapsedTime":10,"duration":100,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        assert_eq!(
+            latest_now_playing().unwrap().unwrap().elapsed_time,
+            Some(10.0)
+        );
     }
 
     #[test]

--- a/crates/nook-core/src/models.rs
+++ b/crates/nook-core/src/models.rs
@@ -41,4 +41,7 @@ pub struct NowPlayingData {
     /// Bundle identifier of that app, used to load its icon.
     #[serde(default)]
     pub bundle_id: Option<String>,
+    /// Apple Music editorialVideo HLS loop, when the catalog has one.
+    #[serde(default)]
+    pub motion_artwork_url: Option<String>,
 }

--- a/crates/nook-core/src/motion_artwork.rs
+++ b/crates/nook-core/src/motion_artwork.rs
@@ -1,0 +1,587 @@
+//! Apple Music editorialVideo lookup for animated album covers.
+//!
+//! MediaRemote only yields a static JPEG. Motion art lives on the catalog as
+//! `editorialVideo` HLS loops. The path is: iTunes Search (adamId) → AMP
+//! `extend=editorialVideo` with an anonymous web JWT scraped from
+//! music.apple.com. Everything here fails silent — a miss or a broken token
+//! leaves the static artwork in place. Lookups fire only on album change;
+//! hits and confirmed misses are cached so each album costs at most one
+//! search + one catalog call.
+
+use crate::database;
+use crate::utils::read_response_limited;
+use reqwest::Client;
+use serde::Deserialize;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+const ITUNES_SEARCH: &str = "https://itunes.apple.com/search";
+const AMP_HOST: &str = "https://amp-api.music.apple.com";
+const MUSIC_HOME: &str = "https://music.apple.com";
+const ORIGIN: &str = "https://music.apple.com";
+const CLIENT_ID: &str = concat!(
+    "openNook/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/prodBirdy/openNook)"
+);
+const BROWSER_UA: &str = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+    AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(8);
+const MAX_ITUNES_BYTES: usize = 256 * 1024;
+const MAX_AMP_BYTES: usize = 512 * 1024;
+const MAX_HTML_BYTES: usize = 2 * 1024 * 1024;
+const MAX_JS_BYTES: usize = 4 * 1024 * 1024;
+const NEGATIVE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
+const TOKEN_TTL: Duration = Duration::from_secs(12 * 60 * 60);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MotionArtwork {
+    pub m3u8_url: String,
+    pub preview_frame: Option<String>,
+}
+
+struct TokenCache {
+    token: String,
+    fetched_at: Instant,
+}
+
+fn token_slot() -> &'static Mutex<Option<TokenCache>> {
+    static SLOT: OnceLock<Mutex<Option<TokenCache>>> = OnceLock::new();
+    SLOT.get_or_init(|| Mutex::new(None))
+}
+
+fn http_client() -> Client {
+    static CLIENT: OnceLock<Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            Client::builder()
+                .timeout(REQUEST_TIMEOUT)
+                .user_agent(BROWSER_UA)
+                .build()
+                .unwrap_or_else(|_| Client::new())
+        })
+        .clone()
+}
+
+/// Resolve motion art for the current album. `None` on miss, mismatch, or
+/// any network/token failure.
+pub async fn lookup(artist: &str, album: &str, _title: Option<&str>) -> Option<MotionArtwork> {
+    if artist.trim().is_empty() || album.trim().is_empty() {
+        return None;
+    }
+    let key = cache_key(artist, album);
+    if let Some(cached) = cache_read(&key) {
+        return cached;
+    }
+    match lookup_uncached(artist, album).await {
+        LookupOutcome::Hit(art) => {
+            cache_write(&key, Some(&art));
+            Some(art)
+        }
+        LookupOutcome::Miss => {
+            cache_write(&key, None);
+            None
+        }
+        LookupOutcome::SoftFail => None,
+    }
+}
+
+enum LookupOutcome {
+    Hit(MotionArtwork),
+    Miss,
+    SoftFail,
+}
+
+async fn lookup_uncached(artist: &str, album: &str) -> LookupOutcome {
+    let Some(hit) = search_album(artist, album).await else {
+        return LookupOutcome::SoftFail;
+    };
+    let Some(hit) = hit else {
+        return LookupOutcome::Miss;
+    };
+    match fetch_editorial_video(&hit).await {
+        Ok(Some(art)) => LookupOutcome::Hit(art),
+        Ok(None) => LookupOutcome::Miss,
+        Err(err) => {
+            log::debug!("motion art catalog: {err}");
+            LookupOutcome::SoftFail
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AlbumHit {
+    collection_id: u64,
+    storefront: String,
+}
+
+async fn search_album(artist: &str, album: &str) -> Option<Option<AlbumHit>> {
+    let term = format!("{} {}", artist.trim(), album.trim());
+    let response = http_client()
+        .get(ITUNES_SEARCH)
+        .header(reqwest::header::USER_AGENT, CLIENT_ID)
+        .query(&[
+            ("term", term.as_str()),
+            ("entity", "album"),
+            ("media", "music"),
+            ("limit", "8"),
+        ])
+        .send()
+        .await
+        .ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let bytes = read_response_limited(response, MAX_ITUNES_BYTES)
+        .await
+        .ok()?;
+    let parsed: ItunesSearch = serde_json::from_slice(&bytes).ok()?;
+    Some(pick_album_hit(artist, album, &parsed))
+}
+
+#[derive(Debug, Deserialize)]
+struct ItunesSearch {
+    #[serde(default)]
+    results: Vec<ItunesAlbum>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ItunesAlbum {
+    collection_id: Option<u64>,
+    artist_name: Option<String>,
+    collection_name: Option<String>,
+    collection_view_url: Option<String>,
+}
+
+fn pick_album_hit(artist: &str, album: &str, search: &ItunesSearch) -> Option<AlbumHit> {
+    search.results.iter().find_map(|row| {
+        let id = row.collection_id?;
+        let got_artist = row.artist_name.as_deref().unwrap_or("");
+        let got_album = row.collection_name.as_deref().unwrap_or("");
+        if !album_names_match(artist, album, got_artist, got_album) {
+            return None;
+        }
+        Some(AlbumHit {
+            collection_id: id,
+            storefront: storefront_from_url(row.collection_view_url.as_deref())
+                .unwrap_or_else(|| "us".into()),
+        })
+    })
+}
+
+async fn fetch_editorial_video(hit: &AlbumHit) -> Result<Option<MotionArtwork>, String> {
+    let mut token = match cached_or_fresh_token().await {
+        Some(token) => token,
+        None => return Err("amp token unavailable".into()),
+    };
+    let url = format!(
+        "{AMP_HOST}/v1/catalog/{}/albums/{}?extend=editorialVideo",
+        hit.storefront, hit.collection_id
+    );
+    let mut response = amp_get(&url, &token).await?;
+    if response.status().as_u16() == 401 {
+        invalidate_token();
+        token = cached_or_fresh_token()
+            .await
+            .ok_or_else(|| "amp token refresh failed".to_string())?;
+        response = amp_get(&url, &token).await?;
+    }
+    if !response.status().is_success() {
+        return Err(format!("amp status {}", response.status()));
+    }
+    let bytes = read_response_limited(response, MAX_AMP_BYTES).await?;
+    let json: serde_json::Value =
+        serde_json::from_slice(&bytes).map_err(|err| err.to_string())?;
+    Ok(parse_editorial_video(&json))
+}
+
+async fn amp_get(url: &str, token: &str) -> Result<reqwest::Response, String> {
+    http_client()
+        .get(url)
+        .header(reqwest::header::AUTHORIZATION, format!("Bearer {token}"))
+        .header(reqwest::header::ORIGIN, ORIGIN)
+        .header(reqwest::header::REFERER, format!("{ORIGIN}/"))
+        .send()
+        .await
+        .map_err(|err| err.to_string())
+}
+
+async fn cached_or_fresh_token() -> Option<String> {
+    if let Some(token) = cached_token() {
+        return Some(token);
+    }
+    let token = scrape_amp_token().await?;
+    if let Ok(mut slot) = token_slot().lock() {
+        *slot = Some(TokenCache {
+            token: token.clone(),
+            fetched_at: Instant::now(),
+        });
+    }
+    Some(token)
+}
+
+fn cached_token() -> Option<String> {
+    let slot = token_slot().lock().ok()?;
+    let cached = slot.as_ref()?;
+    if cached.fetched_at.elapsed() > TOKEN_TTL {
+        return None;
+    }
+    if cached.token.is_empty() {
+        return None;
+    }
+    Some(cached.token.clone())
+}
+
+fn invalidate_token() {
+    if let Ok(mut slot) = token_slot().lock() {
+        *slot = None;
+    }
+}
+
+async fn scrape_amp_token() -> Option<String> {
+    let html = fetch_text(MUSIC_HOME, MAX_HTML_BYTES).await?;
+    let js_path = extract_index_js(&html)?;
+    let js_url = if js_path.starts_with("http") {
+        js_path
+    } else {
+        format!("{ORIGIN}{js_path}")
+    };
+    let js = fetch_text(&js_url, MAX_JS_BYTES).await?;
+    extract_jwt(&js)
+}
+
+async fn fetch_text(url: &str, max_bytes: usize) -> Option<String> {
+    let response = http_client().get(url).send().await.ok()?;
+    if !response.status().is_success() {
+        return None;
+    }
+    let bytes = read_response_limited(response, max_bytes).await.ok()?;
+    String::from_utf8(bytes).ok()
+}
+
+pub(crate) fn cache_key(artist: &str, album: &str) -> String {
+    format!(
+        "{}\u{1f}{}",
+        artist.trim().to_lowercase(),
+        album.trim().to_lowercase()
+    )
+}
+
+fn unix_now() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// `Some(Some(art))` hit, `Some(None)` valid negative, `None` miss/expired.
+fn cache_read(key: &str) -> Option<Option<MotionArtwork>> {
+    let Ok(conn) = database::get_connection() else {
+        return None;
+    };
+    let (m3u8, preview, hit, fetched_at): (Option<String>, Option<String>, i64, i64) = conn
+        .query_row(
+            "SELECT m3u8, preview, hit, fetched_at FROM motion_artwork WHERE cache_key = ?1",
+            [key],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .ok()?;
+    let now = unix_now();
+    if hit == 0 {
+        if now.saturating_sub(fetched_at) > NEGATIVE_TTL_SECS {
+            return None;
+        }
+        return Some(None);
+    }
+    let m3u8 = m3u8.filter(|url| !url.is_empty())?;
+    Some(Some(MotionArtwork {
+        m3u8_url: m3u8,
+        preview_frame: preview.filter(|url| !url.is_empty()),
+    }))
+}
+
+fn cache_write(key: &str, value: Option<&MotionArtwork>) {
+    let Ok(conn) = database::get_connection() else {
+        return;
+    };
+    let (m3u8, preview, hit) = match value {
+        Some(art) => (Some(art.m3u8_url.as_str()), art.preview_frame.as_deref(), 1i64),
+        None => (None, None, 0i64),
+    };
+    if let Err(err) = conn.execute(
+        "INSERT OR REPLACE INTO motion_artwork (cache_key, m3u8, preview, hit, fetched_at)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![key, m3u8, preview, hit, unix_now()],
+    ) {
+        log::debug!("motion art cache write: {err}");
+    }
+}
+
+pub(crate) fn normalize_name(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_alphanumeric() { c } else { ' ' })
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+pub(crate) fn names_match(want: &str, got: &str) -> bool {
+    let want = normalize_name(want);
+    let got = normalize_name(got);
+    if want.is_empty() || got.is_empty() {
+        return false;
+    }
+    want == got || want.contains(&got) || got.contains(&want)
+}
+
+pub(crate) fn album_names_match(
+    want_artist: &str,
+    want_album: &str,
+    got_artist: &str,
+    got_album: &str,
+) -> bool {
+    names_match(want_artist, got_artist) && names_match(want_album, got_album)
+}
+
+pub(crate) fn storefront_from_url(url: Option<&str>) -> Option<String> {
+    let url = url?;
+    let after = url.split("music.apple.com/").nth(1)?;
+    let code = after.split('/').next()?.to_ascii_lowercase();
+    if code.len() == 2 && code.bytes().all(|b| b.is_ascii_lowercase()) {
+        Some(code)
+    } else {
+        None
+    }
+}
+
+pub(crate) fn extract_index_js(html: &str) -> Option<String> {
+    let start = html.find("/assets/index")?;
+    let rest = &html[start..];
+    let end = rest.find(".js")? + 3;
+    let path = &rest[..end];
+    if path.len() < 16 || path.len() > 200 || path.contains(['<', '>', '"', '\'']) {
+        return None;
+    }
+    Some(path.to_string())
+}
+
+pub(crate) fn extract_jwt(haystack: &str) -> Option<String> {
+    let bytes = haystack.as_bytes();
+    let mut i = 0;
+    while i + 20 < bytes.len() {
+        if bytes[i] == b'e' && bytes[i + 1] == b'y' && bytes[i + 2] == b'J' {
+            let start = i;
+            let mut dots = 0;
+            let mut j = i;
+            while j < bytes.len() {
+                let c = bytes[j];
+                if c == b'.' {
+                    dots += 1;
+                    j += 1;
+                    continue;
+                }
+                if c.is_ascii_alphanumeric() || c == b'-' || c == b'_' {
+                    j += 1;
+                    continue;
+                }
+                break;
+            }
+            if dots == 2 && j.saturating_sub(start) > 40 {
+                return Some(haystack[start..j].to_string());
+            }
+            i = j.max(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+    None
+}
+
+pub(crate) fn parse_editorial_video(json: &serde_json::Value) -> Option<MotionArtwork> {
+    let ev = json
+        .get("data")?
+        .as_array()?
+        .first()?
+        .get("attributes")?
+        .get("editorialVideo")?;
+    for key in [
+        "motionSquareVideo1x1",
+        "motionDetailSquare",
+        "motionDetailTall",
+    ] {
+        let node = match ev.get(key) {
+            Some(node) => node,
+            None => continue,
+        };
+        let video = match node.get("video").and_then(|v| v.as_str()) {
+            Some(video) if video.contains(".m3u8") => video.to_string(),
+            _ => continue,
+        };
+        let preview = node
+            .get("previewFrame")
+            .and_then(|frame| frame.get("url").and_then(|v| v.as_str()).or(frame.as_str()))
+            .map(str::to_string);
+        return Some(MotionArtwork {
+            m3u8_url: video,
+            preview_frame: preview,
+        });
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_strips_punctuation_and_case() {
+        assert_eq!(normalize_name("Taylor Swift"), "taylor swift");
+        assert_eq!(normalize_name("  Folklore (Deluxe) "), "folklore deluxe");
+        assert_eq!(normalize_name("A$AP Rocky"), "a ap rocky");
+    }
+
+    #[test]
+    fn album_match_requires_both_fields() {
+        assert!(album_names_match(
+            "Taylor Swift",
+            "Folklore",
+            "Taylor Swift",
+            "folklore (deluxe edition)"
+        ));
+        assert!(!album_names_match(
+            "Taylor Swift",
+            "Folklore",
+            "Taylor Swift",
+            "Lover"
+        ));
+        assert!(!album_names_match(
+            "Taylor Swift",
+            "Folklore",
+            "Bon Iver",
+            "Folklore"
+        ));
+        assert!(!album_names_match("", "Folklore", "Taylor Swift", "Folklore"));
+    }
+
+    #[test]
+    fn storefront_reads_collection_url() {
+        assert_eq!(
+            storefront_from_url(Some(
+                "https://music.apple.com/gb/album/folklore/1524801260"
+            ))
+            .as_deref(),
+            Some("gb")
+        );
+        assert_eq!(
+            storefront_from_url(Some(
+                "https://music.apple.com/us/album/something/1?uo=4"
+            ))
+            .as_deref(),
+            Some("us")
+        );
+        assert_eq!(storefront_from_url(Some("https://example.com/x")), None);
+    }
+
+    #[test]
+    fn jwt_is_pulled_from_a_js_bundle_snippet() {
+        let js = r#"const t="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0In0.abc_def-0123456789","other""#;
+        let token = extract_jwt(js).expect("jwt");
+        assert!(token.starts_with("eyJ"));
+        assert_eq!(token.matches('.').count(), 2);
+        assert!(extract_jwt("no token here").is_none());
+        assert!(extract_jwt("eyJshort").is_none());
+    }
+
+    #[test]
+    fn index_js_path_is_pulled_from_html() {
+        let html = r#"<script crossorigin src="/assets/index-a1b2c3d4.js"></script>"#;
+        assert_eq!(
+            extract_index_js(html).as_deref(),
+            Some("/assets/index-a1b2c3d4.js")
+        );
+        assert!(extract_index_js("<html></html>").is_none());
+    }
+
+    #[test]
+    fn editorial_video_prefers_square_hls() {
+        let json = serde_json::json!({
+            "data": [{
+                "attributes": {
+                    "editorialVideo": {
+                        "motionDetailTall": { "video": "https://x/tall.m3u8" },
+                        "motionSquareVideo1x1": {
+                            "video": "https://x/square.m3u8",
+                            "previewFrame": { "url": "https://x/frame.jpg" }
+                        }
+                    }
+                }
+            }]
+        });
+        let art = parse_editorial_video(&json).expect("video");
+        assert_eq!(art.m3u8_url, "https://x/square.m3u8");
+        assert_eq!(art.preview_frame.as_deref(), Some("https://x/frame.jpg"));
+    }
+
+    #[test]
+    fn editorial_video_missing_is_none() {
+        let json = serde_json::json!({ "data": [{ "attributes": {} }] });
+        assert!(parse_editorial_video(&json).is_none());
+        let empty = serde_json::json!({ "data": [] });
+        assert!(parse_editorial_video(&empty).is_none());
+    }
+
+    #[test]
+    fn itunes_pick_rejects_fuzzy_wrong_album() {
+        let search = ItunesSearch {
+            results: vec![ItunesAlbum {
+                collection_id: Some(99),
+                artist_name: Some("Taylor Swift".into()),
+                collection_name: Some("Lover".into()),
+                collection_view_url: Some("https://music.apple.com/us/album/lover/1".into()),
+            }],
+        };
+        assert!(pick_album_hit("Taylor Swift", "Folklore", &search).is_none());
+    }
+
+    #[test]
+    fn itunes_pick_accepts_verified_match() {
+        let search = ItunesSearch {
+            results: vec![ItunesAlbum {
+                collection_id: Some(1524801260),
+                artist_name: Some("Taylor Swift".into()),
+                collection_name: Some("folklore".into()),
+                collection_view_url: Some(
+                    "https://music.apple.com/us/album/folklore/1524801260".into(),
+                ),
+            }],
+        };
+        let hit = pick_album_hit("Taylor Swift", "Folklore", &search).unwrap();
+        assert_eq!(hit.collection_id, 1524801260);
+        assert_eq!(hit.storefront, "us");
+    }
+
+    #[test]
+    fn cache_key_is_stable_and_case_insensitive() {
+        assert_eq!(
+            cache_key("Taylor Swift", "Folklore"),
+            cache_key("taylor swift", " folklore ")
+        );
+        assert_ne!(
+            cache_key("Taylor Swift", "Folklore"),
+            cache_key("Taylor Swift", "Lover")
+        );
+    }
+
+    #[test]
+    fn lookup_without_artist_or_album_is_none() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        assert!(rt.block_on(lookup("", "Folklore", None)).is_none());
+        assert!(rt.block_on(lookup("Taylor Swift", "", None)).is_none());
+    }
+}

--- a/crates/nook-core/src/mouse.rs
+++ b/crates/nook-core/src/mouse.rs
@@ -185,7 +185,11 @@ fn contains((x0, x1, y0, y1): (f64, f64, f64, f64), x: f64, y: f64) -> bool {
     x >= x0 && x <= x1 && y >= y0 && y <= y1
 }
 
-/// Sample the cursor off the UI thread. Safe to call more than once.
+/// Sample the cursor. On macOS this is a 250 ms backstop — NSEvent global
+/// and local monitors (installed on the main thread from `platform`) write
+/// the same atomics on every move/drag. Monitors can drop during secure
+/// input or some full-screen games; the slow poll is how hover still exits.
+/// Windows/Linux keep the tighter poll (no AppKit monitors).
 pub fn start_polling() {
     if POLL_STARTED.swap(true, Ordering::SeqCst) {
         return;
@@ -195,20 +199,33 @@ pub fn start_polling() {
         .name("nook-mouse".into())
         .spawn(|| loop {
             sample_now();
-            let inside = {
-                let (mx, my) = current_mouse_logical();
-                hit_test(mx, my)
-            };
-            let ms = if inside || DRAG_ACTIVE.load(Ordering::Relaxed) {
-                20
-            } else {
-                33
-            };
+            let ms = poll_interval_ms();
             std::thread::sleep(std::time::Duration::from_millis(ms));
         });
 }
 
-fn sample_now() {
+fn poll_interval_ms() -> u64 {
+    #[cfg(target_os = "macos")]
+    {
+        250
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let inside = {
+            let (mx, my) = current_mouse_logical();
+            hit_test(mx, my)
+        };
+        if inside || DRAG_ACTIVE.load(Ordering::Relaxed) {
+            20
+        } else {
+            33
+        }
+    }
+}
+
+/// Read cursor + drag into the atomics. Safe from NSEvent monitor handlers
+/// (main thread) and from the safety-poll thread.
+pub fn sample_now() {
     let (x, y) = read_mouse_logical();
     MOUSE_X.store(x.to_bits(), Ordering::Relaxed);
     MOUSE_Y.store(y.to_bits(), Ordering::Relaxed);

--- a/crates/nook-core/src/occupancy.rs
+++ b/crates/nook-core/src/occupancy.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Refresh at most this often — `CGWindowListCopyWindowInfo` is not cheap
-/// enough for the 20 ms mouse poll.
-const CACHE_MS: u64 = 250;
+/// enough for the mouse path. App-activate notifications invalidate sooner.
+const CACHE_MS: u64 = 1000;
 
 static CACHE: AtomicBool = AtomicBool::new(false);
 static LAST_MS: AtomicU64 = AtomicU64::new(0);
@@ -42,9 +42,19 @@ pub fn window_fills_display(window: ScreenRect, screen: ScreenRect, visible: Scr
     window.covers(screen, TOL) || window.covers(visible, TOL)
 }
 
+/// Drop the occupancy cache so the next sample talks to the window server.
+/// Driven from `NSWorkspaceDidActivateApplicationNotification`.
+pub fn invalidate() {
+    LAST_MS.store(0, Ordering::Relaxed);
+}
+
 /// Cached sample of [`query_frontmost_fills`]. Safe to call from the island
-/// poll loop.
+/// poll loop. No-ops when hide-when-maximized is off so the window-list
+/// walk never runs for users who disabled the setting.
 pub fn frontmost_fills_display() -> bool {
+    if !crate::settings::get_app_settings().hide_when_maximized {
+        return false;
+    }
     let now = unix_ms();
     let last = LAST_MS.load(Ordering::Relaxed);
     if now.saturating_sub(last) < CACHE_MS {
@@ -297,5 +307,15 @@ mod tests {
             screen,
             visible
         ));
+    }
+
+    #[test]
+    fn hide_when_maximized_off_is_a_cheap_false() {
+        invalidate();
+        assert!(
+            !crate::settings::get_app_settings().hide_when_maximized,
+            "default settings keep the occupancy walk off"
+        );
+        assert!(!frontmost_fills_display());
     }
 }

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -167,6 +167,12 @@ pub struct AppSettings {
     /// Per-widget widths in Nook cells. Missing entries use [`WidgetModule::default_cells`].
     #[serde(default)]
     pub widget_widths: Vec<(WidgetModule, u8)>,
+    /// Network lookup for Apple Music editorialVideo loops. Opt-in; ToS-gray.
+    #[serde(default)]
+    pub animated_album_art: bool,
+    /// Local dominant-color glow behind the expanded media card.
+    #[serde(default = "default_true")]
+    pub ambient_art_glow: bool,
     #[serde(default)]
     pub window: WindowSettings,
 }
@@ -239,6 +245,8 @@ impl Default for AppSettings {
             hide_when_maximized: false,
             island_color: None,
             widget_widths: Vec::new(),
+            animated_album_art: false,
+            ambient_art_glow: true,
             window: WindowSettings::default(),
         }
     }
@@ -617,6 +625,17 @@ mod tests {
         assert_eq!(parsed.island_y, 0.0);
         assert!(!parsed.hide_when_maximized);
         assert_eq!(parsed.island_color, None);
+        assert!(!parsed.animated_album_art);
+        assert!(parsed.ambient_art_glow);
+    }
+
+    #[test]
+    fn motion_art_toggles_default_network_off_aura_on() {
+        let parsed: AppSettings = serde_json::from_str("{}").unwrap();
+        assert!(!parsed.animated_album_art);
+        assert!(parsed.ambient_art_glow);
+        assert_eq!(parsed.animated_album_art, AppSettings::default().animated_album_art);
+        assert_eq!(parsed.ambient_art_glow, AppSettings::default().ambient_art_glow);
     }
 
     #[test]

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -99,7 +99,7 @@ impl Island {
                     &mut kids,
                     cell_pane(
                         self.settings.cells_for(module),
-                        nook_media_pane(&self.now_playing, cx),
+                        nook_media_pane(self, cx),
                     ),
                 ),
                 WidgetModule::Calendar if self.settings.show_calendar => add(

--- a/crates/nook/src/island/media.rs
+++ b/crates/nook/src/island/media.rs
@@ -9,8 +9,8 @@ use super::Island;
 use crate::icons::lucide_color;
 use crate::theme;
 use gpui::{
-    div, img, linear_color_stop, linear_gradient, prelude::*, px, relative, rgb, rgba, AnyElement,
-    Context, CursorStyle, Image, MouseButton, MouseDownEvent, Rgba, SharedString,
+    canvas, div, img, linear_color_stop, linear_gradient, prelude::*, px, relative, rgb, rgba,
+    AnyElement, Context, CursorStyle, Image, MouseButton, MouseDownEvent, Rgba, SharedString,
 };
 use nook_core::models::NowPlayingData;
 use std::sync::{Mutex, OnceLock};
@@ -236,16 +236,18 @@ pub(super) fn visualizer(levels: &[f64], playing: bool, color: Option<Rgba>) -> 
 }
 
 const NOOK_ART: f32 = 84.0;
-const NOOK_ART_RADIUS: f32 = 14.0;
+pub(crate) const NOOK_ART_RADIUS: f32 = 14.0;
 const APP_BADGE: f32 = 22.0;
 const APP_BADGE_RADIUS: f32 = 5.0;
 
 /// Horizontal Now Playing strip for the Nook tab (art + metadata + transport).
-pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> impl IntoElement {
+pub(crate) fn nook_media_pane(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let np = &island.now_playing;
     let title = np.title.clone().unwrap_or_else(|| "Unknown Title".into());
     let artist = np.artist.clone().unwrap_or_else(|| "Unknown Artist".into());
     let album = np.album.clone().filter(|s| !s.is_empty());
     let playing = np.is_playing;
+    let aura = media_aura(island);
     let elapsed = np.elapsed_time.unwrap_or(0.0);
     let duration = np.duration.unwrap_or(0.0);
     let progress = if duration > 0.0 {
@@ -261,9 +263,11 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
 
     div()
         .id("nook-media")
+        .relative()
         .w_full()
         .h_full()
         .overflow_hidden()
+        .when_some(aura, |d, aura| d.child(aura))
         .flex()
         .items_center()
         .gap(px(14.))
@@ -292,7 +296,21 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                                 .justify_center()
                                 .child(lucide_color("music", 28.0, rgba(0xffffff66)))
                                 .into_any_element()
-                        })),
+                        }))
+                        .child(
+                            canvas(
+                                |bounds, _, _| {
+                                    let x: f32 = bounds.origin.x.into();
+                                    let y: f32 = bounds.origin.y.into();
+                                    let w: f32 = bounds.size.width.into();
+                                    let h: f32 = bounds.size.height.into();
+                                    report_art_bounds(x, y, w, h);
+                                },
+                                |_, _, _, _| {},
+                            )
+                            .absolute()
+                            .inset_0(),
+                        ),
                 )
                 .child(
                     div()
@@ -846,6 +864,147 @@ fn sample_dominant_color(b64: &str) -> Option<Rgba> {
     })
 }
 
+pub(crate) fn art_palette(artwork_base64: Option<&str>) -> Option<[Rgba; 3]> {
+    let b64 = artwork_base64?;
+    use std::hash::{DefaultHasher, Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    b64.hash(&mut hasher);
+    let key = hasher.finish();
+    static CACHE: OnceLock<Mutex<(u64, Option<[Rgba; 3]>)>> = OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new((0, None)));
+    if let Ok(guard) = cache.lock() {
+        if guard.0 == key {
+            return guard.1;
+        }
+    }
+    let palette = sample_palette(b64);
+    if let Ok(mut guard) = cache.lock() {
+        *guard = (key, palette);
+    }
+    palette
+}
+
+fn sample_palette(b64: &str) -> Option<[Rgba; 3]> {
+    use image::GenericImageView;
+    use std::collections::HashMap;
+
+    let bytes = artwork_bytes(b64)?;
+    let img = image::load_from_memory(&bytes).ok()?.thumbnail(32, 32);
+    let mut buckets: HashMap<(u8, u8, u8), u32> = HashMap::new();
+    for (_, _, px) in img.pixels() {
+        let [r, g, b, a] = px.0;
+        if a < 200 {
+            continue;
+        }
+        let brightness = (r as u16 + g as u16 + b as u16) / 3;
+        if !(16..=240).contains(&brightness) {
+            continue;
+        }
+        *buckets.entry((r >> 4, g >> 4, b >> 4)).or_insert(0) += 1;
+    }
+    if buckets.is_empty() {
+        return sample_dominant_color(b64).map(|c| [c, shift_color(c, 0.08), shift_color(c, 0.16)]);
+    }
+    let mut ranked: Vec<_> = buckets.into_iter().collect();
+    ranked.sort_by(|a, b| b.1.cmp(&a.1));
+    let mut picked: Vec<Rgba> = Vec::new();
+    for ((r, g, b), _) in ranked {
+        let color = Rgba {
+            r: (r as f32 + 0.5) * 16.0 / 255.0,
+            g: (g as f32 + 0.5) * 16.0 / 255.0,
+            b: (b as f32 + 0.5) * 16.0 / 255.0,
+            a: 1.0,
+        };
+        if picked.iter().all(|p| color_dist(*p, color) > 0.18) {
+            picked.push(color);
+        }
+        if picked.len() == 3 {
+            break;
+        }
+    }
+    while picked.len() < 3 {
+        let base = picked.first().copied().or_else(|| sample_dominant_color(b64))?;
+        picked.push(shift_color(base, 0.08 * picked.len() as f32));
+    }
+    Some([picked[0], picked[1], picked[2]])
+}
+
+fn shift_color(color: Rgba, amount: f32) -> Rgba {
+    Rgba {
+        r: (color.r + amount).clamp(0.0, 1.0),
+        g: (color.g + amount * 0.5).clamp(0.0, 1.0),
+        b: (color.b + amount * 0.75).clamp(0.0, 1.0),
+        a: 1.0,
+    }
+}
+
+fn color_dist(a: Rgba, b: Rgba) -> f32 {
+    let dr = a.r - b.r;
+    let dg = a.g - b.g;
+    let db = a.b - b.b;
+    (dr * dr + dg * dg + db * db).sqrt()
+}
+
+fn media_aura(island: &Island) -> Option<AnyElement> {
+    if !island.settings.ambient_art_glow || island.reduce_motion {
+        return None;
+    }
+    let palette = island.aura_palette?;
+    let t = if island.now_playing.is_playing {
+        island.aura_t
+    } else {
+        0.0
+    };
+    let mut layer = div()
+        .absolute()
+        .inset_0()
+        .overflow_hidden()
+        .opacity(0.9);
+    for (i, color) in palette.iter().enumerate() {
+        let (dx, dy) = crate::motion::aura_blob_offset(i, t);
+        let faded = Rgba {
+            r: color.r,
+            g: color.g,
+            b: color.b,
+            a: 0.32,
+        };
+        layer = layer.child(
+            div()
+                .absolute()
+                .left(px(8.0 + dx))
+                .top(px(-16.0 + dy))
+                .size(px(140.0))
+                .rounded_full()
+                .bg(faded),
+        );
+    }
+    Some(layer.into_any_element())
+}
+
+static ART_BOUNDS: OnceLock<Mutex<(u64, f32, f32, f32, f32)>> = OnceLock::new();
+
+fn report_art_bounds(x: f32, y: f32, w: f32, h: f32) {
+    let cache = ART_BOUNDS.get_or_init(|| Mutex::new((0, 0.0, 0.0, 0.0, 0.0)));
+    let Ok(mut guard) = cache.lock() else {
+        return;
+    };
+    let (gen, ox, oy, ow, oh) = *guard;
+    if (ox - x).abs() < 0.5 && (oy - y).abs() < 0.5 && (ow - w).abs() < 0.5 && (oh - h).abs() < 0.5 {
+        return;
+    }
+    *guard = (gen.wrapping_add(1), x, y, w, h);
+}
+
+pub(crate) fn take_art_bounds(seen: &mut u64) -> Option<(f32, f32, f32, f32)> {
+    let cache = ART_BOUNDS.get_or_init(|| Mutex::new((0, 0.0, 0.0, 0.0, 0.0)));
+    let guard = cache.lock().ok()?;
+    if guard.0 == *seen || guard.0 == 0 {
+        return None;
+    }
+    *seen = guard.0;
+    Some((guard.1, guard.2, guard.3, guard.4))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -914,5 +1073,47 @@ mod tests {
         assert_eq!(gpui_format(&jpeg), gpui::ImageFormat::Jpeg);
         let png = artwork_bytes(&encode_rgba(8, 8, image::ImageFormat::Png)).unwrap();
         assert_eq!(gpui_format(&png), gpui::ImageFormat::Png);
+    }
+
+    fn encode_two_tone() -> String {
+        use base64::Engine;
+        use std::io::Cursor;
+        let mut img = image::RgbaImage::new(16, 16);
+        for (x, y, px) in img.enumerate_pixels_mut() {
+            *px = if x < 8 {
+                image::Rgba([0x20, 0x40, 0xC0, 0xff])
+            } else if y < 8 {
+                image::Rgba([0xC0, 0x30, 0x20, 0xff])
+            } else {
+                image::Rgba([0x20, 0xB0, 0x40, 0xff])
+            };
+        }
+        let mut encoded = Cursor::new(Vec::new());
+        img.write_to(&mut encoded, image::ImageFormat::Png).unwrap();
+        base64::engine::general_purpose::STANDARD.encode(encoded.into_inner())
+    }
+
+    #[test]
+    fn artwork_palette_returns_three_distinct_colors() {
+        let palette = art_palette(Some(&encode_two_tone())).expect("palette");
+        assert_eq!(palette.len(), 3);
+        assert!(color_dist(palette[0], palette[1]) > 0.1);
+        assert!(art_palette(None).is_none());
+    }
+
+    #[test]
+    fn art_bounds_only_surface_when_the_rect_moves() {
+        let mut seen = 0;
+        assert!(take_art_bounds(&mut seen).is_none());
+        report_art_bounds(10.0, 20.0, 84.0, 84.0);
+        let first = take_art_bounds(&mut seen).expect("first report");
+        assert_eq!(first, (10.0, 20.0, 84.0, 84.0));
+        report_art_bounds(10.2, 20.1, 84.0, 84.0);
+        assert!(take_art_bounds(&mut seen).is_none());
+        report_art_bounds(40.0, 20.0, 84.0, 84.0);
+        assert_eq!(
+            take_art_bounds(&mut seen).expect("moved"),
+            (40.0, 20.0, 84.0, 84.0)
+        );
     }
 }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -68,6 +68,16 @@ pub struct Island {
     pub tab: Tab,
     pub now_playing: NowPlayingData,
     pub visualizer_color: Option<gpui::Rgba>,
+    /// 2–3 dominant artwork colors for the ambient media glow.
+    pub aura_palette: Option<[gpui::Rgba; 3]>,
+    /// Seconds of aura drift, only advanced while the glow is on screen.
+    aura_t: f32,
+    last_aura_frame: Instant,
+    /// Album we last asked the catalog about (`artist`, `album`).
+    motion_art_key: Option<(String, String)>,
+    motion_art_bounds: Option<(f32, f32, f32, f32)>,
+    motion_art_bounds_gen: u64,
+    last_motion_spec: Option<platform::MotionArtSpec>,
     pub files: Vec<FileTrayItem>,
     pub events: Vec<CalendarEvent>,
     pub reminders: Vec<Reminder>,
@@ -198,6 +208,13 @@ impl Island {
             tab: Tab::Widgets,
             now_playing: NowPlayingData::default(),
             visualizer_color: None,
+            aura_palette: None,
+            aura_t: 0.0,
+            last_aura_frame: Instant::now(),
+            motion_art_key: None,
+            motion_art_bounds: None,
+            motion_art_bounds_gen: 0,
+            last_motion_spec: None,
             files,
             events: Vec::new(),
             reminders: Vec::new(),
@@ -339,6 +356,7 @@ impl Island {
                         } else {
                             this.settings = settings;
                         }
+                        this.sync_motion_art_from_settings(cx);
                         dirty = true;
                     }
                     if this.repositioning {
@@ -489,6 +507,19 @@ impl Island {
                         this.pixel_t = now.duration_since(this.pixel_origin).as_secs_f32();
                         dirty = true;
                     }
+                    if this.aura_should_animate()
+                        && now.duration_since(this.last_aura_frame)
+                            >= Duration::from_millis(33)
+                    {
+                        this.last_aura_frame = now;
+                        this.aura_t = now.duration_since(this.pixel_origin).as_secs_f32();
+                        dirty = true;
+                    }
+                    if let Some(rect) = media::take_art_bounds(&mut this.motion_art_bounds_gen)
+                    {
+                        this.motion_art_bounds = Some(rect);
+                    }
+                    this.apply_motion_art_layer();
                     if this.mirror_on {
                         if let Some((gen, bgra)) = platform::mirror_frame(this.mirror_gen) {
                             this.mirror_gen = gen;
@@ -551,6 +582,9 @@ impl Island {
                         || this.now_playing.elapsed_time != playing.elapsed_time
                         || this.now_playing.app_name != playing.app_name
                         || this.now_playing.bundle_id != playing.bundle_id;
+                    let album_changed = this.now_playing.artist != playing.artist
+                        || this.now_playing.album != playing.album;
+                    let art_changed = this.now_playing.artwork_base64 != playing.artwork_base64;
                     this.now_playing.title = playing.title;
                     this.now_playing.artist = playing.artist;
                     this.now_playing.album = playing.album;
@@ -563,10 +597,21 @@ impl Island {
                     this.visualizer_color = media::visualizer_color_from_art(
                         this.now_playing.artwork_base64.as_deref(),
                     );
+                    if art_changed || this.aura_palette.is_none() {
+                        this.aura_palette = media::art_palette(
+                            this.now_playing.artwork_base64.as_deref(),
+                        );
+                    }
+                    if album_changed {
+                        this.motion_art_key = None;
+                        this.now_playing.motion_artwork_url = None;
+                        this.request_motion_art(cx);
+                    }
+                    this.apply_motion_art_layer();
                     if !was_media && this.has_media() {
                         this.preferred = Some(CompactMode::Media);
                     }
-                    if changed {
+                    if changed || album_changed {
                         cx.notify();
                     }
                     this.has_media() && this.now_playing.is_playing
@@ -737,6 +782,116 @@ impl Island {
             && (self.now_playing.is_playing
                 || self.now_playing.title.is_some()
                 || self.now_playing.artist.is_some())
+    }
+
+    fn motion_art_album_key(&self) -> (String, String) {
+        (
+            self.now_playing.artist.clone().unwrap_or_default(),
+            self.now_playing.album.clone().unwrap_or_default(),
+        )
+    }
+
+    fn aura_should_animate(&self) -> bool {
+        self.expanded
+            && self.tab == Tab::Widgets
+            && self.settings.show_media
+            && self.settings.ambient_art_glow
+            && self.now_playing.is_playing
+            && !self.reduce_motion
+            && self.aura_palette.is_some()
+            && !self.suppressed
+    }
+
+    fn sync_motion_art_from_settings(&mut self, cx: &mut Context<Self>) {
+        if !self.settings.animated_album_art || !self.settings.show_media {
+            self.motion_art_key = None;
+            self.now_playing.motion_artwork_url = None;
+            self.apply_motion_art_layer();
+            return;
+        }
+        if self.motion_art_key.is_none() {
+            self.request_motion_art(cx);
+        }
+        self.apply_motion_art_layer();
+    }
+
+    fn request_motion_art(&mut self, cx: &mut Context<Self>) {
+        if !self.settings.animated_album_art || !self.settings.show_media {
+            return;
+        }
+        let key = self.motion_art_album_key();
+        if key.0.trim().is_empty() || key.1.trim().is_empty() {
+            self.now_playing.motion_artwork_url = None;
+            return;
+        }
+        if self.motion_art_key.as_ref() == Some(&key) {
+            return;
+        }
+        self.motion_art_key = Some(key.clone());
+        self.now_playing.motion_artwork_url = None;
+        let lookup_key = key.clone();
+        cx.spawn(async move |this, cx| {
+            let fetched = cx
+                .background_executor()
+                .spawn({
+                    let lookup_key = lookup_key.clone();
+                    async move {
+                        nook_core::runtime().block_on(nook_core::motion_artwork::lookup(
+                            &lookup_key.0,
+                            &lookup_key.1,
+                            None,
+                        ))
+                    }
+                })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                if this.motion_art_key.as_ref() != Some(&lookup_key) {
+                    return;
+                }
+                this.now_playing.motion_artwork_url = fetched.map(|art| art.m3u8_url);
+                this.apply_motion_art_layer();
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    fn apply_motion_art_layer(&mut self) {
+        let spec = self.motion_art_spec();
+        if spec == self.last_motion_spec {
+            return;
+        }
+        self.last_motion_spec = spec.clone();
+        match spec.as_ref() {
+            Some(spec) => platform::sync_motion_art(Some(spec)),
+            None => platform::hide_motion_art(),
+        }
+    }
+
+    fn motion_art_spec(&self) -> Option<platform::MotionArtSpec> {
+        if self.reduce_motion
+            || !self.expanded
+            || self.tab != Tab::Widgets
+            || self.suppressed
+            || !self.settings.animated_album_art
+            || !self.settings.show_media
+        {
+            return None;
+        }
+        let url = self.now_playing.motion_artwork_url.clone()?;
+        let (x, y, w, h) = self.motion_art_bounds?;
+        if w < 8.0 || h < 8.0 {
+            return None;
+        }
+        Some(platform::MotionArtSpec {
+            url,
+            x: x as f64,
+            y: y as f64,
+            w: w as f64,
+            h: h as f64,
+            radius: media::NOOK_ART_RADIUS as f64,
+            playing: self.now_playing.is_playing,
+        })
     }
 
     pub(crate) fn running_timer(&self) -> Option<&Timer> {
@@ -1443,6 +1598,13 @@ mod tests {
             tab: Tab::Widgets,
             now_playing: NowPlayingData::default(),
             visualizer_color: None,
+            aura_palette: None,
+            aura_t: 0.0,
+            last_aura_frame: Instant::now(),
+            motion_art_key: None,
+            motion_art_bounds: None,
+            motion_art_bounds_gen: 0,
+            last_motion_spec: None,
             files: Vec::new(),
             events: Vec::new(),
             reminders: Vec::new(),
@@ -2113,5 +2275,74 @@ mod tests {
         assert!(island.blur > 0.5, "crossfade left the content sharp");
         let (dx, dy) = island.blur_offset().expect("crossfade needs a smear");
         assert!(dx > dy, "a still island should smear along its long axis");
+    }
+
+    #[test]
+    fn motion_art_layer_stays_off_when_collapsed_or_paused() {
+        let mut island = test_island();
+        island.settings.animated_album_art = true;
+        island.now_playing.artist = Some("Taylor Swift".into());
+        island.now_playing.album = Some("Folklore".into());
+        island.now_playing.is_playing = true;
+        island.now_playing.motion_artwork_url = Some("https://example.com/a.m3u8".into());
+        island.motion_art_bounds = Some((40.0, 20.0, 84.0, 84.0));
+        assert!(island.motion_art_spec().is_none(), "collapsed hides the layer");
+
+        island.expanded = true;
+        let spec = island.motion_art_spec().expect("expanded playing");
+        assert_eq!(spec.url, "https://example.com/a.m3u8");
+        assert!(spec.playing);
+        assert_eq!(spec.radius, media::NOOK_ART_RADIUS as f64);
+
+        island.now_playing.is_playing = false;
+        assert!(
+            !island.motion_art_spec().expect("paused still has a spec").playing,
+            "pause hides via playing=false"
+        );
+
+        island.now_playing.is_playing = true;
+        island.reduce_motion = true;
+        assert!(island.motion_art_spec().is_none());
+        island.reduce_motion = false;
+        island.suppressed = true;
+        assert!(island.motion_art_spec().is_none());
+    }
+
+    #[test]
+    fn aura_only_animates_while_expanded_and_playing() {
+        let mut island = test_island();
+        island.settings.ambient_art_glow = true;
+        island.aura_palette = Some([
+            gpui::Rgba {
+                r: 0.2,
+                g: 0.3,
+                b: 0.8,
+                a: 1.0,
+            },
+            gpui::Rgba {
+                r: 0.8,
+                g: 0.2,
+                b: 0.2,
+                a: 1.0,
+            },
+            gpui::Rgba {
+                r: 0.2,
+                g: 0.7,
+                b: 0.3,
+                a: 1.0,
+            },
+        ]);
+        island.now_playing.is_playing = true;
+        assert!(!island.aura_should_animate());
+        island.expanded = true;
+        assert!(island.aura_should_animate());
+        island.now_playing.is_playing = false;
+        assert!(!island.aura_should_animate());
+        island.now_playing.is_playing = true;
+        island.reduce_motion = true;
+        assert!(!island.aura_should_animate());
+        island.reduce_motion = false;
+        island.settings.ambient_art_glow = false;
+        assert!(!island.aura_should_animate());
     }
 }

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -286,14 +286,18 @@ impl Island {
                 platform::apply_island_chrome();
             }
             platform::request_pin();
+            // Park until a screen/space notification (or a 30s backstop).
+            // The previous 250 ms poll was an idle wakeup; handlers already
+            // pin on the main thread, this only covers a missed first pin.
             loop {
-                cx.background_executor()
-                    .timer(Duration::from_millis(250))
+                let needed = cx
+                    .background_executor()
+                    .spawn(async { platform::wait_pin_needed(Duration::from_secs(30)) })
                     .await;
                 if this.update(cx, |_, _| ()).is_err() {
                     break;
                 }
-                if platform::take_pin_needed() {
+                if needed || platform::take_pin_needed() {
                     platform::pin_island_windows();
                 }
             }
@@ -573,22 +577,19 @@ impl Island {
                 // Stream-backed adapter reads are a cheap lock; cadence is
                 // for interpolated elapsed (1s while playing) and the
                 // AppleScript fallback (5s idle). Distributed-notification
-                // observers and the MediaRemote stream flip `take_media_event`
-                // so the wait wakes instantly on real changes.
+                // observers and the MediaRemote stream poke `note_media_event`
+                // so this parks until a real change instead of slicing 250 ms.
                 let cadence = if is_playing {
                     Duration::from_secs(1)
                 } else {
                     Duration::from_secs(5)
                 };
-                let slice = Duration::from_millis(250);
-                let mut waited = Duration::ZERO;
-                loop {
-                    cx.background_executor().timer(slice).await;
-                    waited += slice;
-                    if nook_core::audio::take_media_event() || waited >= cadence {
-                        break;
-                    }
-                }
+                cx.background_executor()
+                    .spawn(async move {
+                        nook_core::runtime()
+                            .block_on(nook_core::audio::wait_media_or_timeout(cadence))
+                    })
+                    .await;
             }
         })
         .detach();

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -263,6 +263,7 @@ impl Island {
         this.anim_h.set(h);
 
         platform::install_media_observers();
+        platform::install_mouse_monitors();
         nook_core::runtime().spawn(async {
             let _ = nook_core::calendar::request_calendar_access().await;
         });
@@ -284,12 +285,17 @@ impl Island {
                     .await;
                 platform::apply_island_chrome();
             }
+            platform::request_pin();
             loop {
-                cx.background_executor().timer(Duration::from_secs(2)).await;
+                cx.background_executor()
+                    .timer(Duration::from_millis(250))
+                    .await;
                 if this.update(cx, |_, _| ()).is_err() {
                     break;
                 }
-                platform::pin_island_windows();
+                if platform::take_pin_needed() {
+                    platform::pin_island_windows();
+                }
             }
         })
         .detach();
@@ -564,12 +570,11 @@ impl Island {
                 let Ok(is_playing) = alive else {
                     break;
                 };
-                // Every poll spawns an osascript/perl child, so cadence is
-                // the battery cost that matters: 1s while playing (the
-                // elapsed display ticks in whole seconds anyway), 5s
-                // otherwise. The distributed-notification observers wake the
-                // wait instantly on Spotify/Music play/pause/track changes —
-                // the slow cadence only gates Safari/YouTube pickup.
+                // Stream-backed adapter reads are a cheap lock; cadence is
+                // for interpolated elapsed (1s while playing) and the
+                // AppleScript fallback (5s idle). Distributed-notification
+                // observers and the MediaRemote stream flip `take_media_event`
+                // so the wait wakes instantly on real changes.
                 let cadence = if is_playing {
                     Duration::from_secs(1)
                 } else {

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -960,6 +960,23 @@ impl SettingsView {
         let enabled = self.module.enabled(settings);
         let mut rows = vec![self.width_slider(settings, cx).into_any_element()];
         match self.module {
+            WidgetModule::Music => {
+                rows.push(
+                    toggle_row(
+                        "Animated album art (Apple Music)",
+                        settings.animated_album_art,
+                        cx,
+                        |s| s.animated_album_art = !s.animated_album_art,
+                    )
+                    .into_any_element(),
+                );
+                rows.push(
+                    toggle_row("Ambient art glow", settings.ambient_art_glow, cx, |s| {
+                        s.ambient_art_glow = !s.ambient_art_glow
+                    })
+                    .into_any_element(),
+                );
+            }
             WidgetModule::Calendar => {
                 rows.push(
                     action_row(
@@ -1346,7 +1363,7 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Pinned metrics on the compact island and the expanded card.".into()
         }
         WidgetModule::Music => {
-            "Now Playing from MediaRemote on macOS, with an AppleScript fallback.".into()
+            "Now Playing from MediaRemote. Optional Apple Music motion art is opt-in and fails silent to static covers; the glow uses local artwork colors.".into()
         }
         WidgetModule::Files => "Drop zone and tray live on the Tray tab of the expanded island.".into(),
         WidgetModule::Timers => "Countdown presets and a compact ring while a timer is running.".into(),

--- a/crates/nook/src/motion.rs
+++ b/crates/nook/src/motion.rs
@@ -14,6 +14,15 @@
 
 use std::f32::consts::PI;
 
+/// Slow drift for the ambient media-card glow. Periods stay in the 8–14 s
+/// range so the blobs read as atmosphere, not a screensaver.
+pub fn aura_blob_offset(index: usize, t: f32) -> (f32, f32) {
+    let i = index as f32;
+    let x = ((t * (0.22 + i * 0.05)) + i * 1.7).sin() * (18.0 + i * 6.0);
+    let y = ((t * (0.18 + i * 0.04)) + i * 2.3).cos() * (10.0 + i * 4.0);
+    (x, y)
+}
+
 /// Island size morph: expand/collapse and compact mode changes. `snappy` at
 /// the pace of the previous hand-tuned spring (stiffness 400, damping 30,
 /// mass 0.8 ⇒ response 0.28s, damping fraction 0.84 — i.e. this, unnamed).
@@ -223,5 +232,21 @@ mod tests {
         assert!(!v.step(MORPH, 42.0, 0.016, REST_PX));
         assert_eq!(v.value, 42.0);
         assert_eq!(v.velocity, 0.0);
+    }
+
+    #[test]
+    fn aura_blobs_drift_slowly_and_stay_nearby() {
+        let (x0, y0) = aura_blob_offset(0, 0.0);
+        let (x1, y1) = aura_blob_offset(0, 0.5);
+        assert!((x1 - x0).abs() < 8.0 && (y1 - y0).abs() < 6.0);
+        for i in 0..3 {
+            for t in [0.0, 3.0, 11.0] {
+                let (x, y) = aura_blob_offset(i, t);
+                assert!(x.abs() < 50.0 && y.abs() < 40.0, "blob {i} escaped: {x},{y}");
+            }
+        }
+        let a = aura_blob_offset(0, 1.0);
+        let b = aura_blob_offset(1, 1.0);
+        assert_ne!(a, b);
     }
 }

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -20,6 +20,9 @@ use nook_core::notch::{CGPoint, CGRect, CGSize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::Once;
+#[cfg(target_os = "macos")]
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 static INSTALL: Once = Once::new();
@@ -46,7 +49,14 @@ pub fn install() {
 /// handlers also pin immediately on the main thread.
 pub fn request_pin() {
     #[cfg(target_os = "macos")]
-    PIN_NEEDED.store(true, Ordering::Release);
+    {
+        PIN_NEEDED.store(true, Ordering::Release);
+        let wait = pin_wait();
+        if let Ok(mut ready) = wait.ready.lock() {
+            *ready = true;
+            wait.cv.notify_one();
+        }
+    }
 }
 
 pub fn take_pin_needed() -> bool {
@@ -56,6 +66,52 @@ pub fn take_pin_needed() -> bool {
     }
     #[cfg(not(target_os = "macos"))]
     false
+}
+
+#[cfg(target_os = "macos")]
+struct PinWait {
+    ready: Mutex<bool>,
+    cv: Condvar,
+}
+
+#[cfg(target_os = "macos")]
+fn pin_wait() -> &'static PinWait {
+    static WAIT: OnceLock<PinWait> = OnceLock::new();
+    WAIT.get_or_init(|| PinWait {
+        ready: Mutex::new(false),
+        cv: Condvar::new(),
+    })
+}
+
+/// Block until [`request_pin`] or `timeout`. Must run off the main thread.
+pub fn wait_pin_needed(timeout: Duration) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if PIN_NEEDED.load(Ordering::Acquire) {
+            return true;
+        }
+        let wait = pin_wait();
+        let Ok(mut ready) = wait.ready.lock() else {
+            std::thread::sleep(timeout);
+            return PIN_NEEDED.load(Ordering::Acquire);
+        };
+        if *ready {
+            *ready = false;
+            return true;
+        }
+        let (mut ready, _) = wait
+            .cv
+            .wait_timeout(ready, timeout)
+            .unwrap_or_else(|e| e.into_inner());
+        let signaled = *ready;
+        *ready = false;
+        signaled || PIN_NEEDED.load(Ordering::Acquire)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::thread::sleep(timeout);
+        false
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -887,6 +943,17 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(colorsChanged:),
         name: colors_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let appearance_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSApplicationDidChangeEffectiveAppearanceNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        center,
+        addObserver: target,
+        selector: sel!(colorsChanged:),
+        name: appearance_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -2519,6 +2519,250 @@ fn stop_mirror_macos() {
     }));
 }
 
+/// GPUI top-left artwork rect plus the HLS URL to play over it.
+#[derive(Clone, Debug, PartialEq)]
+pub struct MotionArtSpec {
+    pub url: String,
+    pub x: f64,
+    pub y: f64,
+    pub w: f64,
+    pub h: f64,
+    pub radius: f64,
+    pub playing: bool,
+}
+
+/// Attach or update the looping AVPlayerLayer. `None` hides and pauses.
+/// Created once per URL; later calls only move the frame or pause.
+pub fn sync_motion_art(spec: Option<&MotionArtSpec>) {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        sync_motion_art_macos(spec);
+    }
+    #[cfg(not(target_os = "macos"))]
+    let _ = spec;
+}
+
+pub fn hide_motion_art() {
+    sync_motion_art(None);
+}
+
+#[cfg(target_os = "macos")]
+struct MotionArtCap {
+    url: String,
+    layer: *mut objc2::runtime::AnyObject,
+    player: *mut objc2::runtime::AnyObject,
+    looper: *mut objc2::runtime::AnyObject,
+    last: Option<(f64, f64, f64, f64, f64)>,
+    hidden: bool,
+    paused: bool,
+}
+
+#[cfg(target_os = "macos")]
+fn motion_art_cap() -> &'static std::sync::Mutex<MotionArtCap> {
+    static CAP: std::sync::OnceLock<std::sync::Mutex<MotionArtCap>> = std::sync::OnceLock::new();
+    CAP.get_or_init(|| {
+        std::sync::Mutex::new(MotionArtCap {
+            url: String::new(),
+            layer: std::ptr::null_mut(),
+            player: std::ptr::null_mut(),
+            looper: std::ptr::null_mut(),
+            last: None,
+            hidden: true,
+            paused: true,
+        })
+    })
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn sync_motion_art_macos(spec: Option<&MotionArtSpec>) {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    let Some(spec) = spec.filter(|s| !s.url.is_empty() && s.w > 1.0 && s.h > 1.0) else {
+        hide_motion_art_macos();
+        return;
+    };
+
+    let mut ns_win = std::ptr::null_mut();
+    for_each_island_window(|w| {
+        if ns_win.is_null() {
+            ns_win = w;
+        }
+    });
+    if ns_win.is_null() {
+        return;
+    }
+    let content: *mut AnyObject = msg_send![ns_win, contentView];
+    if content.is_null() {
+        return;
+    }
+    let _: () = msg_send![content, setWantsLayer: true];
+    let host: *mut AnyObject = msg_send![content, layer];
+    if host.is_null() {
+        return;
+    }
+    let view_frame: CGRect = msg_send![content, bounds];
+    let view_h = view_frame.size.height;
+    let (cx, cy, cw, ch) = cocoa_rect_from_gpui(spec.x, spec.y, spec.w, spec.h, view_h);
+    let rect = CGRect {
+        origin: CGPoint { x: cx, y: cy },
+        size: CGSize {
+            width: cw,
+            height: ch,
+        },
+    };
+
+    let mut cap = motion_art_cap().lock().unwrap_or_else(|e| e.into_inner());
+    if cap.url != spec.url || cap.layer.is_null() {
+        teardown_motion_art_locked(&mut cap);
+        let Some((layer, player, looper)) = create_motion_art_layer(&spec.url, rect, spec.radius)
+        else {
+            return;
+        };
+        let _: () = msg_send![host, addSublayer: layer];
+        cap.url = spec.url.clone();
+        cap.layer = layer;
+        cap.player = player;
+        cap.looper = looper;
+        cap.last = None;
+        cap.hidden = false;
+        cap.paused = true;
+    }
+
+    let frame_key = (cx, cy, cw, ch, spec.radius);
+    if cap.last != Some(frame_key) && !cap.layer.is_null() {
+        let _: () = msg_send![cap.layer, setFrame: rect];
+        let _: () = msg_send![cap.layer, setCornerRadius: spec.radius];
+        cap.last = Some(frame_key);
+    }
+
+    let hide = !spec.playing;
+    if cap.hidden != hide && !cap.layer.is_null() {
+        let _: () = msg_send![cap.layer, setHidden: hide];
+        cap.hidden = hide;
+    }
+    if cap.paused != hide && !cap.player.is_null() {
+        if hide {
+            let _: () = msg_send![cap.player, pause];
+        } else {
+            let _: () = msg_send![cap.player, play];
+        }
+        cap.paused = hide;
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn hide_motion_art_macos() {
+    use objc2::*;
+    let mut cap = motion_art_cap().lock().unwrap_or_else(|e| e.into_inner());
+    if !cap.layer.is_null() && !cap.hidden {
+        let _: () = msg_send![cap.layer, setHidden: true];
+        cap.hidden = true;
+    }
+    if !cap.player.is_null() && !cap.paused {
+        let _: () = msg_send![cap.player, pause];
+        cap.paused = true;
+    }
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn teardown_motion_art_locked(cap: &mut MotionArtCap) {
+    use objc2::*;
+    if !cap.player.is_null() {
+        let _: () = msg_send![cap.player, pause];
+        let _: () = msg_send![cap.player, release];
+        cap.player = std::ptr::null_mut();
+    }
+    if !cap.looper.is_null() {
+        let _: () = msg_send![cap.looper, release];
+        cap.looper = std::ptr::null_mut();
+    }
+    if !cap.layer.is_null() {
+        let _: () = msg_send![cap.layer, removeFromSuperlayer];
+        let _: () = msg_send![cap.layer, release];
+        cap.layer = std::ptr::null_mut();
+    }
+    cap.url.clear();
+    cap.last = None;
+    cap.hidden = true;
+    cap.paused = true;
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn create_motion_art_layer(
+    url: &str,
+    rect: CGRect,
+    radius: f64,
+) -> Option<(
+    *mut objc2::runtime::AnyObject,
+    *mut objc2::runtime::AnyObject,
+    *mut objc2::runtime::AnyObject,
+)> {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+
+    load_avfoundation();
+    let item_cls = av_class(c"AVPlayerItem")?;
+    let player_cls = av_class(c"AVQueuePlayer")?;
+    let layer_cls = av_class(c"AVPlayerLayer")?;
+    let ns_url_cls = class!(NSURL);
+    let url_str = ns_string(url);
+    if url_str.is_null() {
+        return None;
+    }
+    let ns_url: *mut AnyObject = msg_send![ns_url_cls, URLWithString: url_str];
+    if ns_url.is_null() {
+        return None;
+    }
+    let item: *mut AnyObject = msg_send![item_cls, playerItemWithURL: ns_url];
+    if item.is_null() {
+        return None;
+    }
+    let items: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: item];
+    let player: *mut AnyObject = msg_send![player_cls, queuePlayerWithItems: items];
+    if player.is_null() {
+        return None;
+    }
+    let _: *mut AnyObject = msg_send![player, retain];
+    let _: () = msg_send![player, setMuted: true];
+    let sel = sel!(setPreventsDisplaySleepDuringVideoPlayback:);
+    let can_sleep: bool = msg_send![player, respondsToSelector: sel];
+    if can_sleep {
+        let _: () = msg_send![player, setPreventsDisplaySleepDuringVideoPlayback: false];
+    }
+
+    let looper = if let Some(looper_cls) = av_class(c"AVPlayerLooper") {
+        let looper: *mut AnyObject =
+            msg_send![looper_cls, playerLooperWithPlayer: player, templateItem: item];
+        if looper.is_null() {
+            std::ptr::null_mut()
+        } else {
+            let _: *mut AnyObject = msg_send![looper, retain];
+            looper
+        }
+    } else {
+        std::ptr::null_mut()
+    };
+
+    let layer: *mut AnyObject = msg_send![layer_cls, playerLayerWithPlayer: player];
+    if layer.is_null() {
+        let _: () = msg_send![player, release];
+        if !looper.is_null() {
+            let _: () = msg_send![looper, release];
+        }
+        return None;
+    }
+    let _: *mut AnyObject = msg_send![layer, retain];
+    let gravity = ns_string("AVLayerVideoGravityResizeAspectFill");
+    if !gravity.is_null() {
+        let _: () = msg_send![layer, setVideoGravity: gravity];
+    }
+    let _: () = msg_send![layer, setFrame: rect];
+    let _: () = msg_send![layer, setCornerRadius: radius];
+    let _: () = msg_send![layer, setMasksToBounds: true];
+    Some((layer, player, looper))
+}
+
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -2546,12 +2546,44 @@ pub fn hide_motion_art() {
     sync_motion_art(None);
 }
 
+/// Retained AVFoundation object stored for the process lifetime.
+///
+/// # Safety
+/// `Send` so the pointer can live in a `static Mutex` (`OnceLock` requires
+/// `Sync`). AVQueuePlayer / AVPlayerLayer / AVPlayerLooper are only created,
+/// messaged, and released on the AppKit main thread (GPUI's UI thread). The
+/// mutex is storage, not a cross-thread handoff of the objects.
+#[cfg(target_os = "macos")]
+struct MainThreadObjc(*mut objc2::runtime::AnyObject);
+
+#[cfg(target_os = "macos")]
+unsafe impl Send for MainThreadObjc {}
+
+#[cfg(target_os = "macos")]
+impl MainThreadObjc {
+    const fn null() -> Self {
+        Self(std::ptr::null_mut())
+    }
+
+    fn is_null(&self) -> bool {
+        self.0.is_null()
+    }
+
+    fn get(&self) -> *mut objc2::runtime::AnyObject {
+        self.0
+    }
+
+    fn set(&mut self, ptr: *mut objc2::runtime::AnyObject) {
+        self.0 = ptr;
+    }
+}
+
 #[cfg(target_os = "macos")]
 struct MotionArtCap {
     url: String,
-    layer: *mut objc2::runtime::AnyObject,
-    player: *mut objc2::runtime::AnyObject,
-    looper: *mut objc2::runtime::AnyObject,
+    layer: MainThreadObjc,
+    player: MainThreadObjc,
+    looper: MainThreadObjc,
     last: Option<(f64, f64, f64, f64, f64)>,
     hidden: bool,
     paused: bool,
@@ -2563,9 +2595,9 @@ fn motion_art_cap() -> &'static std::sync::Mutex<MotionArtCap> {
     CAP.get_or_init(|| {
         std::sync::Mutex::new(MotionArtCap {
             url: String::new(),
-            layer: std::ptr::null_mut(),
-            player: std::ptr::null_mut(),
-            looper: std::ptr::null_mut(),
+            layer: MainThreadObjc::null(),
+            player: MainThreadObjc::null(),
+            looper: MainThreadObjc::null(),
             last: None,
             hidden: true,
             paused: true,
@@ -2583,7 +2615,7 @@ unsafe fn sync_motion_art_macos(spec: Option<&MotionArtSpec>) {
         return;
     };
 
-    let mut ns_win = std::ptr::null_mut();
+    let mut ns_win: *mut AnyObject = std::ptr::null_mut();
     for_each_island_window(|w| {
         if ns_win.is_null() {
             ns_win = w;
@@ -2621,9 +2653,9 @@ unsafe fn sync_motion_art_macos(spec: Option<&MotionArtSpec>) {
         };
         let _: () = msg_send![host, addSublayer: layer];
         cap.url = spec.url.clone();
-        cap.layer = layer;
-        cap.player = player;
-        cap.looper = looper;
+        cap.layer.set(layer);
+        cap.player.set(player);
+        cap.looper.set(looper);
         cap.last = None;
         cap.hidden = false;
         cap.paused = true;
@@ -2631,21 +2663,21 @@ unsafe fn sync_motion_art_macos(spec: Option<&MotionArtSpec>) {
 
     let frame_key = (cx, cy, cw, ch, spec.radius);
     if cap.last != Some(frame_key) && !cap.layer.is_null() {
-        let _: () = msg_send![cap.layer, setFrame: rect];
-        let _: () = msg_send![cap.layer, setCornerRadius: spec.radius];
+        let _: () = msg_send![cap.layer.get(), setFrame: rect];
+        let _: () = msg_send![cap.layer.get(), setCornerRadius: spec.radius];
         cap.last = Some(frame_key);
     }
 
     let hide = !spec.playing;
     if cap.hidden != hide && !cap.layer.is_null() {
-        let _: () = msg_send![cap.layer, setHidden: hide];
+        let _: () = msg_send![cap.layer.get(), setHidden: hide];
         cap.hidden = hide;
     }
     if cap.paused != hide && !cap.player.is_null() {
         if hide {
-            let _: () = msg_send![cap.player, pause];
+            let _: () = msg_send![cap.player.get(), pause];
         } else {
-            let _: () = msg_send![cap.player, play];
+            let _: () = msg_send![cap.player.get(), play];
         }
         cap.paused = hide;
     }
@@ -2656,11 +2688,11 @@ unsafe fn hide_motion_art_macos() {
     use objc2::*;
     let mut cap = motion_art_cap().lock().unwrap_or_else(|e| e.into_inner());
     if !cap.layer.is_null() && !cap.hidden {
-        let _: () = msg_send![cap.layer, setHidden: true];
+        let _: () = msg_send![cap.layer.get(), setHidden: true];
         cap.hidden = true;
     }
     if !cap.player.is_null() && !cap.paused {
-        let _: () = msg_send![cap.player, pause];
+        let _: () = msg_send![cap.player.get(), pause];
         cap.paused = true;
     }
 }
@@ -2669,18 +2701,18 @@ unsafe fn hide_motion_art_macos() {
 unsafe fn teardown_motion_art_locked(cap: &mut MotionArtCap) {
     use objc2::*;
     if !cap.player.is_null() {
-        let _: () = msg_send![cap.player, pause];
-        let _: () = msg_send![cap.player, release];
-        cap.player = std::ptr::null_mut();
+        let _: () = msg_send![cap.player.get(), pause];
+        let _: () = msg_send![cap.player.get(), release];
+        cap.player.set(std::ptr::null_mut());
     }
     if !cap.looper.is_null() {
-        let _: () = msg_send![cap.looper, release];
-        cap.looper = std::ptr::null_mut();
+        let _: () = msg_send![cap.looper.get(), release];
+        cap.looper.set(std::ptr::null_mut());
     }
     if !cap.layer.is_null() {
-        let _: () = msg_send![cap.layer, removeFromSuperlayer];
-        let _: () = msg_send![cap.layer, release];
-        cap.layer = std::ptr::null_mut();
+        let _: () = msg_send![cap.layer.get(), removeFromSuperlayer];
+        let _: () = msg_send![cap.layer.get(), release];
+        cap.layer.set(std::ptr::null_mut());
     }
     cap.url.clear();
     cap.last = None;
@@ -2731,7 +2763,7 @@ unsafe fn create_motion_art_layer(
         let _: () = msg_send![player, setPreventsDisplaySleepDuringVideoPlayback: false];
     }
 
-    let looper = if let Some(looper_cls) = av_class(c"AVPlayerLooper") {
+    let looper: *mut AnyObject = if let Some(looper_cls) = av_class(c"AVPlayerLooper") {
         let looper: *mut AnyObject =
             msg_send![looper_cls, playerLooperWithPlayer: player, templateItem: item];
         if looper.is_null() {
@@ -2766,6 +2798,13 @@ unsafe fn create_motion_art_layer(
 #[cfg(all(test, target_os = "macos"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn motion_art_cap_is_send() {
+        fn assert_send<T: Send>() {}
+        assert_send::<MainThreadObjc>();
+        assert_send::<MotionArtCap>();
+    }
 
     #[test]
     fn media_app_icon_png_is_a_reasonable_png() {

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -806,6 +806,16 @@ fn install_app_target() {
         extern "C" fn app_activated(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
             nook_core::occupancy::invalidate();
         }
+        extern "C" fn accessibility_changed(
+            _this: *mut AnyObject,
+            _cmd: Sel,
+            _note: *mut AnyObject,
+        ) {
+            invalidate_accessibility_flags();
+        }
+        extern "C" fn colors_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            invalidate_accent_color();
+        }
 
         let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
         let cls = objc_allocateClassPair(super_cls, c"NookAppTarget".as_ptr(), 0);
@@ -826,10 +836,18 @@ fn install_app_target() {
         let imp_app: Imp = std::mem::transmute(
             app_activated as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
         );
+        let imp_a11y: Imp = std::mem::transmute(
+            accessibility_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
+        let imp_colors: Imp = std::mem::transmute(
+            colors_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
         let _ = class_addMethod(cls, sel!(openSettings:), imp_settings, types.as_ptr());
         let _ = class_addMethod(cls, sel!(screenChanged:), imp_screen, types.as_ptr());
         let _ = class_addMethod(cls, sel!(spaceChanged:), imp_space, types.as_ptr());
         let _ = class_addMethod(cls, sel!(appActivated:), imp_app, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(accessibilityChanged:), imp_a11y, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(colorsChanged:), imp_colors, types.as_ptr());
         objc_registerClassPair(cls);
         observe_screen_changes();
     }
@@ -857,6 +875,18 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(screenChanged:),
         name: name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+
+    let colors_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSSystemColorsDidChangeNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        center,
+        addObserver: target,
+        selector: sel!(colorsChanged:),
+        name: colors_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 
@@ -888,6 +918,18 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(appActivated:),
         name: app_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let a11y_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification"
+            .as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(accessibilityChanged:),
+        name: a11y_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 }
@@ -1380,16 +1422,43 @@ pub fn open_calendar() {
     }
 }
 
+#[cfg(target_os = "macos")]
+static ACCENT_VALID: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static ACCENT_R: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+#[cfg(target_os = "macos")]
+static ACCENT_G: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+#[cfg(target_os = "macos")]
+static ACCENT_B: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+#[cfg(target_os = "macos")]
+fn invalidate_accent_color() {
+    ACCENT_VALID.store(false, Ordering::Relaxed);
+}
+
 /// System Settings → Appearance → *Accent color* (`NSColor.controlAccentColor`),
 /// as sRGB components in 0..=1. `None` when there is no AppKit to ask or the
 /// color cannot be converted to an RGB space — callers fall back to systemBlue.
 ///
-/// Read live rather than cached so switching the accent in System Settings
-/// shows up on the next frame. Must be called on the main thread.
+/// Cached until `NSSystemColorsDidChangeNotification` so idle frames do not
+/// walk CoreUI catalog colors. Must be called on the main thread for the
+/// first resolve.
 pub fn accent_color() -> Option<(f32, f32, f32)> {
     #[cfg(target_os = "macos")]
     {
-        accent_color_macos()
+        if ACCENT_VALID.load(Ordering::Relaxed) {
+            return Some((
+                f32::from_bits(ACCENT_R.load(Ordering::Relaxed)),
+                f32::from_bits(ACCENT_G.load(Ordering::Relaxed)),
+                f32::from_bits(ACCENT_B.load(Ordering::Relaxed)),
+            ));
+        }
+        let color = accent_color_macos()?;
+        ACCENT_R.store(color.0.to_bits(), Ordering::Relaxed);
+        ACCENT_G.store(color.1.to_bits(), Ordering::Relaxed);
+        ACCENT_B.store(color.2.to_bits(), Ordering::Relaxed);
+        ACCENT_VALID.store(true, Ordering::Relaxed);
+        Some(color)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1432,10 +1501,23 @@ fn accent_color_macos() -> Option<(f32, f32, f32)> {
     })
 }
 
+#[cfg(target_os = "macos")]
+static REDUCE_TRANSPARENCY_CACHE: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_os = "macos")]
+static REDUCE_MOTION_CACHE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(target_os = "macos")]
+fn invalidate_accessibility_flags() {
+    REDUCE_TRANSPARENCY_CACHE.store(0, Ordering::Relaxed);
+    REDUCE_MOTION_CACHE.store(0, Ordering::Relaxed);
+}
+
 /// 1s-TTL cache for an AppKit accessibility flag. Both flags below are read
 /// from the 20ms island tick; two ObjC round-trips per tick is pointless for
-/// settings a human toggles at most a few times a day. Layout: bit0 = value,
-/// bit1 = valid, upper bits = last-read unix ms.
+/// settings a human toggles at most a few times a day. The workspace
+/// accessibility-display observer also invalidates these so a toggle applies
+/// on the next tick. Layout: bit0 = value, bit1 = valid, upper bits = last-read
+/// unix ms.
 #[cfg(target_os = "macos")]
 fn cached_accessibility_flag(cache: &AtomicU64, read: unsafe fn() -> bool) -> bool {
     let now_ms = std::time::SystemTime::now()
@@ -1457,7 +1539,6 @@ fn cached_accessibility_flag(cache: &AtomicU64, read: unsafe fn() -> bool) -> bo
 pub fn reduce_transparency() -> bool {
     #[cfg(target_os = "macos")]
     {
-        static CACHE: AtomicU64 = AtomicU64::new(0);
         unsafe fn read() -> bool {
             use objc2::runtime::AnyObject;
             use objc2::*;
@@ -1467,7 +1548,7 @@ pub fn reduce_transparency() -> bool {
             }
             msg_send![workspace, accessibilityDisplayShouldReduceTransparency]
         }
-        cached_accessibility_flag(&CACHE, read)
+        cached_accessibility_flag(&REDUCE_TRANSPARENCY_CACHE, read)
     }
     #[cfg(not(target_os = "macos"))]
     false
@@ -1480,7 +1561,6 @@ pub fn reduce_transparency() -> bool {
 pub fn reduce_motion() -> bool {
     #[cfg(target_os = "macos")]
     {
-        static CACHE: AtomicU64 = AtomicU64::new(0);
         unsafe fn read() -> bool {
             use objc2::runtime::AnyObject;
             use objc2::*;
@@ -1490,10 +1570,44 @@ pub fn reduce_motion() -> bool {
             }
             msg_send![workspace, accessibilityDisplayShouldReduceMotion]
         }
-        cached_accessibility_flag(&CACHE, read)
+        cached_accessibility_flag(&REDUCE_MOTION_CACHE, read)
     }
     #[cfg(not(target_os = "macos"))]
     false
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn workspace_note_bundle_id(note: *mut objc2::runtime::AnyObject) -> Option<String> {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    if note.is_null() {
+        return None;
+    }
+    let info: *mut AnyObject = msg_send![note, userInfo];
+    if info.is_null() {
+        return None;
+    }
+    let key: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceApplicationKey".as_ptr()
+    ];
+    let app: *mut AnyObject = msg_send![info, objectForKey: key];
+    if app.is_null() {
+        return None;
+    }
+    let ident: *mut AnyObject = msg_send![app, bundleIdentifier];
+    if ident.is_null() {
+        return None;
+    }
+    let utf8: *const std::ffi::c_char = msg_send![ident, UTF8String];
+    if utf8.is_null() {
+        return None;
+    }
+    Some(
+        std::ffi::CStr::from_ptr(utf8)
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Subscribe to Spotify's and Music's public playback-change broadcasts.
@@ -1514,23 +1628,60 @@ pub fn install_media_observers() {
 
         static INSTALLED: Once = Once::new();
         INSTALLED.call_once(|| {
+            let _ = nook_core::audio::prime_media_apps();
+
             let center: *mut AnyObject =
                 msg_send![class!(NSDistributedNotificationCenter), defaultCenter];
-            if center.is_null() {
+            if !center.is_null() {
+                for name in [
+                    c"com.spotify.client.PlaybackStateChanged",
+                    c"com.apple.Music.playerInfo",
+                    c"com.apple.iTunes.playerInfo",
+                ] {
+                    let ns_name: *mut AnyObject =
+                        msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
+                    let block = RcBlock::new(move |_note: *mut AnyObject| {
+                        nook_core::audio::note_media_event();
+                    });
+                    let token: *mut AnyObject = msg_send![
+                        center,
+                        addObserverForName: ns_name,
+                        object: std::ptr::null_mut::<AnyObject>(),
+                        queue: std::ptr::null_mut::<AnyObject>(),
+                        usingBlock: &*block
+                    ];
+                    std::mem::forget(block);
+                    let _ = token;
+                }
+            }
+
+            let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+            if workspace.is_null() {
                 return;
             }
-            for name in [
-                c"com.spotify.client.PlaybackStateChanged",
-                c"com.apple.Music.playerInfo",
-                c"com.apple.iTunes.playerInfo",
+            let wsnc: *mut AnyObject = msg_send![workspace, notificationCenter];
+            if wsnc.is_null() {
+                return;
+            }
+            for (name, running) in [
+                (c"NSWorkspaceDidLaunchApplicationNotification", true),
+                (c"NSWorkspaceDidTerminateApplicationNotification", false),
             ] {
                 let ns_name: *mut AnyObject =
                     msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
-                let block = RcBlock::new(move |_note: *mut AnyObject| {
-                    nook_core::audio::note_media_event();
+                let block = RcBlock::new(move |note: *mut AnyObject| {
+                    if let Some(id) = workspace_note_bundle_id(note) {
+                        nook_core::audio::note_media_app_running(&id, running);
+                        if matches!(
+                            id.as_str(),
+                            "com.spotify.client" | "com.apple.Music" | "com.apple.Safari"
+                        ) {
+                            nook_core::audio::note_media_event();
+                        }
+                    }
                 });
                 let token: *mut AnyObject = msg_send![
-                    center,
+                    wsnc,
                     addObserverForName: ns_name,
                     object: std::ptr::null_mut::<AnyObject>(),
                     queue: std::ptr::null_mut::<AnyObject>(),

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -28,13 +28,34 @@ static LOGGED_PIN: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static OPEN_SETTINGS: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
+static PIN_NEEDED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
 static STATUS_ITEM: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 /// Call once before `open_island`. Safe to call again.
 pub fn install() {
     #[cfg(target_os = "macos")]
-    install_macos();
+    {
+        install_macos();
+        install_mouse_monitors();
+    }
+}
+
+/// Ask the pin backstop loop to restyle/pin island windows. Notification
+/// handlers also pin immediately on the main thread.
+pub fn request_pin() {
+    #[cfg(target_os = "macos")]
+    PIN_NEEDED.store(true, Ordering::Release);
+}
+
+pub fn take_pin_needed() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        return PIN_NEEDED.swap(false, Ordering::AcqRel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
 }
 
 #[cfg(target_os = "macos")]
@@ -774,7 +795,16 @@ fn install_app_target() {
         }
         extern "C" fn screen_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
             nook_core::notch::invalidate_screen_cache();
+            request_pin();
             pin_island_windows();
+        }
+        extern "C" fn space_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            nook_core::notch::invalidate_screen_cache();
+            request_pin();
+            pin_island_windows();
+        }
+        extern "C" fn app_activated(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            nook_core::occupancy::invalidate();
         }
 
         let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
@@ -790,8 +820,16 @@ fn install_app_target() {
         let imp_screen: Imp = std::mem::transmute(
             screen_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
         );
+        let imp_space: Imp = std::mem::transmute(
+            space_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
+        let imp_app: Imp = std::mem::transmute(
+            app_activated as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
         let _ = class_addMethod(cls, sel!(openSettings:), imp_settings, types.as_ptr());
         let _ = class_addMethod(cls, sel!(screenChanged:), imp_screen, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(spaceChanged:), imp_space, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(appActivated:), imp_app, types.as_ptr());
         objc_registerClassPair(cls);
         observe_screen_changes();
     }
@@ -821,6 +859,78 @@ unsafe fn observe_screen_changes() {
         name: name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
+
+    let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+    if workspace.is_null() {
+        return;
+    }
+    let wsnc: *mut AnyObject = msg_send![workspace, notificationCenter];
+    if wsnc.is_null() {
+        return;
+    }
+    let space_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceActiveSpaceDidChangeNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(spaceChanged:),
+        name: space_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let app_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceDidActivateApplicationNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(appActivated:),
+        name: app_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+}
+
+/// NSEvent global + local monitors for mouse moved / left-drag / left-up.
+/// Main thread only. Handlers write the same atomics as the 250 ms backstop
+/// poll in `nook_core::mouse`. Local handler must return the event.
+pub fn install_mouse_monitors() {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use block2::RcBlock;
+        use objc2::runtime::AnyObject;
+        use objc2::*;
+
+        static INSTALLED: Once = Once::new();
+        INSTALLED.call_once(|| {
+            // MouseMoved | LeftMouseDragged | LeftMouseUp
+            const MASK: u64 = (1 << 5) | (1 << 6) | (1 << 2);
+
+            let global = RcBlock::new(move |_event: *mut AnyObject| {
+                nook_core::mouse::sample_now();
+            });
+            let g: *mut AnyObject = msg_send![
+                class!(NSEvent),
+                addGlobalMonitorForEventsMatchingMask: MASK,
+                handler: &*global
+            ];
+            std::mem::forget(global);
+            let _ = g;
+
+            let local = RcBlock::new(move |event: *mut AnyObject| -> *mut AnyObject {
+                nook_core::mouse::sample_now();
+                event
+            });
+            let l: *mut AnyObject = msg_send![
+                class!(NSEvent),
+                addLocalMonitorForEventsMatchingMask: MASK,
+                handler: &*local
+            ];
+            std::mem::forget(local);
+            let _ = l;
+        });
+    }
 }
 
 /// Hand files to the system AirDrop picker (`NSSharingServiceNameSendViaAirDrop`).


### PR DESCRIPTION
Live motion art / animated album covers (WP17 only). Base is `cursor/wp01-media-stream-mouse-a6ea`.

## What landed
- `nook-core::motion_artwork`: iTunes Search → AMP `extend=editorialVideo` with an anonymous music.apple.com JWT. Artist+album string match before accepting an adamId. Hits and confirmed misses cached in SQLite; token cached in memory and refreshed on 401. All network failures fail silent to static art.
- `NowPlayingData.motion_artwork_url` plus album-change lookup inside the existing media wait loop (no new poll).
- `AVQueuePlayer` + `AVPlayerLooper` + `AVPlayerLayer` in `platform.rs`, attached once per track above the GPUI Metal layer. Frame updates only; pause + hide when the island collapses, is suppressed, Reduce Motion is on, or playback stops.
- GPUI aura fallback: 2–3 dominant artwork colors as slow sinusoidal blobs behind the expanded media card, 30 fps only while expanded + playing.
- Settings (Music module): **Animated album art (Apple Music)** default off, **Ambient art glow** default on.

## Tests
`cargo test -p nook -p nook-core` green (nook-core 106, nook 86). New coverage: iTunes/AMP JSON parse, JWT/index.js scrape, album match, storefront, settings defaults, palette, art-bounds, aura gate, layer visibility.

## Notes / blockers
- AMP token scrape is unofficial and ToS-gray — designed to fail silent; coverage is only albums Apple produced motion art for.
- AVPlayerLayer compositing over GPUI was not exercised on this Linux host; needs a macOS run to confirm z-order vs the glass underlay and corner clipping.
- Catalog matching from Spotify/browser metadata is fuzzy; we require both artist and album to match before accepting a video.