### PR TITLE
WP18: Playing Next queue (Music playlist + Spotify)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -29,6 +29,6 @@
 	<key>NSCameraUsageDescription</key>
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
+	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, to read the current Music playlist so the island can show upcoming tracks, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
 </dict>
 </plist>

--- a/crates/nook-core/src/agents.rs
+++ b/crates/nook-core/src/agents.rs
@@ -10,6 +10,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
+#[cfg(target_os = "macos")]
+use sysinfo::Pid;
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, System, UpdateKind};
 
 /// CPU % above which a descendant process counts as doing real work. The
@@ -153,6 +155,45 @@ fn process_system() -> &'static Mutex<System> {
 }
 
 fn scan_processes() -> HashMap<u32, ProcInfo> {
+    #[cfg(target_os = "macos")]
+    {
+        scan_processes_macos()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        scan_processes_all()
+    }
+}
+
+fn proc_from_sysinfo(pid_u32: u32, proc_: &sysinfo::Process) -> Option<ProcInfo> {
+    let name = proc_.name().to_string_lossy().into_owned();
+    let argv: Vec<String> = if proc_.cmd().is_empty() {
+        if name.is_empty() {
+            return None;
+        }
+        vec![name.clone()]
+    } else {
+        proc_
+            .cmd()
+            .iter()
+            .map(|s| s.to_string_lossy().into_owned())
+            .collect()
+    };
+    Some(ProcInfo {
+        pid: pid_u32,
+        ppid: proc_.parent().map(|p| p.as_u32()).unwrap_or(0),
+        cpu_pct: proc_.cpu_usage(),
+        name,
+        argv,
+        cwd: proc_.cwd().map(PathBuf::from),
+        exe: proc_.exe().map(PathBuf::from),
+        start_time: proc_.start_time(),
+    })
+}
+
+/// Full-table refresh. Used off macOS, where the process list is small and
+/// there is no `proc_pidpath` two-stage split.
+fn scan_processes_all() -> HashMap<u32, ProcInfo> {
     let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
     // argv (KERN_PROCARGS2 sysctl) and the exe path are fixed at exec time, so
     // OnlyIfNotSet fetches them once per new pid instead of re-reading them
@@ -172,35 +213,119 @@ fn scan_processes() -> HashMap<u32, ProcInfo> {
 
     let mut map = HashMap::new();
     for (pid, proc_) in sys.processes() {
-        let pid_u32 = pid.as_u32();
-        let name = proc_.name().to_string_lossy().into_owned();
-        let argv: Vec<String> = if proc_.cmd().is_empty() {
-            if name.is_empty() {
-                continue;
-            }
-            vec![name.clone()]
-        } else {
-            proc_
-                .cmd()
-                .iter()
-                .map(|s| s.to_string_lossy().into_owned())
-                .collect()
-        };
-        map.insert(
-            pid_u32,
-            ProcInfo {
-                pid: pid_u32,
-                ppid: proc_.parent().map(|p| p.as_u32()).unwrap_or(0),
-                cpu_pct: proc_.cpu_usage(),
-                name,
-                argv,
-                cwd: proc_.cwd().map(PathBuf::from),
-                exe: proc_.exe().map(PathBuf::from),
-                start_time: proc_.start_time(),
-            },
-        );
+        if let Some(info) = proc_from_sysinfo(pid.as_u32(), proc_) {
+            map.insert(info.pid, info);
+        }
     }
     map
+}
+
+/// macOS two-stage scan: list every pid with a cheap `proc_pidpath` (exe
+/// OnlyIfNotSet), then fetch argv / cwd / cpu only for agent candidates and
+/// their descendants. Avoids KERN_PROCARGS2 on hundreds of unrelated pids.
+#[cfg(target_os = "macos")]
+fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
+    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing()
+            .without_tasks()
+            .with_exe(UpdateKind::OnlyIfNotSet),
+    );
+
+    let sidecar: HashSet<u32> = grok_sessions()
+        .keys()
+        .chain(claude_sessions().keys())
+        .copied()
+        .collect();
+
+    let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut seeds = Vec::new();
+    for (pid, proc_) in sys.processes() {
+        let pid_u32 = pid.as_u32();
+        let ppid = proc_.parent().map(|p| p.as_u32()).unwrap_or(0);
+        children.entry(ppid).or_default().push(pid_u32);
+        let name = proc_.name().to_string_lossy();
+        let exe = proc_
+            .exe()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        if is_scan_seed(&exe, &name) || sidecar.contains(&pid_u32) {
+            seeds.push(pid_u32);
+        }
+    }
+
+    let mut detail = HashSet::new();
+    let mut stack = seeds;
+    while let Some(pid) = stack.pop() {
+        if detail.insert(pid) {
+            if let Some(kids) = children.get(&pid) {
+                stack.extend(kids.iter().copied());
+            }
+        }
+    }
+    if detail.is_empty() {
+        return HashMap::new();
+    }
+
+    let pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::Some(&pids),
+        true,
+        ProcessRefreshKind::nothing()
+            .without_tasks()
+            .with_cpu()
+            .with_cmd(UpdateKind::OnlyIfNotSet)
+            .with_cwd(UpdateKind::Always)
+            .with_exe(UpdateKind::OnlyIfNotSet),
+    );
+
+    let mut map = HashMap::new();
+    for pid in detail {
+        let Some(proc_) = sys.process(Pid::from_u32(pid)) else {
+            continue;
+        };
+        if let Some(info) = proc_from_sysinfo(pid, proc_) {
+            map.insert(info.pid, info);
+        }
+    }
+    map
+}
+
+/// Stage-1 filter: exe path or `comm` looks like an agent or a wrapper that
+/// may hide the real binary in argv (`node …/claude`).
+fn is_scan_seed(path: &str, comm: &str) -> bool {
+    if grok_install_path(path) {
+        return true;
+    }
+    if is_wrapper_comm(comm) || is_wrapper_comm(path.rsplit('/').next().unwrap_or(path)) {
+        return true;
+    }
+    [
+        AgentKind::Cursor,
+        AgentKind::OpenCode,
+        AgentKind::Claude,
+        AgentKind::Codex,
+        AgentKind::Fx,
+        AgentKind::Grok,
+        AgentKind::Aider,
+        AgentKind::Gemini,
+    ]
+    .into_iter()
+    .any(|kind| {
+        kind.binaries()
+            .iter()
+            .any(|bin| token_has_binary(path, bin) || token_has_binary(comm, bin))
+    })
+}
+
+fn is_wrapper_comm(name: &str) -> bool {
+    const WRAPPERS: &[&str] = &["node", "bun", "deno", "ruby", "perl", "npx", "python", "python3"];
+    let base = name.rsplit(['/', '\\']).next().unwrap_or(name);
+    let base = base.strip_suffix(".exe").unwrap_or(base);
+    let lower = base.to_ascii_lowercase();
+    WRAPPERS.iter().any(|w| lower == *w) || lower.starts_with("python")
 }
 
 fn assemble(procs: &HashMap<u32, ProcInfo>) -> Vec<AgentSession> {
@@ -1086,6 +1211,22 @@ mod tests {
             ),
             Some(AgentKind::Cursor)
         );
+    }
+
+    #[test]
+    fn scan_seed_matches_agent_paths_and_wrappers() {
+        assert!(is_scan_seed("/usr/local/bin/claude", "claude"));
+        assert!(is_scan_seed(
+            "/Users/a/.local/share/claude/versions/2.1.121",
+            "claude"
+        ));
+        assert!(is_scan_seed("/bin/cursor-agent", "cursor-agent"));
+        assert!(is_scan_seed("/opt/homebrew/bin/node", "node"));
+        assert!(is_scan_seed("/usr/bin/python3.12", "Python"));
+        assert!(is_scan_seed("/Users/a/.grok/bin/agent", "agent"));
+        assert!(!is_scan_seed("/usr/bin/grep", "grep"));
+        assert!(!is_scan_seed("/Applications/Safari.app/Contents/MacOS/Safari", "Safari"));
+        assert!(!is_scan_seed("/usr/sbin/syslogd", "syslogd"));
     }
 
     #[test]

--- a/crates/nook-core/src/agents.rs
+++ b/crates/nook-core/src/agents.rs
@@ -220,19 +220,48 @@ fn scan_processes_all() -> HashMap<u32, ProcInfo> {
     map
 }
 
-/// macOS two-stage scan: list every pid with a cheap `proc_pidpath` (exe
-/// OnlyIfNotSet), then fetch argv / cwd / cpu only for agent candidates and
-/// their descendants. Avoids KERN_PROCARGS2 on hundreds of unrelated pids.
+/// Cached argv/cwd/exe for a live pid. Invalidated when start_time changes
+/// (pid reuse) or the pid disappears.
+#[cfg(any(target_os = "macos", test))]
+#[derive(Clone, Debug, PartialEq)]
+struct CachedDetail {
+    start_time: u64,
+    name: String,
+    argv: Vec<String>,
+    cwd: Option<PathBuf>,
+    exe: Option<PathBuf>,
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn cache_lookup<'a>(
+    cache: &'a HashMap<u32, CachedDetail>,
+    pid: u32,
+    start_time: u64,
+) -> Option<&'a CachedDetail> {
+    let hit = cache.get(&pid)?;
+    (start_time > 0 && hit.start_time == start_time).then_some(hit)
+}
+
+#[cfg(any(target_os = "macos", test))]
+fn prune_detail_cache(cache: &mut HashMap<u32, CachedDetail>, live: &HashSet<u32>) {
+    cache.retain(|pid, _| live.contains(pid));
+}
+
+#[cfg(target_os = "macos")]
+fn detail_cache() -> &'static Mutex<HashMap<u32, CachedDetail>> {
+    static CACHE: OnceLock<Mutex<HashMap<u32, CachedDetail>>> = OnceLock::new();
+    CACHE.get_or_init(Mutex::default)
+}
+
+/// macOS two-stage scan: `proc_listallpids` + `proc_pidpath` / `PROC_PIDTBSDINFO`
+/// first (cheap), then argv (KERN_PROCARGS2) and cwd only for agent candidates
+/// and their descendants, and only when `(pid, start_time)` is not cached.
 #[cfg(target_os = "macos")]
 fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
-    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::All,
-        true,
-        ProcessRefreshKind::nothing()
-            .without_tasks()
-            .with_exe(UpdateKind::OnlyIfNotSet),
-    );
+    let stage = list_stage1();
+    if stage.is_empty() {
+        return scan_processes_all();
+    }
 
     let sidecar: HashSet<u32> = grok_sessions()
         .keys()
@@ -241,19 +270,14 @@ fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
         .collect();
 
     let mut children: HashMap<u32, Vec<u32>> = HashMap::new();
+    let mut by_pid: HashMap<u32, Stage1> = HashMap::new();
     let mut seeds = Vec::new();
-    for (pid, proc_) in sys.processes() {
-        let pid_u32 = pid.as_u32();
-        let ppid = proc_.parent().map(|p| p.as_u32()).unwrap_or(0);
-        children.entry(ppid).or_default().push(pid_u32);
-        let name = proc_.name().to_string_lossy();
-        let exe = proc_
-            .exe()
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_default();
-        if is_scan_seed(&exe, &name) || sidecar.contains(&pid_u32) {
-            seeds.push(pid_u32);
+    for info in stage {
+        children.entry(info.ppid).or_default().push(info.pid);
+        if is_scan_seed(&info.path, &info.comm) || sidecar.contains(&info.pid) {
+            seeds.push(info.pid);
         }
+        by_pid.insert(info.pid, info);
     }
 
     let mut detail = HashSet::new();
@@ -266,31 +290,233 @@ fn scan_processes_macos() -> HashMap<u32, ProcInfo> {
         }
     }
     if detail.is_empty() {
+        let mut cache = detail_cache().lock().unwrap_or_else(|e| e.into_inner());
+        cache.clear();
         return HashMap::new();
     }
 
-    let pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
-    sys.refresh_processes_specifics(
-        ProcessesToUpdate::Some(&pids),
-        true,
-        ProcessRefreshKind::nothing()
-            .without_tasks()
-            .with_cpu()
-            .with_cmd(UpdateKind::OnlyIfNotSet)
-            .with_cwd(UpdateKind::Always)
-            .with_exe(UpdateKind::OnlyIfNotSet),
-    );
+    let mut cache = detail_cache().lock().unwrap_or_else(|e| e.into_inner());
+    let mut hits: HashMap<u32, CachedDetail> = HashMap::new();
+    let mut misses = Vec::new();
+    for pid in &detail {
+        let start = by_pid.get(pid).map(|s| s.start_time).unwrap_or(0);
+        if let Some(hit) = cache_lookup(&cache, *pid, start) {
+            hits.insert(*pid, hit.clone());
+        } else {
+            misses.push(*pid);
+        }
+    }
+
+    let mut sys = process_system().lock().unwrap_or_else(|e| e.into_inner());
+    let cpu_kind = ProcessRefreshKind::nothing().without_tasks().with_cpu();
+    let all_pids: Vec<Pid> = detail.iter().copied().map(Pid::from_u32).collect();
+    sys.refresh_processes_specifics(ProcessesToUpdate::Some(&all_pids), true, cpu_kind);
+    if !misses.is_empty() {
+        let miss_pids: Vec<Pid> = misses.iter().copied().map(Pid::from_u32).collect();
+        sys.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&miss_pids),
+            true,
+            ProcessRefreshKind::nothing()
+                .without_tasks()
+                .with_cpu()
+                .with_cmd(UpdateKind::OnlyIfNotSet)
+                .with_cwd(UpdateKind::OnlyIfNotSet)
+                .with_exe(UpdateKind::OnlyIfNotSet),
+        );
+    }
 
     let mut map = HashMap::new();
     for pid in detail {
+        let stage = by_pid.get(&pid);
+        let start = stage.map(|s| s.start_time).unwrap_or(0);
+        let ppid = stage.map(|s| s.ppid).unwrap_or(0);
+        let cpu_pct = sys
+            .process(Pid::from_u32(pid))
+            .map(|p| p.cpu_usage())
+            .unwrap_or(0.0);
+        if let Some(hit) = hits.get(&pid) {
+            map.insert(
+                pid,
+                ProcInfo {
+                    pid,
+                    ppid,
+                    cpu_pct,
+                    name: hit.name.clone(),
+                    argv: hit.argv.clone(),
+                    cwd: hit.cwd.clone(),
+                    exe: hit.exe.clone(),
+                    start_time: hit.start_time,
+                },
+            );
+            continue;
+        }
         let Some(proc_) = sys.process(Pid::from_u32(pid)) else {
             continue;
         };
-        if let Some(info) = proc_from_sysinfo(pid, proc_) {
-            map.insert(info.pid, info);
+        let Some(mut info) = proc_from_sysinfo(pid, proc_) else {
+            continue;
+        };
+        if info.start_time == 0 {
+            info.start_time = start;
         }
+        if info.ppid == 0 {
+            info.ppid = ppid;
+        }
+        cache.insert(
+            pid,
+            CachedDetail {
+                start_time: info.start_time,
+                name: info.name.clone(),
+                argv: info.argv.clone(),
+                cwd: info.cwd.clone(),
+                exe: info.exe.clone(),
+            },
+        );
+        map.insert(pid, info);
     }
+    prune_detail_cache(&mut cache, &map.keys().copied().collect());
     map
+}
+
+#[cfg(target_os = "macos")]
+#[derive(Clone)]
+struct Stage1 {
+    pid: u32,
+    ppid: u32,
+    start_time: u64,
+    path: String,
+    comm: String,
+}
+
+#[cfg(target_os = "macos")]
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+struct ProcBsdInfo {
+    pbi_flags: u32,
+    pbi_status: u32,
+    pbi_xstatus: u32,
+    pbi_pid: u32,
+    pbi_ppid: u32,
+    pbi_uid: u32,
+    pbi_gid: u32,
+    pbi_ruid: u32,
+    pbi_rgid: u32,
+    pbi_svuid: u32,
+    pbi_svgid: u32,
+    rfu_1: u32,
+    pbi_comm: [u8; 16],
+    pbi_name: [u8; 32],
+    pbi_nfiles: u32,
+    pbi_pgid: u32,
+    pbi_pjobc: u32,
+    e_tdev: u32,
+    e_tpgid: u32,
+    pbi_nice: i32,
+    pbi_start_tvsec: u64,
+    pbi_start_tvusec: u64,
+}
+
+#[cfg(target_os = "macos")]
+const PROC_PIDTBSDINFO: i32 = 3;
+
+#[cfg(target_os = "macos")]
+extern "C" {
+    fn proc_listallpids(buffer: *mut std::ffi::c_void, buffersize: i32) -> i32;
+    fn proc_pidpath(pid: i32, buffer: *mut std::ffi::c_void, buffersize: u32) -> i32;
+    fn proc_pidinfo(
+        pid: i32,
+        flavor: i32,
+        arg: u64,
+        buffer: *mut std::ffi::c_void,
+        buffersize: i32,
+    ) -> i32;
+}
+
+#[cfg(target_os = "macos")]
+fn c_name(buf: &[u8]) -> String {
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..end]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn list_all_pids() -> Vec<i32> {
+    unsafe {
+        let hint = proc_listallpids(std::ptr::null_mut(), 0);
+        if hint <= 0 {
+            return Vec::new();
+        }
+        let mut buf = vec![0i32; hint as usize + 64];
+        let bytes = (buf.len() * std::mem::size_of::<i32>()) as i32;
+        let n = proc_listallpids(buf.as_mut_ptr() as *mut std::ffi::c_void, bytes);
+        if n <= 0 {
+            return Vec::new();
+        }
+        buf.truncate(n as usize);
+        buf.retain(|&p| p > 0);
+        buf
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn pid_path(pid: i32) -> String {
+    let mut buf = [0u8; 4096];
+    let n = unsafe {
+        proc_pidpath(
+            pid,
+            buf.as_mut_ptr() as *mut std::ffi::c_void,
+            buf.len() as u32,
+        )
+    };
+    if n <= 0 {
+        return String::new();
+    }
+    String::from_utf8_lossy(&buf[..n as usize]).into_owned()
+}
+
+#[cfg(target_os = "macos")]
+fn pid_bsdinfo(pid: i32) -> Option<ProcBsdInfo> {
+    let mut info = ProcBsdInfo::default();
+    let sz = std::mem::size_of::<ProcBsdInfo>() as i32;
+    let n = unsafe {
+        proc_pidinfo(
+            pid,
+            PROC_PIDTBSDINFO,
+            0,
+            &mut info as *mut _ as *mut std::ffi::c_void,
+            sz,
+        )
+    };
+    (n == sz).then_some(info)
+}
+
+#[cfg(target_os = "macos")]
+fn list_stage1() -> Vec<Stage1> {
+    list_all_pids()
+        .into_iter()
+        .filter_map(|pid| {
+            let bsd = pid_bsdinfo(pid)?;
+            let path = pid_path(pid);
+            let comm = {
+                let name = c_name(&bsd.pbi_name);
+                if name.is_empty() {
+                    c_name(&bsd.pbi_comm)
+                } else {
+                    name
+                }
+            };
+            Some(Stage1 {
+                pid: if bsd.pbi_pid != 0 {
+                    bsd.pbi_pid
+                } else {
+                    pid as u32
+                },
+                ppid: bsd.pbi_ppid,
+                start_time: bsd.pbi_start_tvsec,
+                path,
+                comm,
+            })
+        })
+        .collect()
 }
 
 /// Stage-1 filter: exe path or `comm` looks like an agent or a wrapper that
@@ -1115,17 +1341,16 @@ fn activate(_pid: u32) -> bool {
     false
 }
 
-/// How long the island should wait between scans: quick while sessions are
-/// live (status changes matter), relaxed once none have been seen for a
-/// while — a newly started agent then appears within one slow tick, which is
-/// fine for a status glance and keeps the recurring process-table walk off
-/// the battery.
+/// How long the island should wait between scans: 2s while a session was
+/// seen recently, 5s once none are active — a newly started agent then
+/// appears within one slow tick, which is fine for a status glance and
+/// keeps the recurring process-table walk off the battery.
 pub fn poll_interval() -> Duration {
     let last = LAST_AGENT_SEEN.load(std::sync::atomic::Ordering::Relaxed);
     if unix_secs().saturating_sub(last) < 30 {
         Duration::from_secs(2)
     } else {
-        Duration::from_secs(6)
+        Duration::from_secs(5)
     }
 }
 
@@ -1227,6 +1452,37 @@ mod tests {
         assert!(!is_scan_seed("/usr/bin/grep", "grep"));
         assert!(!is_scan_seed("/Applications/Safari.app/Contents/MacOS/Safari", "Safari"));
         assert!(!is_scan_seed("/usr/sbin/syslogd", "syslogd"));
+    }
+
+    #[test]
+    fn argv_cache_hits_only_matching_start_time() {
+        let mut cache = HashMap::new();
+        cache.insert(
+            7,
+            CachedDetail {
+                start_time: 100,
+                name: "claude".into(),
+                argv: vec!["claude".into()],
+                cwd: None,
+                exe: None,
+            },
+        );
+        assert!(cache_lookup(&cache, 7, 100).is_some());
+        assert!(cache_lookup(&cache, 7, 101).is_none());
+        assert!(cache_lookup(&cache, 7, 0).is_none());
+        assert!(cache_lookup(&cache, 8, 100).is_none());
+        let live = HashSet::from([8u32]);
+        prune_detail_cache(&mut cache, &live);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn poll_interval_is_5s_when_no_recent_session() {
+        let prev = LAST_AGENT_SEEN.swap(0, std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(poll_interval(), Duration::from_secs(5));
+        LAST_AGENT_SEEN.store(unix_secs(), std::sync::atomic::Ordering::Relaxed);
+        assert_eq!(poll_interval(), Duration::from_secs(2));
+        LAST_AGENT_SEEN.store(prev, std::sync::atomic::Ordering::Relaxed);
     }
 
     #[test]

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -308,12 +308,75 @@ fn safari_artwork_url<'a>(page_url: &str, artwork_url: &'a str) -> Option<&'a st
 /// waiting out its idle cadence.
 static MEDIA_EVENT: AtomicBool = AtomicBool::new(false);
 
+/// Launch Services snapshot of the AppleScript fallback players, refreshed
+/// from `NSWorkspace` launch/terminate notifications instead of walking the
+/// process table. Bit0 = primed, bit1 = Spotify, bit2 = Music, bit3 = Safari.
+static MEDIA_APPS: std::sync::atomic::AtomicU8 = std::sync::atomic::AtomicU8::new(0);
+const MEDIA_APPS_PRIMED: u8 = 1 << 0;
+const MEDIA_APP_SPOTIFY: u8 = 1 << 1;
+const MEDIA_APP_MUSIC: u8 = 1 << 2;
+const MEDIA_APP_SAFARI: u8 = 1 << 3;
+
 pub fn note_media_event() {
     MEDIA_EVENT.store(true, Ordering::Relaxed);
 }
 
 pub fn take_media_event() -> bool {
     MEDIA_EVENT.swap(false, Ordering::Relaxed)
+}
+
+/// Record that a media-capable app launched or quit. Unknown bundle ids are
+/// ignored so the workspace observers can be wired to every app event.
+pub fn note_media_app_running(bundle_id: &str, running: bool) {
+    let bit = match bundle_id {
+        "com.spotify.client" => MEDIA_APP_SPOTIFY,
+        "com.apple.Music" => MEDIA_APP_MUSIC,
+        "com.apple.Safari" => MEDIA_APP_SAFARI,
+        _ => return,
+    };
+    let mut packed = MEDIA_APPS.load(Ordering::Relaxed) | MEDIA_APPS_PRIMED;
+    if running {
+        packed |= bit;
+    } else {
+        packed &= !bit;
+    }
+    MEDIA_APPS.store(packed, Ordering::Relaxed);
+}
+
+/// `(spotify, music, safari)` from the launch/terminate cache, priming via
+/// `NSRunningApplication` once if no observer has run yet.
+#[cfg(target_os = "macos")]
+fn media_players_running() -> (bool, bool, bool) {
+    let packed = MEDIA_APPS.load(Ordering::Relaxed);
+    if packed & MEDIA_APPS_PRIMED == 0 {
+        return prime_media_apps();
+    }
+    (
+        packed & MEDIA_APP_SPOTIFY != 0,
+        packed & MEDIA_APP_MUSIC != 0,
+        packed & MEDIA_APP_SAFARI != 0,
+    )
+}
+
+/// Seed the media-app bits from Launch Services. Called from
+/// `install_media_observers` so the first AppleScript poll does not race.
+#[cfg(target_os = "macos")]
+pub fn prime_media_apps() -> (bool, bool, bool) {
+    let spotify = app_running(c"com.spotify.client");
+    let music = app_running(c"com.apple.Music");
+    let safari = app_running(c"com.apple.Safari");
+    let mut packed = MEDIA_APPS_PRIMED;
+    if spotify {
+        packed |= MEDIA_APP_SPOTIFY;
+    }
+    if music {
+        packed |= MEDIA_APP_MUSIC;
+    }
+    if safari {
+        packed |= MEDIA_APP_SAFARI;
+    }
+    MEDIA_APPS.store(packed, Ordering::Relaxed);
+    (spotify, music, safari)
 }
 
 /// Whether an app with this bundle id is running, via Launch Services.
@@ -365,11 +428,7 @@ pub async fn get_now_playing() -> NowPlayingData {
         // Services' in-process app list — no walk of the whole process table
         // (the sysinfo refresh this replaces enumerated every pid on the
         // system each poll, a measurable slice of idle CPU).
-        let (spotify_running, music_running, safari_running) = (
-            app_running(c"com.spotify.client"),
-            app_running(c"com.apple.Music"),
-            app_running(c"com.apple.Safari"),
-        );
+        let (spotify_running, music_running, safari_running) = media_players_running();
 
         // If no relevant apps are running, return early with no overhead
         if !spotify_running && !music_running && !safari_running {
@@ -1402,6 +1461,22 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn media_app_running_cache_ignores_unrelated_bundles() {
+        note_media_app_running("com.apple.finder", true);
+        note_media_app_running("com.spotify.client", true);
+        note_media_app_running("com.apple.Music", false);
+        note_media_app_running("com.apple.Safari", true);
+        let packed = MEDIA_APPS.load(Ordering::Relaxed);
+        assert_ne!(packed & MEDIA_APPS_PRIMED, 0);
+        assert_ne!(packed & MEDIA_APP_SPOTIFY, 0);
+        assert_eq!(packed & MEDIA_APP_MUSIC, 0);
+        assert_ne!(packed & MEDIA_APP_SAFARI, 0);
+        note_media_app_running("com.spotify.client", false);
+        let packed = MEDIA_APPS.load(Ordering::Relaxed);
+        assert_eq!(packed & MEDIA_APP_SPOTIFY, 0);
     }
 
     #[test]

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -25,6 +25,8 @@ pub fn init_audio_state() {
     let _ = AUDIO_LEVELS.set(std::sync::Mutex::new(vec![0.15; 6]));
     let _ = TRACK_CACHE.set(std::sync::Mutex::new((None, None, None)));
     let _ = LAST_PLAYED.set(std::sync::Mutex::new(None));
+    #[cfg(target_os = "macos")]
+    crate::mediaremote::ensure_stream();
 }
 
 fn lock_mutex<T>(m: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
@@ -337,7 +339,8 @@ fn app_running(bundle_id: &std::ffi::CStr) -> bool {
 /// Get currently playing music information.
 ///
 /// On macOS this prefers MediaRemote via [mediaremote-adapter]
-/// (`get --now`), which works for any now-playing app on 15.4+.
+/// (live `stream` cell, `get --now` only as primer / fallback),
+/// which works for any now-playing app on 15.4+.
 /// AppleScript (Spotify / Music / Safari) is the fallback.
 ///
 /// [mediaremote-adapter]: https://github.com/ungive/mediaremote-adapter

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -2,6 +2,9 @@ use crate::models::NowPlayingData;
 use crate::utils::fetch_artwork_from_url;
 
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::OnceLock;
+use std::time::Duration;
+use tokio::sync::Notify;
 
 /// Global state for audio levels (updated by audio monitoring thread)
 static AUDIO_LEVELS: std::sync::OnceLock<std::sync::Mutex<Vec<f64>>> = std::sync::OnceLock::new();
@@ -317,12 +320,38 @@ const MEDIA_APP_SPOTIFY: u8 = 1 << 1;
 const MEDIA_APP_MUSIC: u8 = 1 << 2;
 const MEDIA_APP_SAFARI: u8 = 1 << 3;
 
+static MEDIA_WAKE: OnceLock<Notify> = OnceLock::new();
+
+fn media_wake() -> &'static Notify {
+    MEDIA_WAKE.get_or_init(Notify::new)
+}
+
 pub fn note_media_event() {
     MEDIA_EVENT.store(true, Ordering::Relaxed);
+    media_wake().notify_waiters();
 }
 
 pub fn take_media_event() -> bool {
     MEDIA_EVENT.swap(false, Ordering::Relaxed)
+}
+
+/// Park until a playback-change poke or `timeout`.
+///
+/// The island now-playing loop uses this so idle is one timer, not a 250 ms
+/// poll of the event flag. Subscribe before checking the flag so a poke that
+/// lands in between cannot be missed.
+pub async fn wait_media_or_timeout(timeout: Duration) {
+    let notified = media_wake().notified();
+    tokio::pin!(notified);
+    if MEDIA_EVENT.swap(false, Ordering::Relaxed) {
+        return;
+    }
+    tokio::select! {
+        _ = notified => {
+            let _ = MEDIA_EVENT.swap(false, Ordering::Relaxed);
+        }
+        _ = tokio::time::sleep(timeout) => {}
+    }
 }
 
 /// Record that a media-capable app launched or quit. Unknown bundle ids are
@@ -1488,5 +1517,41 @@ mod tests {
             ),
             Some("https://music.youtube.com/favicon.ico")
         );
+    }
+
+    static MEDIA_WAIT_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn wait_media_returns_when_event_already_set() {
+        let _g = MEDIA_WAIT_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = take_media_event();
+        note_media_event();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let start = std::time::Instant::now();
+        rt.block_on(wait_media_or_timeout(Duration::from_secs(3)));
+        assert!(start.elapsed() < Duration::from_millis(250));
+    }
+
+    #[test]
+    fn wait_media_wakes_on_note() {
+        let _g = MEDIA_WAIT_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        let _ = take_media_event();
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let start = std::time::Instant::now();
+        rt.block_on(async {
+            let waiter = wait_media_or_timeout(Duration::from_secs(3));
+            let poker = async {
+                tokio::time::sleep(Duration::from_millis(15)).await;
+                note_media_event();
+            };
+            tokio::join!(waiter, poker);
+        });
+        assert!(start.elapsed() < Duration::from_millis(500));
     }
 }

--- a/crates/nook-core/src/audio.rs
+++ b/crates/nook-core/src/audio.rs
@@ -1,4 +1,4 @@
-use crate::models::NowPlayingData;
+use crate::models::{NowPlayingData, QueueItem};
 use crate::utils::fetch_artwork_from_url;
 
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -765,6 +765,16 @@ pub async fn get_now_playing() -> NowPlayingData {
 
         get_last_played_or_default(get_audio_levels())
     }
+}
+
+/// Jump to an Up Next row. Music uses `play track i of current playlist`;
+/// Spotify uses context+offset or N sequential nexts.
+pub async fn media_jump_to_queue_item(
+    item: QueueItem,
+    context_uri: Option<String>,
+) -> Result<(), String> {
+    note_media_event();
+    crate::queue::jump_to_item(&item, context_uri.as_deref()).await
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -18,11 +18,13 @@ pub mod notch;
 pub mod notes;
 pub mod observe;
 pub mod occupancy;
+pub mod queue;
 pub mod settings;
+pub mod spotify;
 pub mod utils;
 pub mod widgets;
 
-pub use models::{NotchInfo, NowPlayingData};
+pub use models::{NotchInfo, NowPlayingData, PlaybackQueue, QueueItem};
 pub use settings::{AppSettings, WindowSettings};
 
 use std::sync::{Once, OnceLock};
@@ -62,6 +64,7 @@ pub fn init() {
         }
         audio::init_audio_state();
         audio::setup_audio_monitoring();
+        crate::spotify::hydrate_status();
         mouse::start_polling();
     });
 }

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,7 +10,6 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
-#[cfg(target_os = "macos")]
 mod mediaremote;
 pub mod models;
 pub mod mouse;

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod calendar;
 pub mod database;
 pub mod files;
 pub mod haptics;
+#[cfg(any(target_os = "macos", test))]
 mod mediaremote;
 pub mod models;
 pub mod mouse;

--- a/crates/nook-core/src/mediaremote.rs
+++ b/crates/nook-core/src/mediaremote.rs
@@ -11,10 +11,14 @@
 //!
 //! [mediaremote-adapter]: https://github.com/ungive/mediaremote-adapter
 
-use serde_json::Value;
+use serde::Deserialize;
+use serde_json::{Map, Value};
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::Command;
-use std::sync::OnceLock;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, Once, OnceLock};
+use std::time::{Duration, Instant};
 
 /// MediaRemote `MRCommand` / adapter `MRACommand` IDs.
 #[derive(Debug, Clone, Copy)]
@@ -180,6 +184,247 @@ fn find_media_control() -> Option<PathBuf> {
     None
 }
 
+fn adapter_supports_stream() -> bool {
+    matches!(backend(), Some(Backend::Adapter { .. }))
+}
+
+struct StreamState {
+    merged: Value,
+    track: Option<AdapterTrack>,
+    elapsed_base: Option<f64>,
+    elapsed_at: Instant,
+    playing: bool,
+    primed: bool,
+}
+
+impl StreamState {
+    fn fresh() -> Self {
+        Self {
+            merged: Value::Object(Map::new()),
+            track: None,
+            elapsed_base: None,
+            elapsed_at: Instant::now(),
+            playing: false,
+            primed: false,
+        }
+    }
+}
+
+fn stream_state() -> &'static Mutex<StreamState> {
+    static STATE: OnceLock<Mutex<StreamState>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(StreamState::fresh()))
+}
+
+static STREAM_CHANGED: AtomicBool = AtomicBool::new(false);
+static STREAM_ALIVE: AtomicBool = AtomicBool::new(false);
+
+#[derive(Deserialize)]
+struct StreamEvent {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    diff: bool,
+    #[serde(default)]
+    payload: Value,
+}
+
+/// Spawn the long-lived adapter `stream --diff` child (once). No-op for the
+/// debug `media-control` backend and when the adapter is missing.
+pub fn ensure_stream() {
+    if !adapter_supports_stream() {
+        return;
+    }
+    static STARTED: Once = Once::new();
+    STARTED.call_once(|| {
+        let _ = std::thread::Builder::new()
+            .name("nook-mr-stream".into())
+            .spawn(stream_supervisor);
+    });
+}
+
+/// Latest snapshot from the live stream, with `elapsed_time` interpolated
+/// from the last event while playing. `None` if the stream has not produced
+/// a snapshot yet (caller should one-shot `get --now`).
+pub fn latest_now_playing() -> Option<Option<AdapterTrack>> {
+    let Ok(state) = stream_state().lock() else {
+        return None;
+    };
+    if !state.primed {
+        return None;
+    }
+    Some(interpolated_track(&state))
+}
+
+pub fn take_stream_changed() -> bool {
+    STREAM_CHANGED.swap(false, Ordering::Relaxed)
+}
+
+pub fn stream_is_live() -> bool {
+    STREAM_ALIVE.load(Ordering::Relaxed)
+}
+
+fn interpolated_track(state: &StreamState) -> Option<AdapterTrack> {
+    let mut track = state.track.clone()?;
+    if state.playing {
+        if let Some(base) = state.elapsed_base.or(track.elapsed_time) {
+            let mut elapsed = base + state.elapsed_at.elapsed().as_secs_f64();
+            if let Some(duration) = track.duration {
+                elapsed = elapsed.min(duration.max(0.0));
+            }
+            track.elapsed_time = Some(elapsed);
+        }
+    }
+    Some(track)
+}
+
+fn merge_diff(target: &mut Value, diff: Value) {
+    let Value::Object(diff_map) = diff else {
+        if !diff.is_null() {
+            *target = diff;
+        }
+        return;
+    };
+    if !target.is_object() {
+        *target = Value::Object(Map::new());
+    }
+    let Some(map) = target.as_object_mut() else {
+        return;
+    };
+    for (k, v) in diff_map {
+        if v.is_null() {
+            map.remove(&k);
+        } else {
+            map.insert(k, v);
+        }
+    }
+}
+
+fn apply_payload(diff: bool, payload: Value) {
+    let mut state = stream_state().lock().unwrap_or_else(|e| e.into_inner());
+    if diff {
+        merge_diff(&mut state.merged, payload);
+    } else {
+        state.merged = match payload {
+            Value::Object(map) => Value::Object(map),
+            Value::Null => Value::Object(Map::new()),
+            other => other,
+        };
+    }
+    let json = serde_json::to_string(&state.merged).unwrap_or_else(|_| "{}".into());
+    let track = parse_get_output(&json).ok().flatten();
+    state.playing = track.as_ref().map(|t| t.is_playing).unwrap_or(false);
+    state.elapsed_base = track.as_ref().and_then(|t| t.elapsed_time);
+    state.elapsed_at = Instant::now();
+    state.track = track;
+    state.primed = true;
+    STREAM_CHANGED.store(true, Ordering::Relaxed);
+    drop(state);
+    crate::audio::note_media_event();
+}
+
+fn apply_stream_event(line: &str) -> bool {
+    let ev: StreamEvent = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(err) => {
+            log::debug!("MediaRemote stream JSON: {err}");
+            return false;
+        }
+    };
+    if ev.kind != "data" {
+        return false;
+    }
+    apply_payload(ev.diff, ev.payload);
+    true
+}
+
+fn apply_primer_stdout(stdout: &str) {
+    let trimmed = stdout.trim();
+    let payload = if trimmed.is_empty() || trimmed == "null" {
+        Value::Object(Map::new())
+    } else {
+        serde_json::from_str(trimmed).unwrap_or_else(|_| Value::Object(Map::new()))
+    };
+    apply_payload(false, payload);
+}
+
+fn stream_supervisor() {
+    if let Ok(out) = run(&["get", "--now"]) {
+        apply_primer_stdout(&out);
+    }
+    let mut backoff = Duration::from_millis(200);
+    loop {
+        match spawn_stream_child() {
+            Ok(mut child) => {
+                STREAM_ALIVE.store(true, Ordering::Relaxed);
+                backoff = Duration::from_millis(200);
+                let _ = read_stream(&mut child);
+                STREAM_ALIVE.store(false, Ordering::Relaxed);
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            Err(err) => {
+                log::debug!("MediaRemote stream spawn failed: {err}");
+            }
+        }
+        std::thread::sleep(backoff);
+        backoff = (backoff * 2).min(Duration::from_secs(8));
+    }
+}
+
+fn spawn_stream_child() -> Result<std::process::Child, String> {
+    let Some(Backend::Adapter {
+        perl,
+        script,
+        framework,
+    }) = backend()
+    else {
+        return Err("MediaRemote stream needs the adapter backend".into());
+    };
+    Command::new(perl)
+        .arg(script)
+        .arg(framework)
+        .arg("stream")
+        .arg("--diff")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|e| format!("failed to spawn MediaRemote stream: {e}"))
+}
+
+fn read_stream(child: &mut std::process::Child) -> bool {
+    let Some(stdout) = child.stdout.take() else {
+        return false;
+    };
+    let pid = child.id();
+    let first = std::sync::Arc::new(AtomicBool::new(false));
+    let first_flag = first.clone();
+    let _ = std::thread::Builder::new()
+        .name("nook-mr-watchdog".into())
+        .spawn(move || {
+            std::thread::sleep(Duration::from_secs(3));
+            if !first_flag.load(Ordering::Relaxed) {
+                let _ = Command::new("/bin/kill").arg(pid.to_string()).status();
+            }
+        });
+    let reader = BufReader::new(stdout);
+    let mut saw_line = false;
+    for line in reader.lines() {
+        let Ok(line) = line else {
+            break;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        if !saw_line {
+            saw_line = true;
+            first.store(true, Ordering::Relaxed);
+        }
+        apply_stream_event(&line);
+    }
+    saw_line
+}
+
 fn run(args: &[&str]) -> Result<String, String> {
     let backend = backend().ok_or_else(|| "MediaRemote adapter not available".to_string())?;
     let mut cmd = match backend {
@@ -211,7 +456,13 @@ fn run(args: &[&str]) -> Result<String, String> {
 }
 
 /// `adapter_get` / `get --now`. `Ok(None)` means no now-playing item (`null`).
+/// Prefers the live `stream` cell when the supervisor has primed it so a
+/// poll never forks perl. One-shot `get --now` remains the startup primer
+/// and the debug `media-control` path.
 pub fn get_now_playing() -> Result<Option<AdapterTrack>, String> {
+    if let Some(cached) = latest_now_playing() {
+        return Ok(cached);
+    }
     let stdout = run(&["get", "--now"])?;
     parse_get_output(&stdout)
 }
@@ -442,6 +693,94 @@ mod tests {
     #[test]
     fn release_build_has_no_ambient_backend_fallback() {
         assert!(development_backend().is_none());
+    }
+
+    static STREAM_TEST: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn reset_stream() {
+        let mut state = stream_state().lock().unwrap_or_else(|e| e.into_inner());
+        *state = StreamState::fresh();
+        STREAM_CHANGED.store(false, Ordering::Relaxed);
+    }
+
+    #[test]
+    fn stream_full_replace_then_diff_merge() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        assert!(apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{
+                "title":"Helpless","artist":"The Staves","playing":true,
+                "duration":214.2,"elapsedTime":12,
+                "bundleIdentifier":"com.spotify.client"
+            }}"#
+        ));
+        let track = latest_now_playing().unwrap().unwrap();
+        assert_eq!(track.title.as_deref(), Some("Helpless"));
+        let elapsed = track.elapsed_time.unwrap();
+        assert!(elapsed >= 12.0 && elapsed < 12.2, "elapsed={elapsed}");
+        assert!(track.is_playing);
+
+        assert!(apply_stream_event(
+            r#"{"type":"data","diff":true,"payload":{"elapsedTime":40,"playing":false}}"#
+        ));
+        let track = latest_now_playing().unwrap().unwrap();
+        assert_eq!(track.title.as_deref(), Some("Helpless"));
+        assert_eq!(track.elapsed_time, Some(40.0));
+        assert!(!track.is_playing);
+        assert!(take_stream_changed());
+    }
+
+    #[test]
+    fn stream_empty_payload_is_idle() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"X","playing":true,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        apply_stream_event(r#"{"type":"data","diff":false,"payload":{}}"#);
+        assert!(latest_now_playing().unwrap().is_none());
+    }
+
+    #[test]
+    fn stream_diff_null_removes_key() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","artist":"B","playing":true,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        apply_stream_event(r#"{"type":"data","diff":true,"payload":{"title":null}}"#);
+        assert!(latest_now_playing().unwrap().is_none());
+    }
+
+    #[test]
+    fn elapsed_interpolates_while_playing() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","playing":true,"elapsedTime":10,"duration":100,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        let elapsed = latest_now_playing()
+            .unwrap()
+            .unwrap()
+            .elapsed_time
+            .unwrap();
+        assert!(elapsed >= 10.03, "elapsed={elapsed}");
+        assert!(elapsed < 11.0, "elapsed={elapsed}");
+    }
+
+    #[test]
+    fn elapsed_does_not_advance_when_paused() {
+        let _guard = STREAM_TEST.lock().unwrap_or_else(|e| e.into_inner());
+        reset_stream();
+        apply_stream_event(
+            r#"{"type":"data","diff":false,"payload":{"title":"A","playing":false,"elapsedTime":10,"duration":100,"bundleIdentifier":"com.spotify.client"}}"#,
+        );
+        std::thread::sleep(Duration::from_millis(40));
+        assert_eq!(
+            latest_now_playing().unwrap().unwrap().elapsed_time,
+            Some(10.0)
+        );
     }
 
     #[test]

--- a/crates/nook-core/src/models.rs
+++ b/crates/nook-core/src/models.rs
@@ -42,3 +42,62 @@ pub struct NowPlayingData {
     #[serde(default)]
     pub bundle_id: Option<String>,
 }
+
+/// Where an Up Next row came from. Kept off [`NowPlayingData`] so the hot
+/// now-playing path stays a single track snapshot.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueSource {
+    MusicPlaylist,
+    Spotify,
+}
+
+/// Why the island hides the upcoming list. Music's real Playing Next queue
+/// is unreadable; shuffle/radio is the honest fallback.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueHidden {
+    Shuffle,
+    Radio,
+    Idle,
+    NeedsSpotifyAuth,
+    PremiumRequired,
+    AutomationDenied,
+}
+
+/// Handle used by [`crate::audio::media_jump_to_queue_item`].
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum QueueJump {
+    /// 1-based `play track i of current playlist` in Music.app.
+    MusicTrack { index: u32 },
+    /// Sequential `POST /v1/me/player/next` count, plus the track uri so we
+    /// can try `PUT /v1/me/player/play` with context+offset first.
+    Spotify {
+        skip_count: u32,
+        uri: String,
+    },
+}
+
+/// One upcoming row. Artwork stays optional: Spotify uses a 64px URL (lazy),
+/// Music rows may ship without art.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct QueueItem {
+    pub id: String,
+    pub title: String,
+    pub artist: String,
+    pub artwork_url: Option<String>,
+    pub artwork_base64: Option<String>,
+    pub source: QueueSource,
+    pub jump: QueueJump,
+}
+
+/// Separate fetch from now-playing. Empty `items` + no `hidden` means "nothing
+/// to show", not an error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct PlaybackQueue {
+    pub source: Option<QueueSource>,
+    pub label: String,
+    pub items: Vec<QueueItem>,
+    pub hidden: Option<QueueHidden>,
+    pub context_uri: Option<String>,
+}

--- a/crates/nook-core/src/mouse.rs
+++ b/crates/nook-core/src/mouse.rs
@@ -185,7 +185,11 @@ fn contains((x0, x1, y0, y1): (f64, f64, f64, f64), x: f64, y: f64) -> bool {
     x >= x0 && x <= x1 && y >= y0 && y <= y1
 }
 
-/// Sample the cursor off the UI thread. Safe to call more than once.
+/// Sample the cursor. On macOS this is a 250 ms backstop — NSEvent global
+/// and local monitors (installed on the main thread from `platform`) write
+/// the same atomics on every move/drag. Monitors can drop during secure
+/// input or some full-screen games; the slow poll is how hover still exits.
+/// Windows/Linux keep the tighter poll (no AppKit monitors).
 pub fn start_polling() {
     if POLL_STARTED.swap(true, Ordering::SeqCst) {
         return;
@@ -195,20 +199,33 @@ pub fn start_polling() {
         .name("nook-mouse".into())
         .spawn(|| loop {
             sample_now();
-            let inside = {
-                let (mx, my) = current_mouse_logical();
-                hit_test(mx, my)
-            };
-            let ms = if inside || DRAG_ACTIVE.load(Ordering::Relaxed) {
-                20
-            } else {
-                33
-            };
+            let ms = poll_interval_ms();
             std::thread::sleep(std::time::Duration::from_millis(ms));
         });
 }
 
-fn sample_now() {
+fn poll_interval_ms() -> u64 {
+    #[cfg(target_os = "macos")]
+    {
+        250
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let inside = {
+            let (mx, my) = current_mouse_logical();
+            hit_test(mx, my)
+        };
+        if inside || DRAG_ACTIVE.load(Ordering::Relaxed) {
+            20
+        } else {
+            33
+        }
+    }
+}
+
+/// Read cursor + drag into the atomics. Safe from NSEvent monitor handlers
+/// (main thread) and from the safety-poll thread.
+pub fn sample_now() {
     let (x, y) = read_mouse_logical();
     MOUSE_X.store(x.to_bits(), Ordering::Relaxed);
     MOUSE_Y.store(y.to_bits(), Ordering::Relaxed);

--- a/crates/nook-core/src/occupancy.rs
+++ b/crates/nook-core/src/occupancy.rs
@@ -8,8 +8,8 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Refresh at most this often — `CGWindowListCopyWindowInfo` is not cheap
-/// enough for the 20 ms mouse poll.
-const CACHE_MS: u64 = 250;
+/// enough for the mouse path. App-activate notifications invalidate sooner.
+const CACHE_MS: u64 = 1000;
 
 static CACHE: AtomicBool = AtomicBool::new(false);
 static LAST_MS: AtomicU64 = AtomicU64::new(0);
@@ -42,9 +42,19 @@ pub fn window_fills_display(window: ScreenRect, screen: ScreenRect, visible: Scr
     window.covers(screen, TOL) || window.covers(visible, TOL)
 }
 
+/// Drop the occupancy cache so the next sample talks to the window server.
+/// Driven from `NSWorkspaceDidActivateApplicationNotification`.
+pub fn invalidate() {
+    LAST_MS.store(0, Ordering::Relaxed);
+}
+
 /// Cached sample of [`query_frontmost_fills`]. Safe to call from the island
-/// poll loop.
+/// poll loop. No-ops when hide-when-maximized is off so the window-list
+/// walk never runs for users who disabled the setting.
 pub fn frontmost_fills_display() -> bool {
+    if !crate::settings::get_app_settings().hide_when_maximized {
+        return false;
+    }
     let now = unix_ms();
     let last = LAST_MS.load(Ordering::Relaxed);
     if now.saturating_sub(last) < CACHE_MS {
@@ -297,5 +307,15 @@ mod tests {
             screen,
             visible
         ));
+    }
+
+    #[test]
+    fn hide_when_maximized_off_is_a_cheap_false() {
+        invalidate();
+        assert!(
+            !crate::settings::get_app_settings().hide_when_maximized,
+            "default settings keep the occupancy walk off"
+        );
+        assert!(!frontmost_fills_display());
     }
 }

--- a/crates/nook-core/src/queue.rs
+++ b/crates/nook-core/src/queue.rs
@@ -1,0 +1,358 @@
+//! Playing Next / Up Next snapshot. Kept off the hot now-playing struct.
+//!
+//! Music.app: AppleScript `current playlist` window after the current index.
+//! This is **not** Music's real Playing Next queue — hide it under shuffle
+//! or radio/autoplay. Spotify: Web API via [`crate::spotify`].
+
+use crate::models::{
+    NowPlayingData, PlaybackQueue, QueueHidden, QueueItem, QueueJump, QueueSource,
+};
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+const MUSIC_WINDOW: usize = 10;
+static MUSIC_TCC_DENIED: AtomicBool = AtomicBool::new(false);
+static ART_READY: AtomicBool = AtomicBool::new(false);
+static ART_CACHE: OnceLock<Mutex<HashMap<String, Option<String>>>> = OnceLock::new();
+static ART_INFLIGHT: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+
+pub fn music_automation_denied() -> bool {
+    MUSIC_TCC_DENIED.load(Ordering::Relaxed)
+}
+
+pub fn take_artwork_ready() -> bool {
+    ART_READY.swap(false, Ordering::Relaxed)
+}
+
+fn art_cache() -> &'static Mutex<HashMap<String, Option<String>>> {
+    ART_CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn art_inflight() -> &'static Mutex<HashSet<String>> {
+    ART_INFLIGHT.get_or_init(|| Mutex::new(HashSet::new()))
+}
+
+pub fn cached_artwork(id: &str) -> Option<Option<String>> {
+    art_cache()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(id)
+        .cloned()
+}
+
+/// Lazy 64px Spotify art. Completes by flipping [`take_artwork_ready`]; no timer.
+pub fn request_artwork(id: String, url: String) {
+    if url.is_empty() || id.is_empty() {
+        return;
+    }
+    {
+        let cache = art_cache().lock().unwrap_or_else(|e| e.into_inner());
+        if cache.contains_key(&id) {
+            return;
+        }
+    }
+    {
+        let mut inflight = art_inflight().lock().unwrap_or_else(|e| e.into_inner());
+        if !inflight.insert(id.clone()) {
+            return;
+        }
+    }
+    crate::runtime().spawn(async move {
+        let art = crate::utils::fetch_artwork_from_url(&url).await;
+        art_cache()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .insert(id, art);
+        ART_READY.store(true, Ordering::Relaxed);
+        crate::audio::note_media_event();
+    });
+}
+
+pub fn is_music_app(app_name: Option<&str>, bundle_id: Option<&str>) -> bool {
+    let bundle = bundle_id.unwrap_or("");
+    let name = app_name.unwrap_or("");
+    bundle.eq_ignore_ascii_case("com.apple.Music")
+        || name.eq_ignore_ascii_case("Music")
+        || name.eq_ignore_ascii_case("iTunes")
+}
+
+pub fn is_spotify_app(app_name: Option<&str>, bundle_id: Option<&str>) -> bool {
+    let bundle = bundle_id.unwrap_or("");
+    let name = app_name.unwrap_or("");
+    bundle.eq_ignore_ascii_case("com.spotify.client") || name.eq_ignore_ascii_case("Spotify")
+}
+
+pub fn queue_identity(np: &NowPlayingData) -> (Option<String>, Option<String>, Option<String>) {
+    (np.title.clone(), np.artist.clone(), np.app_name.clone())
+}
+
+/// Upcoming Music tracks after `current_index` (1-based). Empty when shuffle
+/// or radio should hide the section.
+pub fn music_window(
+    current_index: u32,
+    tracks: &[(u32, String, String)],
+    shuffle: bool,
+    radio: bool,
+    limit: usize,
+) -> Result<Vec<QueueItem>, QueueHidden> {
+    if shuffle {
+        return Err(QueueHidden::Shuffle);
+    }
+    if radio {
+        return Err(QueueHidden::Radio);
+    }
+    if current_index == 0 {
+        return Err(QueueHidden::Idle);
+    }
+    let items = tracks
+        .iter()
+        .filter(|(index, _, _)| *index > current_index)
+        .take(limit)
+        .map(|(index, title, artist)| QueueItem {
+            id: format!("music-{index}"),
+            title: title.clone(),
+            artist: artist.clone(),
+            artwork_url: None,
+            artwork_base64: None,
+            source: QueueSource::MusicPlaylist,
+            jump: QueueJump::MusicTrack { index: *index },
+        })
+        .collect();
+    Ok(items)
+}
+
+/// Parse the AppleScript snapshot format:
+/// first line `ok|idx|total` / `hide|shuffle` / `hide|radio` / `denied|-1743` / `idle`
+/// then `index\ttitle\tartist` rows.
+pub fn parse_music_snapshot(stdout: &str) -> PlaybackQueue {
+    let mut lines = stdout.lines();
+    let header = lines.next().unwrap_or("").trim();
+    if header.is_empty() || header == "idle" {
+        return hidden(QueueHidden::Idle);
+    }
+    if header.starts_with("denied") {
+        MUSIC_TCC_DENIED.store(true, Ordering::Relaxed);
+        return hidden(QueueHidden::AutomationDenied);
+    }
+    if let Some(rest) = header.strip_prefix("hide|") {
+        let reason = match rest {
+            "shuffle" => QueueHidden::Shuffle,
+            "radio" => QueueHidden::Radio,
+            _ => QueueHidden::Idle,
+        };
+        return hidden(reason);
+    }
+    if !header.starts_with("ok|") {
+        return PlaybackQueue::default();
+    }
+    let mut parts = header.split('|');
+    let _ = parts.next();
+    let current_index = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let tracks = lines
+        .filter_map(|line| {
+            let mut cols = line.splitn(3, '\t');
+            let index = cols.next()?.parse().ok()?;
+            let title = cols.next()?.to_string();
+            let artist = cols.next().unwrap_or("").to_string();
+            Some((index, title, artist))
+        })
+        .collect::<Vec<_>>();
+    match music_window(current_index, &tracks, false, false, MUSIC_WINDOW) {
+        Ok(items) => {
+            MUSIC_TCC_DENIED.store(false, Ordering::Relaxed);
+            PlaybackQueue {
+                source: Some(QueueSource::MusicPlaylist),
+                label: "Up Next in playlist".into(),
+                items,
+                hidden: None,
+                context_uri: None,
+            }
+        }
+        Err(hidden_reason) => hidden(hidden_reason),
+    }
+}
+
+fn hidden(reason: QueueHidden) -> PlaybackQueue {
+    PlaybackQueue {
+        source: Some(QueueSource::MusicPlaylist),
+        label: "Up Next in playlist".into(),
+        items: Vec::new(),
+        hidden: Some(reason),
+        context_uri: None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+const MUSIC_QUEUE_SCRIPT: &str = r#"
+tell application "Music"
+    try
+        if player state is stopped then return "idle"
+        if shuffle enabled then return "hide|shuffle"
+        set trackClass to (class of current track as text)
+        if trackClass contains "URL" or trackClass contains "radio" then return "hide|radio"
+        set plClass to (class of current playlist as text)
+        if plClass contains "radio" then return "hide|radio"
+        set idx to index of current track
+        set total to count of tracks of current playlist
+        set firstIdx to idx + 1
+        set lastIdx to idx + 10
+        if lastIdx > total then set lastIdx to total
+        set out to "ok|" & idx & "|" & total
+        if firstIdx > total then return out
+        repeat with i from firstIdx to lastIdx
+            set t to track i of current playlist
+            set tName to name of t
+            set tArtist to ""
+            try
+                set tArtist to artist of t
+            end try
+            set out to out & return & i & tab & tName & tab & tArtist
+        end repeat
+        return out
+    on error errMsg number errNum
+        if errNum is -1743 then return "denied|-1743"
+        return "error|" & errNum & "|" & errMsg
+    end try
+end tell
+"#;
+
+#[cfg(target_os = "macos")]
+fn run_osascript(script: &str) -> Result<String, String> {
+    use std::process::Command;
+    let output = Command::new("/usr/bin/osascript")
+        .arg("-e")
+        .arg(script)
+        .output()
+        .map_err(|e| e.to_string())?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("-1743") || stderr.to_lowercase().contains("not allowed") {
+        MUSIC_TCC_DENIED.store(true, Ordering::Relaxed);
+        return Err("automation denied".into());
+    }
+    if !output.status.success() {
+        return Err(format!("osascript failed: {}", output.status));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+async fn fetch_music_queue() -> PlaybackQueue {
+    #[cfg(target_os = "macos")]
+    {
+        match run_osascript(MUSIC_QUEUE_SCRIPT) {
+            Ok(stdout) => parse_music_snapshot(&stdout),
+            Err(_) if music_automation_denied() => hidden(QueueHidden::AutomationDenied),
+            Err(err) => {
+                log::debug!("music queue: {err}");
+                PlaybackQueue::default()
+            }
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        PlaybackQueue::default()
+    }
+}
+
+pub async fn fetch_playback_queue(np: &NowPlayingData) -> PlaybackQueue {
+    if is_spotify_app(np.app_name.as_deref(), np.bundle_id.as_deref()) {
+        match crate::spotify::fetch_queue().await {
+            Ok(queue) => queue,
+            Err(err) => {
+                log::debug!("spotify queue: {err}");
+                PlaybackQueue {
+                    source: Some(QueueSource::Spotify),
+                    label: "Playing Next".into(),
+                    ..PlaybackQueue::default()
+                }
+            }
+        }
+    } else if is_music_app(np.app_name.as_deref(), np.bundle_id.as_deref()) {
+        fetch_music_queue().await
+    } else {
+        PlaybackQueue::default()
+    }
+}
+
+pub async fn jump_to_item(item: &QueueItem, context_uri: Option<&str>) -> Result<(), String> {
+    match &item.jump {
+        QueueJump::MusicTrack { index } => jump_music(*index),
+        QueueJump::Spotify { skip_count, uri } => {
+            crate::spotify::jump_to(*skip_count, uri, context_uri).await
+        }
+    }
+}
+
+fn jump_music(index: u32) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        let script = format!(
+            r#"tell application "Music" to play track {index} of current playlist"#
+        );
+        run_osascript(&script).map(|_| ())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = index;
+        Err("Music queue jump is only available on macOS".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn windowing_skips_current_and_caps() {
+        let tracks = (1u32..=20)
+            .map(|i| (i, format!("t{i}"), format!("a{i}")))
+            .collect::<Vec<_>>();
+        let items = music_window(7, &tracks, false, false, 10).unwrap();
+        assert_eq!(items.len(), 10);
+        assert_eq!(items[0].title, "t8");
+        assert_eq!(
+            items[0].jump,
+            QueueJump::MusicTrack { index: 8 }
+        );
+        assert_eq!(items[9].title, "t17");
+    }
+
+    #[test]
+    fn shuffle_and_radio_hide() {
+        let tracks = vec![(2, "x".into(), "y".into())];
+        assert_eq!(
+            music_window(1, &tracks, true, false, 10).unwrap_err(),
+            QueueHidden::Shuffle
+        );
+        assert_eq!(
+            music_window(1, &tracks, false, true, 10).unwrap_err(),
+            QueueHidden::Radio
+        );
+    }
+
+    #[test]
+    fn snapshot_ok_and_denied() {
+        let text = "ok|3|6\n4\tFour\tA\n5\tFive\tB\n";
+        let queue = parse_music_snapshot(text);
+        assert_eq!(queue.label, "Up Next in playlist");
+        assert_eq!(queue.items.len(), 2);
+        assert_eq!(queue.items[0].title, "Four");
+        assert_eq!(queue.hidden, None);
+
+        let denied = parse_music_snapshot("denied|-1743");
+        assert_eq!(denied.hidden, Some(QueueHidden::AutomationDenied));
+        assert!(music_automation_denied());
+
+        let shuffle = parse_music_snapshot("hide|shuffle");
+        assert_eq!(shuffle.hidden, Some(QueueHidden::Shuffle));
+        assert!(shuffle.items.is_empty());
+    }
+
+    #[test]
+    fn app_detection() {
+        assert!(is_music_app(Some("Music"), None));
+        assert!(is_music_app(None, Some("com.apple.Music")));
+        assert!(is_spotify_app(Some("Spotify"), None));
+        assert!(!is_spotify_app(Some("Safari"), Some("com.apple.Safari")));
+    }
+}

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -124,6 +124,13 @@ pub struct AppSettings {
     pub widget_order: Vec<WidgetModule>,
     #[serde(default = "default_true")]
     pub show_media: bool,
+    /// Upcoming list on the expanded Music pane. Off hides Music/Spotify queue
+    /// fetch entirely (no extra osascript / HTTPS when the card is open).
+    #[serde(default = "default_true")]
+    pub show_media_queue: bool,
+    /// Spotify developer-app client ID for PKCE. No client secret is stored.
+    #[serde(default)]
+    pub spotify_client_id: String,
     #[serde(default = "default_true")]
     pub show_calendar: bool,
     #[serde(default = "default_true")]
@@ -222,6 +229,8 @@ impl Default for AppSettings {
         Self {
             widget_order: default_widget_order(),
             show_media: true,
+            show_media_queue: true,
+            spotify_client_id: String::new(),
             show_calendar: true,
             show_reminders: true,
             show_agents: true,
@@ -602,6 +611,8 @@ mod tests {
         let parsed: AppSettings = serde_json::from_str(r#"{"liquid_glass_mode":true}"#).unwrap();
         assert_eq!(parsed.widget_order, default_widget_order());
         assert!(parsed.show_media);
+        assert!(parsed.show_media_queue);
+        assert!(parsed.spotify_client_id.is_empty());
         assert!(parsed.show_calendar);
         assert!(parsed.show_reminders);
         assert!(parsed.show_agents);

--- a/crates/nook-core/src/spotify.rs
+++ b/crates/nook-core/src/spotify.rs
@@ -1,0 +1,913 @@
+//! Spotify Web API: OAuth 2.0 PKCE, queue read, jump-to-item.
+//!
+//! No bundled client secret. The user supplies a developer-app client ID
+//! (Settings). Refresh token lives in the Keychain on macOS.
+
+use crate::models::{PlaybackQueue, QueueHidden, QueueItem, QueueJump, QueueSource};
+use crate::settings;
+use base64::Engine;
+use serde::Deserialize;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+pub const REDIRECT_URI: &str = "http://127.0.0.1:43821/callback";
+pub const REDIRECT_PORT: u16 = 43821;
+pub const AUTH_SCOPES: &str = "user-read-playback-state user-modify-playback-state";
+const AUTHORIZE_URL: &str = "https://accounts.spotify.com/authorize";
+const TOKEN_URL: &str = "https://accounts.spotify.com/api/token";
+const API_BASE: &str = "https://api.spotify.com/v1";
+#[cfg(target_os = "macos")]
+const KEYCHAIN_SERVICE: &str = "com.prodBirdy.openNook.spotify";
+#[cfg(target_os = "macos")]
+const KEYCHAIN_ACCOUNT: &str = "refresh-token";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpotifyStatus {
+    Disconnected,
+    Connecting,
+    Connected,
+    NeedsClientId,
+    PremiumRequired,
+    Error(String),
+}
+
+#[derive(Debug, Clone)]
+struct TokenSet {
+    access: String,
+    refresh: Option<String>,
+    expires_at: Instant,
+}
+
+static STATUS: OnceLock<Mutex<SpotifyStatus>> = OnceLock::new();
+static TOKENS: OnceLock<Mutex<Option<TokenSet>>> = OnceLock::new();
+static CONNECTING: AtomicBool = AtomicBool::new(false);
+static PREMIUM_BLOCKED: AtomicBool = AtomicBool::new(false);
+
+fn status_lock() -> &'static Mutex<SpotifyStatus> {
+    STATUS.get_or_init(|| Mutex::new(SpotifyStatus::Disconnected))
+}
+
+fn tokens_lock() -> &'static Mutex<Option<TokenSet>> {
+    TOKENS.get_or_init(|| Mutex::new(None))
+}
+
+pub fn status() -> SpotifyStatus {
+    status_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+fn set_status(next: SpotifyStatus) {
+    *status_lock().lock().unwrap_or_else(|e| e.into_inner()) = next;
+}
+
+pub fn is_connected() -> bool {
+    matches!(status(), SpotifyStatus::Connected) || tokens_lock()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .is_some()
+        || load_refresh_token().is_some()
+}
+
+pub fn premium_required() -> bool {
+    PREMIUM_BLOCKED.load(Ordering::Relaxed)
+}
+
+pub fn client_id() -> String {
+    settings::get_app_settings()
+        .spotify_client_id
+        .trim()
+        .to_string()
+}
+
+/// RFC 7636 appendix B vector (used by tests).
+pub fn pkce_challenge_s256(verifier: &str) -> String {
+    let hash = sha256(verifier.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash)
+}
+
+/// SHA-256 without pulling `sha2` 0.11 (edition2024 / rustc 1.85).
+fn sha256(input: &[u8]) -> [u8; 32] {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut data = input.to_vec();
+    let bit_len = (input.len() as u64).saturating_mul(8);
+    data.push(0x80);
+    while (data.len() % 64) != 56 {
+        data.push(0);
+    }
+    data.extend_from_slice(&bit_len.to_be_bytes());
+    let mut h = [
+        0x6a09e667u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for chunk in data.chunks_exact(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in chunk.chunks_exact(4).enumerate() {
+            w[i] = u32::from_be_bytes(word.try_into().unwrap());
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let mut a = h[0];
+        let mut b = h[1];
+        let mut c = h[2];
+        let mut d = h[3];
+        let mut e = h[4];
+        let mut f = h[5];
+        let mut g = h[6];
+        let mut hh = h[7];
+        for i in 0..64 {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ ((!e) & g);
+            let temp1 = hh
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(K[i])
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = s0.wrapping_add(maj);
+            hh = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+        h[0] = h[0].wrapping_add(a);
+        h[1] = h[1].wrapping_add(b);
+        h[2] = h[2].wrapping_add(c);
+        h[3] = h[3].wrapping_add(d);
+        h[4] = h[4].wrapping_add(e);
+        h[5] = h[5].wrapping_add(f);
+        h[6] = h[6].wrapping_add(g);
+        h[7] = h[7].wrapping_add(hh);
+    }
+    let mut out = [0u8; 32];
+    for (i, word) in h.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    out
+}
+
+pub fn generate_verifier() -> String {
+    random_b64url(64)
+}
+
+pub fn generate_state() -> String {
+    random_b64url(24)
+}
+
+fn random_b64url(nbytes: usize) -> String {
+    let mut buf = vec![0u8; nbytes];
+    fill_random(&mut buf);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(buf)
+}
+
+fn fill_random(buf: &mut [u8]) {
+    #[cfg(unix)]
+    {
+        if let Ok(mut file) = std::fs::File::open("/dev/urandom") {
+            let _ = file.read_exact(buf);
+            return;
+        }
+    }
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    for (i, byte) in buf.iter_mut().enumerate() {
+        *byte = ((nanos.wrapping_mul(6364136223846793005) >> ((i % 8) * 8)) & 0xFF) as u8
+            ^ (i as u8).wrapping_mul(31);
+    }
+}
+
+pub fn percent_encode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char);
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}
+
+pub fn authorize_url(client_id: &str, redirect_uri: &str, challenge: &str, state: &str) -> String {
+    format!(
+        "{AUTHORIZE_URL}?client_id={}&response_type=code&redirect_uri={}&scope={}&code_challenge_method=S256&code_challenge={}&state={}",
+        percent_encode(client_id),
+        percent_encode(redirect_uri),
+        percent_encode(AUTH_SCOPES),
+        percent_encode(challenge),
+        percent_encode(state),
+    )
+}
+
+pub fn parse_callback_query(query: &str) -> Result<(String, String), String> {
+    let mut code = None;
+    let mut state = None;
+    let mut error = None;
+    for pair in query.split('&') {
+        let (key, value) = pair.split_once('=').unwrap_or((pair, ""));
+        match key {
+            "code" => code = Some(url_decode(value)),
+            "state" => state = Some(url_decode(value)),
+            "error" => error = Some(url_decode(value)),
+            _ => {}
+        }
+    }
+    if let Some(err) = error {
+        return Err(err);
+    }
+    match (code, state) {
+        (Some(code), Some(state)) if !code.is_empty() => Ok((code, state)),
+        _ => Err("missing code or state".into()),
+    }
+}
+
+fn url_decode(value: &str) -> String {
+    let mut out = Vec::with_capacity(value.len());
+    let bytes = value.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let Ok(byte) = u8::from_str_radix(&value[i + 1..i + 3], 16) {
+                out.push(byte);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(if bytes[i] == b'+' { b' ' } else { bytes[i] });
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+pub fn parse_http_request_target(request: &str) -> Option<String> {
+    let line = request.lines().next()?;
+    let mut parts = line.split_whitespace();
+    let _method = parts.next()?;
+    let target = parts.next()?;
+    Some(target.to_string())
+}
+
+/// How many `POST /next` calls to land on upcoming item `index` (0-based).
+pub fn skip_count_for_index(index: usize) -> u32 {
+    (index + 1) as u32
+}
+
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    access_token: String,
+    #[serde(default)]
+    refresh_token: Option<String>,
+    #[serde(default)]
+    expires_in: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlayerState {
+    #[serde(default)]
+    context: Option<PlayerContext>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PlayerContext {
+    #[serde(default)]
+    uri: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct QueueResponse {
+    #[serde(default)]
+    currently_playing: Option<SpotifyTrack>,
+    #[serde(default)]
+    queue: Vec<SpotifyTrack>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpotifyTrack {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    uri: Option<String>,
+    #[serde(default)]
+    artists: Vec<SpotifyArtist>,
+    #[serde(default)]
+    album: Option<SpotifyAlbum>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpotifyArtist {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpotifyAlbum {
+    #[serde(default)]
+    images: Vec<SpotifyImage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpotifyImage {
+    url: String,
+    #[serde(default)]
+    width: Option<u32>,
+}
+
+pub fn pick_artwork_url(images: &[(u32, String)]) -> Option<String> {
+    if images.is_empty() {
+        return None;
+    }
+    let mut ranked = images.to_vec();
+    ranked.sort_by_key(|(w, _)| *w);
+    ranked
+        .iter()
+        .find(|(w, _)| *w >= 64)
+        .or(ranked.last())
+        .map(|(_, url)| url.clone())
+}
+
+pub fn parse_queue_json(body: &str, context_uri: Option<String>) -> Result<PlaybackQueue, String> {
+    let parsed: QueueResponse = serde_json::from_str(body).map_err(|err| err.to_string())?;
+    let mut items = Vec::new();
+    for (index, track) in parsed.queue.into_iter().take(20).enumerate() {
+        let title = track.name.unwrap_or_else(|| "Unknown".into());
+        let artist = track
+            .artists
+            .iter()
+            .filter_map(|a| a.name.clone())
+            .collect::<Vec<_>>()
+            .join(", ");
+        let id = track
+            .id
+            .clone()
+            .or_else(|| track.uri.clone())
+            .unwrap_or_else(|| format!("spotify-{index}"));
+        let uri = track
+            .uri
+            .clone()
+            .unwrap_or_else(|| format!("spotify:track:{id}"));
+        let artwork = track.album.as_ref().and_then(|album| {
+            let pairs = album
+                .images
+                .iter()
+                .map(|img| (img.width.unwrap_or(0), img.url.clone()))
+                .collect::<Vec<_>>();
+            pick_artwork_url(&pairs)
+        });
+        items.push(QueueItem {
+            id,
+            title,
+            artist,
+            artwork_url: artwork,
+            artwork_base64: None,
+            source: QueueSource::Spotify,
+            jump: QueueJump::Spotify {
+                skip_count: skip_count_for_index(index),
+                uri,
+            },
+        });
+    }
+    let _ = parsed.currently_playing;
+    Ok(PlaybackQueue {
+        source: Some(QueueSource::Spotify),
+        label: "Playing Next".into(),
+        items,
+        hidden: None,
+        context_uri,
+    })
+}
+
+fn http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .timeout(Duration::from_secs(8))
+        .build()
+        .map_err(|err| err.to_string())
+}
+
+async fn exchange_token(form: &[(&str, &str)]) -> Result<TokenSet, String> {
+    let client = http_client()?;
+    let response = client
+        .post(TOKEN_URL)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .form(form)
+        .send()
+        .await
+        .map_err(|err| err.to_string())?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        return Err(format!("token exchange {status}: {body}"));
+    }
+    let parsed: TokenResponse = response.json().await.map_err(|err| err.to_string())?;
+    Ok(TokenSet {
+        access: parsed.access_token,
+        refresh: parsed.refresh_token,
+        expires_at: Instant::now() + Duration::from_secs(parsed.expires_in.saturating_sub(30)),
+    })
+}
+
+fn store_tokens(tokens: TokenSet) {
+    if let Some(refresh) = tokens.refresh.as_deref() {
+        store_refresh_token(refresh);
+    }
+    *tokens_lock().lock().unwrap_or_else(|e| e.into_inner()) = Some(tokens);
+    PREMIUM_BLOCKED.store(false, Ordering::Relaxed);
+    set_status(SpotifyStatus::Connected);
+}
+
+fn clear_tokens() {
+    *tokens_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+    delete_refresh_token();
+    PREMIUM_BLOCKED.store(false, Ordering::Relaxed);
+    set_status(SpotifyStatus::Disconnected);
+}
+
+async fn valid_access_token() -> Result<String, String> {
+    {
+        let guard = tokens_lock().lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(tokens) = guard.as_ref() {
+            if Instant::now() < tokens.expires_at && !tokens.access.is_empty() {
+                return Ok(tokens.access.clone());
+            }
+        }
+    }
+    let refresh = load_refresh_token().ok_or_else(|| "not connected".to_string())?;
+    let client_id = client_id();
+    if client_id.is_empty() {
+        set_status(SpotifyStatus::NeedsClientId);
+        return Err("Spotify client ID is missing".into());
+    }
+    let tokens = exchange_token(&[
+        ("grant_type", "refresh_token"),
+        ("refresh_token", &refresh),
+        ("client_id", &client_id),
+    ])
+    .await?;
+    let access = tokens.access.clone();
+    store_tokens(TokenSet {
+        refresh: tokens.refresh.or(Some(refresh)),
+        ..tokens
+    });
+    Ok(access)
+}
+
+async fn api_request(
+    method: reqwest::Method,
+    path: &str,
+    body: Option<serde_json::Value>,
+) -> Result<(reqwest::StatusCode, String), String> {
+    let token = valid_access_token().await?;
+    let client = http_client()?;
+    let url = format!("{API_BASE}{path}");
+    let mut req = client
+        .request(method.clone(), &url)
+        .bearer_auth(&token)
+        .header("Accept", "application/json");
+    if let Some(json) = body.clone() {
+        req = req.json(&json);
+    }
+    let response = req.send().await.map_err(|err| err.to_string())?;
+    let status = response.status();
+    let text = response.text().await.unwrap_or_default();
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        *tokens_lock().lock().unwrap_or_else(|e| e.into_inner()) = None;
+        let token = valid_access_token().await?;
+        let mut retry = client
+            .request(method, &url)
+            .bearer_auth(token)
+            .header("Accept", "application/json");
+        if let Some(json) = body {
+            retry = retry.json(&json);
+        }
+        let response = retry.send().await.map_err(|err| err.to_string())?;
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Ok((status, text));
+    }
+    Ok((status, text))
+}
+
+fn accept_redirect(listener: &TcpListener, expected_state: &str) -> Result<String, String> {
+    listener
+        .set_nonblocking(true)
+        .map_err(|err| err.to_string())?;
+    let deadline = Instant::now() + Duration::from_secs(180);
+    let (mut stream, _) = loop {
+        match listener.accept() {
+            Ok(pair) => break pair,
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {
+                if Instant::now() > deadline {
+                    return Err("authorization timed out".into());
+                }
+                std::thread::sleep(Duration::from_millis(100));
+            }
+            Err(err) => return Err(err.to_string()),
+        }
+    };
+    let _ = stream.set_nonblocking(false);
+    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+    let mut buf = [0u8; 4096];
+    let n = stream.read(&mut buf).map_err(|err| err.to_string())?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+    let target = parse_http_request_target(&request).ok_or("bad request")?;
+    let query = target.split_once('?').map(|(_, q)| q).unwrap_or("");
+    let html = if query.contains("error=") {
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n<html><body>Spotify authorization was cancelled. You can close this window.</body></html>"
+    } else {
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nConnection: close\r\n\r\n<html><body>openNook is connected to Spotify. You can close this window.</body></html>"
+    };
+    let _ = stream.write_all(html.as_bytes());
+    let (code, state) = parse_callback_query(query)?;
+    if state != expected_state {
+        return Err("OAuth state mismatch".into());
+    }
+    Ok(code)
+}
+
+/// Browser PKCE loopback. Safe to call from Settings; no-ops if a flow is live.
+pub async fn connect() -> Result<(), String> {
+    let client_id = client_id();
+    if client_id.is_empty() {
+        set_status(SpotifyStatus::NeedsClientId);
+        return Err("Add a Spotify client ID in Settings first".into());
+    }
+    if CONNECTING.swap(true, Ordering::SeqCst) {
+        return Err("authorization already in progress".into());
+    }
+    set_status(SpotifyStatus::Connecting);
+    let result = connect_inner(&client_id).await;
+    CONNECTING.store(false, Ordering::SeqCst);
+    if let Err(err) = &result {
+        if !matches!(status(), SpotifyStatus::Connected) {
+            set_status(SpotifyStatus::Error(err.clone()));
+        }
+    }
+    result
+}
+
+async fn connect_inner(client_id: &str) -> Result<(), String> {
+    let verifier = generate_verifier();
+    let challenge = pkce_challenge_s256(&verifier);
+    let state = generate_state();
+    let listener = TcpListener::bind(("127.0.0.1", REDIRECT_PORT)).map_err(|err| {
+        format!("could not bind {REDIRECT_URI} ({err}). Close whatever is using port {REDIRECT_PORT} and try again.")
+    })?;
+    let url = authorize_url(client_id, REDIRECT_URI, &challenge, &state);
+    open::that(&url).map_err(|err| format!("open browser: {err}"))?;
+    let expected = state.clone();
+    let code = tokio::task::spawn_blocking(move || accept_redirect(&listener, &expected))
+        .await
+        .map_err(|err| err.to_string())??;
+    let tokens = exchange_token(&[
+        ("grant_type", "authorization_code"),
+        ("code", &code),
+        ("redirect_uri", REDIRECT_URI),
+        ("client_id", client_id),
+        ("code_verifier", &verifier),
+    ])
+    .await?;
+    store_tokens(tokens);
+    Ok(())
+}
+
+pub fn disconnect() {
+    clear_tokens();
+}
+
+pub async fn fetch_queue() -> Result<PlaybackQueue, String> {
+    if client_id().is_empty() && load_refresh_token().is_none() {
+        return Ok(PlaybackQueue {
+            source: Some(QueueSource::Spotify),
+            hidden: Some(QueueHidden::NeedsSpotifyAuth),
+            label: "Playing Next".into(),
+            ..PlaybackQueue::default()
+        });
+    }
+    if load_refresh_token().is_none()
+        && tokens_lock()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .is_none()
+    {
+        return Ok(PlaybackQueue {
+            source: Some(QueueSource::Spotify),
+            hidden: Some(QueueHidden::NeedsSpotifyAuth),
+            label: "Playing Next".into(),
+            ..PlaybackQueue::default()
+        });
+    }
+    let context_uri = match api_request(reqwest::Method::GET, "/me/player", None).await {
+        Ok((status, body)) if status.is_success() => serde_json::from_str::<PlayerState>(&body)
+            .ok()
+            .and_then(|p| p.context.and_then(|c| c.uri)),
+        Ok((status, _)) if status.as_u16() == 204 => None,
+        Ok((status, _)) if status.as_u16() == 403 => {
+            PREMIUM_BLOCKED.store(true, Ordering::Relaxed);
+            set_status(SpotifyStatus::PremiumRequired);
+            return Ok(PlaybackQueue {
+                source: Some(QueueSource::Spotify),
+                hidden: Some(QueueHidden::PremiumRequired),
+                label: "Playing Next".into(),
+                ..PlaybackQueue::default()
+            });
+        }
+        Ok((status, body)) => {
+            log::debug!("spotify player {status}: {body}");
+            None
+        }
+        Err(err) => {
+            log::debug!("spotify player: {err}");
+            None
+        }
+    };
+    let (status, body) = api_request(reqwest::Method::GET, "/me/player/queue", None).await?;
+    if status.as_u16() == 403 {
+        PREMIUM_BLOCKED.store(true, Ordering::Relaxed);
+        set_status(SpotifyStatus::PremiumRequired);
+        return Ok(PlaybackQueue {
+            source: Some(QueueSource::Spotify),
+            hidden: Some(QueueHidden::PremiumRequired),
+            label: "Playing Next".into(),
+            ..PlaybackQueue::default()
+        });
+    }
+    if !status.is_success() {
+        return Err(format!("queue {status}: {body}"));
+    }
+    PREMIUM_BLOCKED.store(false, Ordering::Relaxed);
+    set_status(SpotifyStatus::Connected);
+    parse_queue_json(&body, context_uri)
+}
+
+pub async fn jump_to(skip_count: u32, uri: &str, context_uri: Option<&str>) -> Result<(), String> {
+    if let Some(context) = context_uri.filter(|s| !s.is_empty()) {
+        if play_context_offset(context, uri).await.is_ok() {
+            return Ok(());
+        }
+    }
+    skip_n(skip_count).await
+}
+
+async fn play_context_offset(context_uri: &str, uri: &str) -> Result<(), String> {
+    let body = serde_json::json!({
+        "context_uri": context_uri,
+        "offset": { "uri": uri },
+        "position_ms": 0
+    });
+    let (status, text) =
+        api_request(reqwest::Method::PUT, "/me/player/play", Some(body)).await?;
+    if status.as_u16() == 403 {
+        PREMIUM_BLOCKED.store(true, Ordering::Relaxed);
+        set_status(SpotifyStatus::PremiumRequired);
+        return Err("Spotify Premium is required to jump in the queue".into());
+    }
+    if status.is_success() || status.as_u16() == 204 {
+        Ok(())
+    } else {
+        Err(format!("play {status}: {text}"))
+    }
+}
+
+async fn skip_n(count: u32) -> Result<(), String> {
+    for _ in 0..count {
+        let (status, text) = api_request(reqwest::Method::POST, "/me/player/next", None).await?;
+        if status.as_u16() == 403 {
+            PREMIUM_BLOCKED.store(true, Ordering::Relaxed);
+            set_status(SpotifyStatus::PremiumRequired);
+            return Err("Spotify Premium is required to skip tracks".into());
+        }
+        if !status.is_success() && status.as_u16() != 204 {
+            return Err(format!("next {status}: {text}"));
+        }
+    }
+    Ok(())
+}
+
+fn load_refresh_token() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        security_framework::passwords::get_generic_password(KEYCHAIN_SERVICE, KEYCHAIN_ACCOUNT)
+            .ok()
+            .and_then(|bytes| String::from_utf8(bytes).ok())
+            .filter(|s| !s.is_empty())
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let path = crate::app_data_dir().join("spotify-refresh");
+        std::fs::read_to_string(path)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+}
+
+fn store_refresh_token(token: &str) {
+    #[cfg(target_os = "macos")]
+    {
+        if let Err(err) = security_framework::passwords::set_generic_password(
+            KEYCHAIN_SERVICE,
+            KEYCHAIN_ACCOUNT,
+            token.as_bytes(),
+        ) {
+            log::warn!("spotify keychain store: {err}");
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let path = crate::app_data_dir().join("spotify-refresh");
+        if let Err(err) = std::fs::write(path, token) {
+            log::warn!("spotify token store: {err}");
+        }
+    }
+}
+
+fn delete_refresh_token() {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = security_framework::passwords::delete_generic_password(
+            KEYCHAIN_SERVICE,
+            KEYCHAIN_ACCOUNT,
+        );
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let path = crate::app_data_dir().join("spotify-refresh");
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+/// Prime in-memory status from a persisted refresh token (no network).
+pub fn hydrate_status() {
+    if load_refresh_token().is_some() {
+        if client_id().is_empty() {
+            set_status(SpotifyStatus::NeedsClientId);
+        } else {
+            set_status(SpotifyStatus::Connected);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pkce_rfc7636_appendix_b() {
+        let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+        assert_eq!(
+            pkce_challenge_s256(verifier),
+            "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+        );
+    }
+
+    #[test]
+    fn authorize_url_includes_pkce_and_scopes() {
+        let url = authorize_url(
+            "cid",
+            REDIRECT_URI,
+            "challenge",
+            "state-1",
+        );
+        assert!(url.starts_with(AUTHORIZE_URL));
+        assert!(url.contains("client_id=cid"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("code_challenge=challenge"));
+        assert!(url.contains("state=state-1"));
+        assert!(url.contains("user-read-playback-state"));
+        assert!(url.contains("user-modify-playback-state"));
+        assert!(url.contains(&percent_encode(REDIRECT_URI)));
+    }
+
+    #[test]
+    fn percent_encode_leaves_unreserved() {
+        assert_eq!(percent_encode("Abc-_.~9"), "Abc-_.~9");
+        assert_eq!(percent_encode("a b"), "a%20b");
+        assert_eq!(percent_encode("x&y"), "x%26y");
+    }
+
+    #[test]
+    fn callback_query_reads_code_and_rejects_error() {
+        let (code, state) = parse_callback_query("code=abc%2Fdef&state=s1").unwrap();
+        assert_eq!(code, "abc/def");
+        assert_eq!(state, "s1");
+        assert_eq!(
+            parse_callback_query("error=access_denied&state=s1").unwrap_err(),
+            "access_denied"
+        );
+    }
+
+    #[test]
+    fn http_target_extracts_path() {
+        let req = "GET /callback?code=1&state=2 HTTP/1.1\r\nHost: 127.0.0.1\r\n\r\n";
+        assert_eq!(
+            parse_http_request_target(req).as_deref(),
+            Some("/callback?code=1&state=2")
+        );
+    }
+
+    #[test]
+    fn skip_count_is_one_based() {
+        assert_eq!(skip_count_for_index(0), 1);
+        assert_eq!(skip_count_for_index(4), 5);
+    }
+
+    #[test]
+    fn artwork_prefers_64px_or_smallest_above() {
+        let images = vec![
+            (640, "big".into()),
+            (300, "med".into()),
+            (64, "small".into()),
+        ];
+        assert_eq!(pick_artwork_url(&images).as_deref(), Some("small"));
+        assert_eq!(
+            pick_artwork_url(&[(32, "tiny".into())]).as_deref(),
+            Some("tiny")
+        );
+        assert_eq!(pick_artwork_url(&[]), None);
+    }
+
+    #[test]
+    fn queue_json_maps_upcoming_tracks() {
+        let body = r#"{
+            "currently_playing": {"id":"now","name":"Now","uri":"spotify:track:now","artists":[{"name":"A"}]},
+            "queue": [
+                {"id":"n1","name":"Next","uri":"spotify:track:n1","artists":[{"name":"B"}],
+                 "album":{"images":[{"url":"https://i.scdn.co/image/x","width":64}]}},
+                {"id":"n2","name":"Later","uri":"spotify:track:n2","artists":[{"name":"C"},{"name":"D"}]}
+            ]
+        }"#;
+        let queue = parse_queue_json(body, Some("spotify:playlist:p".into())).unwrap();
+        assert_eq!(queue.source, Some(QueueSource::Spotify));
+        assert_eq!(queue.label, "Playing Next");
+        assert_eq!(queue.items.len(), 2);
+        assert_eq!(queue.items[0].title, "Next");
+        assert_eq!(queue.items[0].artist, "B");
+        assert_eq!(
+            queue.items[0].artwork_url.as_deref(),
+            Some("https://i.scdn.co/image/x")
+        );
+        assert_eq!(
+            queue.items[0].jump,
+            QueueJump::Spotify {
+                skip_count: 1,
+                uri: "spotify:track:n1".into()
+            }
+        );
+        assert_eq!(
+            queue.items[1].jump,
+            QueueJump::Spotify {
+                skip_count: 2,
+                uri: "spotify:track:n2".into()
+            }
+        );
+        assert_eq!(queue.items[1].artist, "C, D");
+        assert_eq!(queue.context_uri.as_deref(), Some("spotify:playlist:p"));
+    }
+
+    #[test]
+    fn generated_verifier_is_pkce_safe_length() {
+        let verifier = generate_verifier();
+        assert!(verifier.len() >= 43 && verifier.len() <= 128);
+        assert!(verifier
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        let state = generate_state();
+        assert!(state.len() >= 16);
+    }
+}

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -99,7 +99,7 @@ impl Island {
                     &mut kids,
                     cell_pane(
                         self.settings.cells_for(module),
-                        nook_media_pane(&self.now_playing, cx),
+                        nook_media_pane(self, cx),
                     ),
                 ),
                 WidgetModule::Calendar if self.settings.show_calendar => add(

--- a/crates/nook/src/island/media.rs
+++ b/crates/nook/src/island/media.rs
@@ -5,14 +5,14 @@ use super::ui::{
     card_chrome, slide_label, MEDIA_ART, MEDIA_ART_RADIUS, MEDIA_PLAY, MEDIA_PROGRESS_HIT,
     MEDIA_TIME_PAD_GAP, MEDIA_TIME_PAD_TOP,
 };
-use super::Island;
+use super::{queue_list_height, Island, QUEUE_ROW_H};
 use crate::icons::lucide_color;
 use crate::theme;
 use gpui::{
-    div, img, linear_color_stop, linear_gradient, prelude::*, px, relative, rgb, rgba, AnyElement,
-    Context, CursorStyle, Image, MouseButton, MouseDownEvent, Rgba, SharedString,
+    canvas, div, img, linear_color_stop, linear_gradient, prelude::*, px, relative, rgb, rgba,
+    AnyElement, Context, CursorStyle, Image, MouseButton, MouseDownEvent, Rgba, SharedString,
 };
-use nook_core::models::NowPlayingData;
+use nook_core::models::{NowPlayingData, PlaybackQueue, QueueItem};
 use std::sync::{Mutex, OnceLock};
 
 const MAX_ARTWORK_BYTES: usize = 5 * 1024 * 1024;
@@ -241,13 +241,14 @@ const APP_BADGE: f32 = 22.0;
 const APP_BADGE_RADIUS: f32 = 5.0;
 
 /// Horizontal Now Playing strip for the Nook tab (art + metadata + transport).
-pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> impl IntoElement {
+pub(crate) fn nook_media_pane(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let np = &island.now_playing;
     let title = np.title.clone().unwrap_or_else(|| "Unknown Title".into());
     let artist = np.artist.clone().unwrap_or_else(|| "Unknown Artist".into());
     let album = np.album.clone().filter(|s| !s.is_empty());
     let playing = np.is_playing;
-    let elapsed = np.elapsed_time.unwrap_or(0.0);
     let duration = np.duration.unwrap_or(0.0);
+    let elapsed = displayed_elapsed(np, island.scrubber_drag);
     let progress = if duration > 0.0 {
         (elapsed / duration) as f32
     } else {
@@ -259,10 +260,11 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
         .as_deref()
         .and_then(|b64| artwork_element(b64, NOOK_ART, NOOK_ART_RADIUS));
 
-    div()
+    let player = div()
         .id("nook-media")
         .w_full()
-        .h_full()
+        .flex_1()
+        .min_h(px(theme::NOOK_BODY - 4.0))
         .overflow_hidden()
         .flex()
         .items_center()
@@ -334,8 +336,28 @@ pub(crate) fn nook_media_pane(np: &NowPlayingData, cx: &mut Context<Island>) -> 
                             });
                         })),
                 )
-                .child(nook_progress(progress, elapsed, duration, seekable, cx)),
-        )
+                .child(nook_progress(
+                    island,
+                    progress,
+                    elapsed,
+                    duration,
+                    seekable,
+                    cx,
+                )),
+        );
+    let queue = island.queue.clone();
+    let show_queue = island.settings.show_media_queue && !queue.items.is_empty();
+    div()
+        .id("nook-media-col")
+        .w_full()
+        .h_full()
+        .overflow_hidden()
+        .flex()
+        .flex_col()
+        .child(player)
+        .when(show_queue, |d| {
+            d.child(up_next_list(&queue, queue_list_height(queue.items.len()), cx))
+        })
 }
 
 fn app_badge(bundle_id: Option<&str>, app_name: Option<&str>) -> AnyElement {
@@ -391,14 +413,30 @@ fn app_icon_image(
     loaded
 }
 
+fn displayed_elapsed(np: &NowPlayingData, drag: Option<f32>) -> f64 {
+    if let Some(ratio) = drag {
+        return np.duration.unwrap_or(0.0) * ratio as f64;
+    }
+    np.elapsed_time.unwrap_or(0.0)
+}
+
+pub(crate) fn scrubber_ratio(x: f32, origin: f32, width: f32) -> f32 {
+    if width < 1.0 {
+        return 0.0;
+    }
+    ((x - origin) / width).clamp(0.0, 1.0)
+}
+
 fn nook_progress(
+    island: &Island,
     progress: f32,
     elapsed: f64,
     duration: f64,
     seekable: bool,
     cx: &mut Context<Island>,
 ) -> impl IntoElement {
-    let progress = progress.clamp(0.0, 1.0);
+    let progress = island.scrubber_drag.unwrap_or(progress).clamp(0.0, 1.0);
+    let bounds = island.scrubber_bounds.clone();
     div()
         .w_full()
         .mt(px(6.))
@@ -408,13 +446,40 @@ fn nook_progress(
         } else {
             CursorStyle::Arrow
         })
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                if !seekable {
+                    return;
+                }
+                cx.stop_propagation();
+                this.update_scrubber_from_x(event.position.x.into());
+                cx.notify();
+            }),
+        )
         .child(
             div()
                 .relative()
                 .w_full()
-                .h(px(10.))
+                .h(px(12.))
                 .flex()
                 .items_center()
+                .child(
+                    canvas(
+                        {
+                            let bounds = bounds.clone();
+                            move |layout, _, _| {
+                                let origin: f32 = layout.origin.x.into();
+                                let width: f32 = layout.size.width.into();
+                                *bounds.borrow_mut() = Some((origin, width));
+                                layout
+                            }
+                        },
+                        |_bounds, _, _, _| {},
+                    )
+                    .absolute()
+                    .inset_0(),
+                )
                 .child(
                     div()
                         .w_full()
@@ -429,7 +494,7 @@ fn nook_progress(
                                 .bg(rgb(0xffffff)),
                         ),
                 )
-                .when(seekable, |d| d.child(nook_seek_hits(cx))),
+                .when(seekable, |d| d.child(scrubber_thumb(progress))),
         )
         .child(
             div()
@@ -441,38 +506,15 @@ fn nook_progress(
         )
 }
 
-fn nook_seek_hits(cx: &mut Context<Island>) -> impl IntoElement {
-    const SEGMENTS: u32 = 24;
-    let mut row = div()
+fn scrubber_thumb(progress: f32) -> impl IntoElement {
+    div()
         .absolute()
-        .inset_0()
-        .flex()
-        .cursor(CursorStyle::PointingHand);
-    for i in 0..SEGMENTS {
-        let ratio = (i as f32 + 0.5) / SEGMENTS as f32;
-        row = row.child(
-            div()
-                .id(SharedString::from(format!("nook-seek-{i}")))
-                .flex_1()
-                .h_full()
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |this, _: &MouseDownEvent, _, cx| {
-                        cx.stop_propagation();
-                        let Some(duration) = this.now_playing.duration.filter(|d| *d > 0.0) else {
-                            return;
-                        };
-                        let position = duration * ratio as f64;
-                        this.now_playing.elapsed_time = Some(position);
-                        cx.notify();
-                        nook_core::runtime().spawn(async move {
-                            let _ = nook_core::audio::media_seek(position).await;
-                        });
-                    }),
-                ),
-        );
-    }
-    row
+        .left(relative(progress.clamp(0.0, 1.0)))
+        .ml(px(-5.))
+        .size(px(10.))
+        .rounded_full()
+        .bg(rgb(0xffffff))
+        .shadow_sm()
 }
 
 fn nook_skip(
@@ -530,12 +572,13 @@ fn nook_play(playing: bool, cx: &mut Context<Island>) -> impl IntoElement {
 }
 
 #[allow(dead_code)]
-pub(crate) fn media_card(np: &NowPlayingData, cx: &mut Context<Island>) -> impl IntoElement {
+pub(crate) fn media_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let np = &island.now_playing;
     let title = np.title.clone().unwrap_or_else(|| "Unknown Title".into());
     let artist = np.artist.clone().unwrap_or_else(|| "Unknown Artist".into());
     let playing = np.is_playing;
-    let elapsed = np.elapsed_time.unwrap_or(0.0);
     let duration = np.duration.unwrap_or(0.0);
+    let elapsed = displayed_elapsed(np, island.scrubber_drag);
     let progress = if duration > 0.0 {
         (elapsed / duration) as f32
     } else {
@@ -587,18 +630,37 @@ pub(crate) fn media_card(np: &NowPlayingData, cx: &mut Context<Island>) -> impl 
                         .child(slide_label(artist, theme::BODY, false).w_full()),
                 ),
         )
-        .child(progress_block(progress, elapsed, duration, seekable, cx))
+        .child(progress_block(
+            island,
+            progress,
+            elapsed,
+            duration,
+            seekable,
+            cx,
+        ))
         .child(transport_row(playing, cx))
+        .when(
+            island.settings.show_media_queue && !island.queue.items.is_empty(),
+            |d| {
+                d.child(up_next_list(
+                    &island.queue,
+                    queue_list_height(island.queue.items.len()),
+                    cx,
+                ))
+            },
+        )
 }
 
 fn progress_block(
+    island: &Island,
     progress: f32,
     elapsed: f64,
     duration: f64,
     seekable: bool,
     cx: &mut Context<Island>,
 ) -> impl IntoElement {
-    let progress = progress.clamp(0.0, 1.0);
+    let progress = island.scrubber_drag.unwrap_or(progress).clamp(0.0, 1.0);
+    let bounds = island.scrubber_bounds.clone();
     div()
         .flex()
         .flex_col()
@@ -609,6 +671,17 @@ fn progress_block(
         } else {
             CursorStyle::Arrow
         })
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, event: &MouseDownEvent, _, cx| {
+                if !seekable {
+                    return;
+                }
+                cx.stop_propagation();
+                this.update_scrubber_from_x(event.position.x.into());
+                cx.notify();
+            }),
+        )
         .child(
             div()
                 .relative()
@@ -616,6 +689,22 @@ fn progress_block(
                 .h(px(MEDIA_PROGRESS_HIT))
                 .flex()
                 .items_center()
+                .child(
+                    canvas(
+                        {
+                            let bounds = bounds.clone();
+                            move |layout, _, _| {
+                                let origin: f32 = layout.origin.x.into();
+                                let width: f32 = layout.size.width.into();
+                                *bounds.borrow_mut() = Some((origin, width));
+                                layout
+                            }
+                        },
+                        |_bounds, _, _, _| {},
+                    )
+                    .absolute()
+                    .inset_0(),
+                )
                 .child(
                     div()
                         .w_full()
@@ -630,7 +719,7 @@ fn progress_block(
                                 .bg(rgb(0xffffff)),
                         ),
                 )
-                .when(seekable, |d| d.child(seek_hits(cx))),
+                .when(seekable, |d| d.child(scrubber_thumb(progress))),
         )
         .child(
             div()
@@ -644,38 +733,119 @@ fn progress_block(
         )
 }
 
-fn seek_hits(cx: &mut Context<Island>) -> impl IntoElement {
-    const SEGMENTS: u32 = 32;
-    let mut row = div()
-        .absolute()
-        .inset_0()
+fn up_next_list(
+    queue: &PlaybackQueue,
+    height: f32,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let label = if queue.label.is_empty() {
+        "Up Next in playlist".to_string()
+    } else {
+        queue.label.clone()
+    };
+    let list = div()
+        .id("up-next")
+        .w_full()
+        .h(px(height))
+        .flex_shrink_0()
         .flex()
-        .cursor(CursorStyle::PointingHand);
-    for i in 0..SEGMENTS {
-        let ratio = (i as f32 + 0.5) / SEGMENTS as f32;
-        row = row.child(
+        .flex_col()
+        .pt(px(6.))
+        .child(
             div()
-                .id(SharedString::from(format!("seek-{i}")))
-                .flex_1()
-                .h_full()
-                .on_mouse_down(
-                    MouseButton::Left,
-                    cx.listener(move |this, _: &MouseDownEvent, _, cx| {
-                        cx.stop_propagation();
-                        let Some(duration) = this.now_playing.duration.filter(|d| *d > 0.0) else {
-                            return;
-                        };
-                        let position = duration * ratio as f64;
-                        this.now_playing.elapsed_time = Some(position);
-                        cx.notify();
-                        nook_core::runtime().spawn(async move {
-                            let _ = nook_core::audio::media_seek(position).await;
-                        });
-                    }),
-                ),
+                .text_size(px(theme::FOOTNOTE.size))
+                .font_weight(theme::FOOTNOTE.emphasized)
+                .text_color(rgba(0xffffff88))
+                .child(label),
         );
+    let mut rows = div()
+        .id("up-next-rows")
+        .flex_1()
+        .min_h(px(0.))
+        .overflow_y_scroll();
+    for (i, item) in queue.items.iter().enumerate() {
+        rows = rows.child(queue_row(i, item, cx));
     }
-    row
+    list.child(rows)
+}
+
+fn queue_row(index: usize, item: &QueueItem, cx: &mut Context<Island>) -> impl IntoElement {
+    if let Some(url) = item.artwork_url.as_ref() {
+        if nook_core::queue::cached_artwork(&item.id).is_none() {
+            nook_core::queue::request_artwork(item.id.clone(), url.clone());
+        }
+    }
+    let thumb = item
+        .artwork_base64
+        .as_deref()
+        .map(str::to_string)
+        .or_else(|| {
+            nook_core::queue::cached_artwork(&item.id).and_then(|hit| hit)
+        });
+    let art = thumb
+        .as_deref()
+        .and_then(|b64| artwork_element(b64, 32.0, 6.0))
+        .unwrap_or_else(|| {
+            div()
+                .size(px(32.))
+                .rounded(px(6.))
+                .bg(rgba(0xffffff14))
+                .flex()
+                .items_center()
+                .justify_center()
+                .child(lucide_color("music", 12.0, rgba(0xffffff66)))
+                .into_any_element()
+        });
+    let title = item.title.clone();
+    let artist = item.artist.clone();
+    let jump = item.clone();
+    div()
+        .id(SharedString::from(format!("up-next-{index}")))
+        .h(px(QUEUE_ROW_H))
+        .w_full()
+        .flex()
+        .items_center()
+        .gap(px(8.))
+        .rounded(px(6.))
+        .hover(|s| s.bg(rgba(0xffffff14)))
+        .cursor(CursorStyle::PointingHand)
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                let item = jump.clone();
+                let context = this.queue.context_uri.clone();
+                nook_core::runtime().spawn(async move {
+                    let _ = nook_core::audio::media_jump_to_queue_item(item, context).await;
+                });
+            }),
+        )
+        .child(art)
+        .child(
+            div()
+                .flex_1()
+                .min_w(px(0.))
+                .overflow_hidden()
+                .flex()
+                .flex_col()
+                .child(
+                    div()
+                        .text_size(px(theme::CALLOUT.size))
+                        .font_weight(theme::CALLOUT.emphasized)
+                        .text_color(rgb(0xffffff))
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .child(title),
+                )
+                .child(
+                    div()
+                        .text_size(px(theme::FOOTNOTE.size))
+                        .text_color(rgba(0xffffff88))
+                        .text_ellipsis()
+                        .whitespace_nowrap()
+                        .child(artist),
+                ),
+        )
 }
 
 fn transport_row(playing: bool, cx: &mut Context<Island>) -> impl IntoElement {
@@ -862,6 +1032,14 @@ mod tests {
             .unwrap();
         let b64 = base64::engine::general_purpose::STANDARD.encode(encoded.into_inner());
         assert!(artwork_bytes(&b64).is_none());
+    }
+
+    #[test]
+    fn scrubber_ratio_clamps_to_the_bar() {
+        assert_eq!(scrubber_ratio(50.0, 0.0, 100.0), 0.5);
+        assert_eq!(scrubber_ratio(-10.0, 0.0, 100.0), 0.0);
+        assert_eq!(scrubber_ratio(200.0, 0.0, 100.0), 1.0);
+        assert_eq!(scrubber_ratio(10.0, 0.0, 0.0), 0.0);
     }
 
     #[test]

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -286,14 +286,18 @@ impl Island {
                 platform::apply_island_chrome();
             }
             platform::request_pin();
+            // Park until a screen/space notification (or a 30s backstop).
+            // The previous 250 ms poll was an idle wakeup; handlers already
+            // pin on the main thread, this only covers a missed first pin.
             loop {
-                cx.background_executor()
-                    .timer(Duration::from_millis(250))
+                let needed = cx
+                    .background_executor()
+                    .spawn(async { platform::wait_pin_needed(Duration::from_secs(30)) })
                     .await;
                 if this.update(cx, |_, _| ()).is_err() {
                     break;
                 }
-                if platform::take_pin_needed() {
+                if needed || platform::take_pin_needed() {
                     platform::pin_island_windows();
                 }
             }
@@ -573,22 +577,19 @@ impl Island {
                 // Stream-backed adapter reads are a cheap lock; cadence is
                 // for interpolated elapsed (1s while playing) and the
                 // AppleScript fallback (5s idle). Distributed-notification
-                // observers and the MediaRemote stream flip `take_media_event`
-                // so the wait wakes instantly on real changes.
+                // observers and the MediaRemote stream poke `note_media_event`
+                // so this parks until a real change instead of slicing 250 ms.
                 let cadence = if is_playing {
                     Duration::from_secs(1)
                 } else {
                     Duration::from_secs(5)
                 };
-                let slice = Duration::from_millis(250);
-                let mut waited = Duration::ZERO;
-                loop {
-                    cx.background_executor().timer(slice).await;
-                    waited += slice;
-                    if nook_core::audio::take_media_event() || waited >= cadence {
-                        break;
-                    }
-                }
+                cx.background_executor()
+                    .spawn(async move {
+                        nook_core::runtime()
+                            .block_on(nook_core::audio::wait_media_or_timeout(cadence))
+                    })
+                    .await;
             }
         })
         .detach();

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -23,11 +23,13 @@ use gpui::{
 use nook_core::agents::AgentSession;
 use nook_core::calendar::{CalendarEvent, Reminder};
 use nook_core::files::FileTrayItem;
-use nook_core::models::NowPlayingData;
+use nook_core::models::{NowPlayingData, PlaybackQueue};
 use nook_core::notch;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
 use settings::SettingsView;
+use std::cell::RefCell;
+use std::rc::Rc;
 use std::time::{Duration, Instant};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -68,6 +70,14 @@ pub struct Island {
     pub tab: Tab,
     pub now_playing: NowPlayingData,
     pub visualizer_color: Option<gpui::Rgba>,
+    pub queue: PlaybackQueue,
+    queue_key: Option<(Option<String>, Option<String>, Option<String>)>,
+    queue_inflight: bool,
+    /// Local scrubber drag 0..1. `None` when the thumb is not held.
+    pub(crate) scrubber_drag: Option<f32>,
+    pub(crate) scrubber_bounds: Rc<RefCell<Option<(f32, f32)>>>,
+    elapsed_base: Option<f64>,
+    elapsed_at: Instant,
     pub files: Vec<FileTrayItem>,
     pub events: Vec<CalendarEvent>,
     pub reminders: Vec<Reminder>,
@@ -198,6 +208,13 @@ impl Island {
             tab: Tab::Widgets,
             now_playing: NowPlayingData::default(),
             visualizer_color: None,
+            queue: PlaybackQueue::default(),
+            queue_key: None,
+            queue_inflight: false,
+            scrubber_drag: None,
+            scrubber_bounds: Rc::new(RefCell::new(None)),
+            elapsed_base: None,
+            elapsed_at: Instant::now(),
             files,
             events: Vec::new(),
             reminders: Vec::new(),
@@ -477,6 +494,12 @@ impl Island {
                         this.now_playing.audio_levels = Some(levels);
                         dirty = true;
                     }
+                    if this.interpolate_elapsed() {
+                        dirty = true;
+                    }
+                    if this.expanded && nook_core::queue::take_artwork_ready() {
+                        dirty = true;
+                    }
                     if this.step_spring(dt) {
                         dirty = true;
                     }
@@ -556,7 +579,11 @@ impl Island {
                     this.now_playing.album = playing.album;
                     this.now_playing.artwork_base64 = playing.artwork_base64;
                     this.now_playing.duration = playing.duration;
-                    this.now_playing.elapsed_time = playing.elapsed_time;
+                    if this.scrubber_drag.is_none() {
+                        this.now_playing.elapsed_time = playing.elapsed_time;
+                        this.elapsed_base = playing.elapsed_time;
+                        this.elapsed_at = Instant::now();
+                    }
                     this.now_playing.is_playing = playing.is_playing;
                     this.now_playing.app_name = playing.app_name;
                     this.now_playing.bundle_id = playing.bundle_id;
@@ -566,14 +593,38 @@ impl Island {
                     if !was_media && this.has_media() {
                         this.preferred = Some(CompactMode::Media);
                     }
+                    let fetch = this.maybe_start_queue_fetch();
                     if changed {
                         cx.notify();
                     }
-                    this.has_media() && this.now_playing.is_playing
+                    (
+                        this.has_media() && this.now_playing.is_playing,
+                        fetch,
+                        this.now_playing.clone(),
+                    )
                 });
-                let Ok(is_playing) = alive else {
+                let Ok((is_playing, fetch_now, np)) = alive else {
                     break;
                 };
+                if fetch_now {
+                    let queue = cx
+                        .background_executor()
+                        .spawn(async move {
+                            nook_core::runtime()
+                                .block_on(nook_core::queue::fetch_playback_queue(&np))
+                        })
+                        .await;
+                    if this
+                        .update(cx, |this, cx| {
+                            this.queue = queue;
+                            this.queue_inflight = false;
+                            cx.notify();
+                        })
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
                 // Stream-backed adapter reads are a cheap lock; cadence is
                 // for interpolated elapsed (1s while playing) and the
                 // AppleScript fallback (5s idle). Distributed-notification
@@ -739,6 +790,99 @@ impl Island {
                 || self.now_playing.artist.is_some())
     }
 
+    pub(crate) fn queue_visible(&self) -> bool {
+        self.settings.show_media
+            && self.settings.show_media_queue
+            && self.expanded
+            && self.tab == Tab::Widgets
+            && self.has_media()
+    }
+
+    /// Extra island height once upcoming rows are in hand. Header + up to 4
+    /// 40px rows; empty/hidden queues add nothing.
+    pub(crate) fn queue_extra_height(&self) -> f32 {
+        if !self.settings.show_media || !self.settings.show_media_queue {
+            return 0.0;
+        }
+        queue_list_height(self.queue.items.len())
+    }
+
+    /// Overlay-strip reserve so a queue arrival does not resize the NSWindow
+    /// mid-animation.
+    fn queue_reserve_height(settings: &AppSettings) -> f32 {
+        if settings.show_media && settings.show_media_queue {
+            queue_list_height(4)
+        } else {
+            0.0
+        }
+    }
+
+    fn maybe_start_queue_fetch(&mut self) -> bool {
+        if !self.queue_visible() {
+            return false;
+        }
+        let key = nook_core::queue::queue_identity(&self.now_playing);
+        if self.queue_inflight {
+            return false;
+        }
+        if self.queue_key.as_ref() == Some(&key) {
+            return false;
+        }
+        self.queue_key = Some(key);
+        self.queue_inflight = true;
+        true
+    }
+
+    fn interpolate_elapsed(&mut self) -> bool {
+        if self.scrubber_drag.is_some() || !self.now_playing.is_playing {
+            return false;
+        }
+        let Some(base) = self.elapsed_base else {
+            return false;
+        };
+        let Some(duration) = self.now_playing.duration.filter(|d| *d > 0.0) else {
+            return false;
+        };
+        let elapsed = (base + self.elapsed_at.elapsed().as_secs_f64()).min(duration);
+        let prev = self.now_playing.elapsed_time.unwrap_or(-1.0);
+        if (elapsed - prev).abs() < 0.04 {
+            return false;
+        }
+        self.now_playing.elapsed_time = Some(elapsed);
+        true
+    }
+
+    pub(crate) fn update_scrubber_from_x(&mut self, x: f32) {
+        let Some((origin, width)) = *self.scrubber_bounds.borrow() else {
+            return;
+        };
+        let ratio = media::scrubber_ratio(x, origin, width);
+        self.scrubber_drag = Some(ratio);
+        if let Some(duration) = self.now_playing.duration.filter(|d| *d > 0.0) {
+            let position = duration * ratio as f64;
+            self.now_playing.elapsed_time = Some(position);
+            self.elapsed_base = Some(position);
+            self.elapsed_at = Instant::now();
+        }
+    }
+
+    pub(crate) fn finish_scrubber(&mut self) -> bool {
+        let Some(ratio) = self.scrubber_drag.take() else {
+            return false;
+        };
+        let Some(duration) = self.now_playing.duration.filter(|d| *d > 0.0) else {
+            return true;
+        };
+        let position = duration * ratio as f64;
+        self.now_playing.elapsed_time = Some(position);
+        self.elapsed_base = Some(position);
+        self.elapsed_at = Instant::now();
+        nook_core::runtime().spawn(async move {
+            let _ = nook_core::audio::media_seek(position).await;
+        });
+        true
+    }
+
     pub(crate) fn running_timer(&self) -> Option<&Timer> {
         self.timers.iter().find(|t| t.running)
     }
@@ -794,6 +938,7 @@ impl Island {
         } else if platform::start_mirror() {
             self.mirror_on = true;
             self.expanded = true;
+            nook_core::audio::note_media_event();
         }
         cx.notify();
     }
@@ -900,7 +1045,7 @@ impl Island {
                 // plus Clear All, so a single file is not clipped behind a scroll.
                 theme::EXPANDED_PAD * 2.0 + files::files_pane_min_height(w)
             } else {
-                theme::NOOK_INSET + theme::NOOK_BODY
+                theme::NOOK_INSET + theme::NOOK_BODY + self.queue_extra_height()
             };
             return (w, self.notch_height.max(32.0) + body);
         }
@@ -928,7 +1073,7 @@ impl Island {
     /// stuttering inside the animation.
     pub(super) fn expanded_bottom(&self) -> f32 {
         let w = self.expanded_width();
-        let mut body = theme::NOOK_INSET + theme::NOOK_BODY;
+        let mut body = theme::NOOK_INSET + theme::NOOK_BODY + Self::queue_reserve_height(&self.settings);
         if self.settings.show_files {
             body = body.max(theme::EXPANDED_PAD * 2.0 + files::files_pane_min_height(w));
         }
@@ -1075,6 +1220,7 @@ impl Island {
     fn toggle_expanded(&mut self, cx: &mut Context<Self>) {
         self.expanded = !self.expanded;
         if self.expanded {
+            nook_core::audio::note_media_event();
             self.tab = if self.mode() == CompactMode::Files {
                 Tab::Files
             } else {
@@ -1161,6 +1307,7 @@ impl Island {
         } else if !self.expanded && ay > 0.0 {
             // AppKit scrollingDeltaY: two-finger swipe *down* is positive.
             self.expanded = true;
+            nook_core::audio::note_media_event();
             nook_core::haptics::trigger(None);
             true
         } else if self.expanded && ay < 0.0 {
@@ -1325,6 +1472,7 @@ impl Island {
             self.preferred = Some(CompactMode::Files);
             self.tab = Tab::Files;
             self.expanded = true;
+            nook_core::audio::note_media_event();
             nook_core::haptics::trigger(None);
             cx.notify();
         }
@@ -1399,6 +1547,17 @@ impl Island {
     }
 }
 
+pub(crate) const QUEUE_ROW_H: f32 = 40.0;
+const QUEUE_HEADER_H: f32 = 18.0;
+const QUEUE_LIST_PAD: f32 = 8.0;
+
+pub(crate) fn queue_list_height(item_count: usize) -> f32 {
+    if item_count == 0 {
+        return 0.0;
+    }
+    QUEUE_HEADER_H + item_count.min(4) as f32 * QUEUE_ROW_H + QUEUE_LIST_PAD
+}
+
 /// Paint camera pixels immediately. `img(Image)` goes through GPUI's async
 /// decoder (200ms placeholder), so a new JPEG every tick looks like a reinit.
 fn mirror_render_image(bgra: Vec<u8>) -> Option<std::sync::Arc<gpui::RenderImage>> {
@@ -1421,6 +1580,7 @@ mod tests {
     use crate::island::ui::format_timer;
     use nook_core::agents::{AgentKind, AgentStatus};
     use std::collections::HashMap;
+    use std::rc::Rc;
     use std::sync::{Mutex, MutexGuard};
 
     /// `outbound_drag_active` is process-global; overlay tests that toggle it
@@ -1443,6 +1603,13 @@ mod tests {
             tab: Tab::Widgets,
             now_playing: NowPlayingData::default(),
             visualizer_color: None,
+            queue: PlaybackQueue::default(),
+            queue_key: None,
+            queue_inflight: false,
+            scrubber_drag: None,
+            scrubber_bounds: Rc::new(RefCell::new(None)),
+            elapsed_base: None,
+            elapsed_at: Instant::now(),
             files: Vec::new(),
             events: Vec::new(),
             reminders: Vec::new(),
@@ -1639,6 +1806,35 @@ mod tests {
         assert!(island.speed_mbps.is_none());
         assert!(!island.speed_running);
         assert_eq!(island.speed_gen, 3);
+    }
+
+    #[test]
+    fn queue_list_height_is_zero_when_empty_and_caps_visible_rows() {
+        assert_eq!(queue_list_height(0), 0.0);
+        assert_eq!(queue_list_height(1), QUEUE_HEADER_H + QUEUE_ROW_H + QUEUE_LIST_PAD);
+        assert_eq!(queue_list_height(4), queue_list_height(12));
+    }
+
+    #[test]
+    fn queue_fetch_only_when_expanded_media_card_is_visible() {
+        let mut island = test_island();
+        island.now_playing.title = Some("Track".into());
+        island.now_playing.app_name = Some("Music".into());
+        island.settings.show_media = true;
+        island.settings.show_media_queue = true;
+        assert!(!island.queue_visible());
+        assert!(!island.maybe_start_queue_fetch());
+
+        island.expanded = true;
+        island.tab = Tab::Widgets;
+        assert!(island.queue_visible());
+        assert!(island.maybe_start_queue_fetch());
+        assert!(island.queue_inflight);
+        assert!(!island.maybe_start_queue_fetch());
+
+        island.queue_inflight = false;
+        island.expanded = false;
+        assert!(!island.maybe_start_queue_fetch());
     }
 
     #[test]

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -263,6 +263,7 @@ impl Island {
         this.anim_h.set(h);
 
         platform::install_media_observers();
+        platform::install_mouse_monitors();
         nook_core::runtime().spawn(async {
             let _ = nook_core::calendar::request_calendar_access().await;
         });
@@ -284,12 +285,17 @@ impl Island {
                     .await;
                 platform::apply_island_chrome();
             }
+            platform::request_pin();
             loop {
-                cx.background_executor().timer(Duration::from_secs(2)).await;
+                cx.background_executor()
+                    .timer(Duration::from_millis(250))
+                    .await;
                 if this.update(cx, |_, _| ()).is_err() {
                     break;
                 }
-                platform::pin_island_windows();
+                if platform::take_pin_needed() {
+                    platform::pin_island_windows();
+                }
             }
         })
         .detach();
@@ -564,12 +570,11 @@ impl Island {
                 let Ok(is_playing) = alive else {
                     break;
                 };
-                // Every poll spawns an osascript/perl child, so cadence is
-                // the battery cost that matters: 1s while playing (the
-                // elapsed display ticks in whole seconds anyway), 5s
-                // otherwise. The distributed-notification observers wake the
-                // wait instantly on Spotify/Music play/pause/track changes —
-                // the slow cadence only gates Safari/YouTube pickup.
+                // Stream-backed adapter reads are a cheap lock; cadence is
+                // for interpolated elapsed (1s while playing) and the
+                // AppleScript fallback (5s idle). Distributed-notification
+                // observers and the MediaRemote stream flip `take_media_event`
+                // so the wait wakes instantly on real changes.
                 let cadence = if is_playing {
                     Duration::from_secs(1)
                 } else {

--- a/crates/nook/src/island/render.rs
+++ b/crates/nook/src/island/render.rs
@@ -122,6 +122,10 @@ impl gpui::Render for Island {
                     this.apply_reposition(event.position.x.into(), event.position.y.into());
                     cx.notify();
                 }
+                if this.scrubber_drag.is_some() {
+                    this.update_scrubber_from_x(event.position.x.into());
+                    cx.notify();
+                }
                 if this.poll_pending_file_drag(Some(window)) {
                     cx.notify();
                 }
@@ -131,7 +135,8 @@ impl gpui::Render for Island {
                 cx.listener(|this, _: &MouseUpEvent, _, cx| {
                     let moved = this.finish_reposition();
                     let file = this.finish_file_press();
-                    if moved || file {
+                    let seek = this.finish_scrubber();
+                    if moved || file || seek {
                         cx.notify();
                     }
                 }),

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -152,7 +152,13 @@ impl WidgetModuleExt for WidgetModule {
     fn subtitle(self, settings: &AppSettings) -> SharedString {
         match self {
             Self::Calendar => "7 days".into(),
-            Self::Music => "Now Playing".into(),
+            Self::Music => {
+                if settings.show_media_queue {
+                    "Now Playing + queue".into()
+                } else {
+                    "Now Playing".into()
+                }
+            }
             Self::Files => "Tray tab".into(),
             Self::Notes => "Scratchpad".into(),
             Self::Observe => observe_subtitle(settings.observe.metrics.len()),
@@ -227,8 +233,10 @@ pub(super) struct SettingsView {
     url_focus: FocusHandle,
     token_focus: FocusHandle,
     query_focus: FocusHandle,
+    client_id_focus: FocusHandle,
     url_draft: String,
     token_draft: String,
+    client_id_draft: String,
     token_revealed: bool,
     query_draft: String,
     catalog: Vec<String>,
@@ -254,8 +262,10 @@ impl SettingsView {
             url_focus: cx.focus_handle(),
             token_focus: cx.focus_handle(),
             query_focus: cx.focus_handle(),
+            client_id_focus: cx.focus_handle(),
             url_draft: settings.observe.prometheus_url,
             token_draft: settings.observe.metrics_token,
+            client_id_draft: settings.spotify_client_id,
             token_revealed: false,
             query_draft: String::new(),
             catalog: Vec::new(),
@@ -390,6 +400,7 @@ impl gpui::Render for SettingsView {
         let url_focused = self.url_focus.is_focused(window);
         let token_focused = self.token_focus.is_focused(window);
         let query_focused = self.query_focus.is_focused(window);
+        let client_id_focused = self.client_id_focus.is_focused(window);
 
         div()
             .id("settings-root")
@@ -412,7 +423,14 @@ impl gpui::Render for SettingsView {
             .child(self.sidebar(cx))
             .child(div().w(px(1.)).h_full().bg(hairline()))
             .child(if self.category == SettingsCategory::Widgets {
-                self.render_widgets(&settings, url_focused, token_focused, query_focused, cx)
+                self.render_widgets(
+                    &settings,
+                    url_focused,
+                    token_focused,
+                    query_focused,
+                    client_id_focused,
+                    cx,
+                )
                     .into_any_element()
             } else {
                 self.render_general(&settings, cx).into_any_element()
@@ -694,6 +712,7 @@ impl SettingsView {
         url_focused: bool,
         token_focused: bool,
         query_focused: bool,
+        client_id_focused: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let remaining = settings.remaining_cells();
@@ -733,6 +752,7 @@ impl SettingsView {
                     url_focused,
                     token_focused,
                     query_focused,
+                    client_id_focused,
                     cx,
                 )),
         )
@@ -954,6 +974,7 @@ impl SettingsView {
         url_focused: bool,
         token_focused: bool,
         query_focused: bool,
+        client_id_focused: bool,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
         let name = self.module.name();
@@ -1021,6 +1042,143 @@ impl SettingsView {
                     cx,
                 ))
             })
+            .when(self.module == WidgetModule::Music, |d| {
+                d.child(self.render_music_settings(settings, client_id_focused, cx))
+            })
+    }
+
+    fn persist_client_id(&self) {
+        let draft = self.client_id_draft.trim().to_string();
+        if nook_core::settings::get_app_settings().spotify_client_id == draft {
+            return;
+        }
+        nook_core::settings::tweak_app_settings(|s| s.spotify_client_id = draft);
+    }
+
+    fn render_music_settings(
+        &self,
+        settings: &AppSettings,
+        client_id_focused: bool,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        if !client_id_focused {
+            self.persist_client_id();
+        }
+        use nook_core::spotify::SpotifyStatus;
+        let status = nook_core::spotify::status();
+        let status_text = match &status {
+            SpotifyStatus::Disconnected => "Not connected".to_string(),
+            SpotifyStatus::Connecting => "Waiting for Spotify login…".to_string(),
+            SpotifyStatus::Connected => "Connected".to_string(),
+            SpotifyStatus::NeedsClientId => "Add a client ID first".to_string(),
+            SpotifyStatus::PremiumRequired => {
+                "Spotify Premium is required for queue control".to_string()
+            }
+            SpotifyStatus::Error(err) => err.clone(),
+        };
+        let connected = matches!(
+            status,
+            SpotifyStatus::Connected | SpotifyStatus::PremiumRequired
+        );
+        let client_placeholder = self.client_id_draft.is_empty();
+        let client_value = if client_placeholder {
+            "Paste your Spotify client ID"
+        } else {
+            self.client_id_draft.as_str()
+        };
+        let mut rows = vec![
+            toggle_row("Show Up Next", settings.show_media_queue, cx, |s| {
+                s.show_media_queue = !s.show_media_queue;
+            })
+            .into_any_element(),
+            field_row(
+                "spotify-client-id",
+                "Client ID",
+                client_value,
+                client_placeholder,
+                client_id_focused,
+                &self.client_id_focus,
+                cx,
+                |this, event, cx| {
+                    if event.keystroke.key == "enter" {
+                        this.persist_client_id();
+                        cx.notify();
+                    } else if SettingsView::apply_key(&mut this.client_id_draft, event, cx) {
+                        cx.notify();
+                    }
+                },
+            )
+            .into_any_element(),
+            settings_row("spotify-status")
+                .child(label("Spotify", theme::BODY, true))
+                .child(label(status_text, theme::SUBHEADLINE, false))
+                .into_any_element(),
+        ];
+        if connected {
+            rows.push(
+                action_row(
+                    "spotify-disconnect",
+                    "Account",
+                    "Disconnect",
+                    cx,
+                    |_, _, cx| {
+                        nook_core::spotify::disconnect();
+                        cx.notify();
+                    },
+                )
+                .into_any_element(),
+            );
+        } else {
+            rows.push(
+                action_row(
+                    "spotify-connect",
+                    "Account",
+                    "Connect Spotify",
+                    cx,
+                    |this, _, cx| {
+                        this.persist_client_id();
+                        cx.spawn(async move |this, cx| {
+                            let result = cx
+                                .background_executor()
+                                .spawn(async {
+                                    nook_core::runtime().block_on(nook_core::spotify::connect())
+                                })
+                                .await;
+                            this.update(cx, |_, cx| {
+                                if let Err(err) = result {
+                                    log::warn!("spotify connect: {err}");
+                                }
+                                cx.notify();
+                            })
+                            .ok();
+                        })
+                        .detach();
+                        cx.notify();
+                    },
+                )
+                .into_any_element(),
+            );
+        }
+        if nook_core::queue::music_automation_denied() {
+            rows.push(
+                settings_row("music-tcc")
+                    .child(label(
+                        "Music Automation was denied. Grant it in System Settings → Privacy & Security → Automation to show Up Next in playlist.",
+                        theme::SUBHEADLINE,
+                        false,
+                    ))
+                    .into_any_element(),
+            );
+        }
+
+        section(
+            "Playing Next",
+            settings_group(rows),
+            Some(format!(
+                "Register redirect URI {} on your Spotify developer app. No client secret is used. Apple Music shows upcoming tracks from the current playlist — not the real Playing Next queue — and hides the list when shuffle or radio is on.",
+                nook_core::spotify::REDIRECT_URI
+            )),
+        )
     }
 
     fn render_observe_settings(
@@ -1346,7 +1504,7 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Pinned metrics on the compact island and the expanded card.".into()
         }
         WidgetModule::Music => {
-            "Now Playing from MediaRemote on macOS, with an AppleScript fallback.".into()
+            "Now Playing from MediaRemote on macOS, with an AppleScript fallback. Up Next lists the current Music playlist (unshuffled) or the Spotify Web API queue.".into()
         }
         WidgetModule::Files => "Drop zone and tray live on the Tray tab of the expanded island.".into(),
         WidgetModule::Timers => "Countdown presets and a compact ring while a timer is running.".into(),

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -20,6 +20,9 @@ use nook_core::notch::{CGPoint, CGRect, CGSize};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 #[cfg(target_os = "macos")]
 use std::sync::Once;
+#[cfg(target_os = "macos")]
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::Duration;
 
 #[cfg(target_os = "macos")]
 static INSTALL: Once = Once::new();
@@ -46,7 +49,14 @@ pub fn install() {
 /// handlers also pin immediately on the main thread.
 pub fn request_pin() {
     #[cfg(target_os = "macos")]
-    PIN_NEEDED.store(true, Ordering::Release);
+    {
+        PIN_NEEDED.store(true, Ordering::Release);
+        let wait = pin_wait();
+        if let Ok(mut ready) = wait.ready.lock() {
+            *ready = true;
+            wait.cv.notify_one();
+        }
+    }
 }
 
 pub fn take_pin_needed() -> bool {
@@ -56,6 +66,52 @@ pub fn take_pin_needed() -> bool {
     }
     #[cfg(not(target_os = "macos"))]
     false
+}
+
+#[cfg(target_os = "macos")]
+struct PinWait {
+    ready: Mutex<bool>,
+    cv: Condvar,
+}
+
+#[cfg(target_os = "macos")]
+fn pin_wait() -> &'static PinWait {
+    static WAIT: OnceLock<PinWait> = OnceLock::new();
+    WAIT.get_or_init(|| PinWait {
+        ready: Mutex::new(false),
+        cv: Condvar::new(),
+    })
+}
+
+/// Block until [`request_pin`] or `timeout`. Must run off the main thread.
+pub fn wait_pin_needed(timeout: Duration) -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if PIN_NEEDED.load(Ordering::Acquire) {
+            return true;
+        }
+        let wait = pin_wait();
+        let Ok(mut ready) = wait.ready.lock() else {
+            std::thread::sleep(timeout);
+            return PIN_NEEDED.load(Ordering::Acquire);
+        };
+        if *ready {
+            *ready = false;
+            return true;
+        }
+        let (mut ready, _) = wait
+            .cv
+            .wait_timeout(ready, timeout)
+            .unwrap_or_else(|e| e.into_inner());
+        let signaled = *ready;
+        *ready = false;
+        signaled || PIN_NEEDED.load(Ordering::Acquire)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        std::thread::sleep(timeout);
+        false
+    }
 }
 
 #[cfg(target_os = "macos")]
@@ -887,6 +943,17 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(colorsChanged:),
         name: colors_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let appearance_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSApplicationDidChangeEffectiveAppearanceNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        center,
+        addObserver: target,
+        selector: sel!(colorsChanged:),
+        name: appearance_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -806,6 +806,16 @@ fn install_app_target() {
         extern "C" fn app_activated(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
             nook_core::occupancy::invalidate();
         }
+        extern "C" fn accessibility_changed(
+            _this: *mut AnyObject,
+            _cmd: Sel,
+            _note: *mut AnyObject,
+        ) {
+            invalidate_accessibility_flags();
+        }
+        extern "C" fn colors_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            invalidate_accent_color();
+        }
 
         let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
         let cls = objc_allocateClassPair(super_cls, c"NookAppTarget".as_ptr(), 0);
@@ -826,10 +836,18 @@ fn install_app_target() {
         let imp_app: Imp = std::mem::transmute(
             app_activated as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
         );
+        let imp_a11y: Imp = std::mem::transmute(
+            accessibility_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
+        let imp_colors: Imp = std::mem::transmute(
+            colors_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
         let _ = class_addMethod(cls, sel!(openSettings:), imp_settings, types.as_ptr());
         let _ = class_addMethod(cls, sel!(screenChanged:), imp_screen, types.as_ptr());
         let _ = class_addMethod(cls, sel!(spaceChanged:), imp_space, types.as_ptr());
         let _ = class_addMethod(cls, sel!(appActivated:), imp_app, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(accessibilityChanged:), imp_a11y, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(colorsChanged:), imp_colors, types.as_ptr());
         objc_registerClassPair(cls);
         observe_screen_changes();
     }
@@ -857,6 +875,18 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(screenChanged:),
         name: name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+
+    let colors_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSSystemColorsDidChangeNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        center,
+        addObserver: target,
+        selector: sel!(colorsChanged:),
+        name: colors_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 
@@ -888,6 +918,18 @@ unsafe fn observe_screen_changes() {
         addObserver: target,
         selector: sel!(appActivated:),
         name: app_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let a11y_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceAccessibilityDisplayOptionsDidChangeNotification"
+            .as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(accessibilityChanged:),
+        name: a11y_name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
 }
@@ -1380,16 +1422,43 @@ pub fn open_calendar() {
     }
 }
 
+#[cfg(target_os = "macos")]
+static ACCENT_VALID: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
+static ACCENT_R: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+#[cfg(target_os = "macos")]
+static ACCENT_G: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+#[cfg(target_os = "macos")]
+static ACCENT_B: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+#[cfg(target_os = "macos")]
+fn invalidate_accent_color() {
+    ACCENT_VALID.store(false, Ordering::Relaxed);
+}
+
 /// System Settings → Appearance → *Accent color* (`NSColor.controlAccentColor`),
 /// as sRGB components in 0..=1. `None` when there is no AppKit to ask or the
 /// color cannot be converted to an RGB space — callers fall back to systemBlue.
 ///
-/// Read live rather than cached so switching the accent in System Settings
-/// shows up on the next frame. Must be called on the main thread.
+/// Cached until `NSSystemColorsDidChangeNotification` so idle frames do not
+/// walk CoreUI catalog colors. Must be called on the main thread for the
+/// first resolve.
 pub fn accent_color() -> Option<(f32, f32, f32)> {
     #[cfg(target_os = "macos")]
     {
-        accent_color_macos()
+        if ACCENT_VALID.load(Ordering::Relaxed) {
+            return Some((
+                f32::from_bits(ACCENT_R.load(Ordering::Relaxed)),
+                f32::from_bits(ACCENT_G.load(Ordering::Relaxed)),
+                f32::from_bits(ACCENT_B.load(Ordering::Relaxed)),
+            ));
+        }
+        let color = accent_color_macos()?;
+        ACCENT_R.store(color.0.to_bits(), Ordering::Relaxed);
+        ACCENT_G.store(color.1.to_bits(), Ordering::Relaxed);
+        ACCENT_B.store(color.2.to_bits(), Ordering::Relaxed);
+        ACCENT_VALID.store(true, Ordering::Relaxed);
+        Some(color)
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -1432,10 +1501,23 @@ fn accent_color_macos() -> Option<(f32, f32, f32)> {
     })
 }
 
+#[cfg(target_os = "macos")]
+static REDUCE_TRANSPARENCY_CACHE: AtomicU64 = AtomicU64::new(0);
+#[cfg(target_os = "macos")]
+static REDUCE_MOTION_CACHE: AtomicU64 = AtomicU64::new(0);
+
+#[cfg(target_os = "macos")]
+fn invalidate_accessibility_flags() {
+    REDUCE_TRANSPARENCY_CACHE.store(0, Ordering::Relaxed);
+    REDUCE_MOTION_CACHE.store(0, Ordering::Relaxed);
+}
+
 /// 1s-TTL cache for an AppKit accessibility flag. Both flags below are read
 /// from the 20ms island tick; two ObjC round-trips per tick is pointless for
-/// settings a human toggles at most a few times a day. Layout: bit0 = value,
-/// bit1 = valid, upper bits = last-read unix ms.
+/// settings a human toggles at most a few times a day. The workspace
+/// accessibility-display observer also invalidates these so a toggle applies
+/// on the next tick. Layout: bit0 = value, bit1 = valid, upper bits = last-read
+/// unix ms.
 #[cfg(target_os = "macos")]
 fn cached_accessibility_flag(cache: &AtomicU64, read: unsafe fn() -> bool) -> bool {
     let now_ms = std::time::SystemTime::now()
@@ -1457,7 +1539,6 @@ fn cached_accessibility_flag(cache: &AtomicU64, read: unsafe fn() -> bool) -> bo
 pub fn reduce_transparency() -> bool {
     #[cfg(target_os = "macos")]
     {
-        static CACHE: AtomicU64 = AtomicU64::new(0);
         unsafe fn read() -> bool {
             use objc2::runtime::AnyObject;
             use objc2::*;
@@ -1467,7 +1548,7 @@ pub fn reduce_transparency() -> bool {
             }
             msg_send![workspace, accessibilityDisplayShouldReduceTransparency]
         }
-        cached_accessibility_flag(&CACHE, read)
+        cached_accessibility_flag(&REDUCE_TRANSPARENCY_CACHE, read)
     }
     #[cfg(not(target_os = "macos"))]
     false
@@ -1480,7 +1561,6 @@ pub fn reduce_transparency() -> bool {
 pub fn reduce_motion() -> bool {
     #[cfg(target_os = "macos")]
     {
-        static CACHE: AtomicU64 = AtomicU64::new(0);
         unsafe fn read() -> bool {
             use objc2::runtime::AnyObject;
             use objc2::*;
@@ -1490,10 +1570,44 @@ pub fn reduce_motion() -> bool {
             }
             msg_send![workspace, accessibilityDisplayShouldReduceMotion]
         }
-        cached_accessibility_flag(&CACHE, read)
+        cached_accessibility_flag(&REDUCE_MOTION_CACHE, read)
     }
     #[cfg(not(target_os = "macos"))]
     false
+}
+
+#[cfg(target_os = "macos")]
+unsafe fn workspace_note_bundle_id(note: *mut objc2::runtime::AnyObject) -> Option<String> {
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    if note.is_null() {
+        return None;
+    }
+    let info: *mut AnyObject = msg_send![note, userInfo];
+    if info.is_null() {
+        return None;
+    }
+    let key: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceApplicationKey".as_ptr()
+    ];
+    let app: *mut AnyObject = msg_send![info, objectForKey: key];
+    if app.is_null() {
+        return None;
+    }
+    let ident: *mut AnyObject = msg_send![app, bundleIdentifier];
+    if ident.is_null() {
+        return None;
+    }
+    let utf8: *const std::ffi::c_char = msg_send![ident, UTF8String];
+    if utf8.is_null() {
+        return None;
+    }
+    Some(
+        std::ffi::CStr::from_ptr(utf8)
+            .to_string_lossy()
+            .into_owned(),
+    )
 }
 
 /// Subscribe to Spotify's and Music's public playback-change broadcasts.
@@ -1514,23 +1628,60 @@ pub fn install_media_observers() {
 
         static INSTALLED: Once = Once::new();
         INSTALLED.call_once(|| {
+            let _ = nook_core::audio::prime_media_apps();
+
             let center: *mut AnyObject =
                 msg_send![class!(NSDistributedNotificationCenter), defaultCenter];
-            if center.is_null() {
+            if !center.is_null() {
+                for name in [
+                    c"com.spotify.client.PlaybackStateChanged",
+                    c"com.apple.Music.playerInfo",
+                    c"com.apple.iTunes.playerInfo",
+                ] {
+                    let ns_name: *mut AnyObject =
+                        msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
+                    let block = RcBlock::new(move |_note: *mut AnyObject| {
+                        nook_core::audio::note_media_event();
+                    });
+                    let token: *mut AnyObject = msg_send![
+                        center,
+                        addObserverForName: ns_name,
+                        object: std::ptr::null_mut::<AnyObject>(),
+                        queue: std::ptr::null_mut::<AnyObject>(),
+                        usingBlock: &*block
+                    ];
+                    std::mem::forget(block);
+                    let _ = token;
+                }
+            }
+
+            let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+            if workspace.is_null() {
                 return;
             }
-            for name in [
-                c"com.spotify.client.PlaybackStateChanged",
-                c"com.apple.Music.playerInfo",
-                c"com.apple.iTunes.playerInfo",
+            let wsnc: *mut AnyObject = msg_send![workspace, notificationCenter];
+            if wsnc.is_null() {
+                return;
+            }
+            for (name, running) in [
+                (c"NSWorkspaceDidLaunchApplicationNotification", true),
+                (c"NSWorkspaceDidTerminateApplicationNotification", false),
             ] {
                 let ns_name: *mut AnyObject =
                     msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
-                let block = RcBlock::new(move |_note: *mut AnyObject| {
-                    nook_core::audio::note_media_event();
+                let block = RcBlock::new(move |note: *mut AnyObject| {
+                    if let Some(id) = workspace_note_bundle_id(note) {
+                        nook_core::audio::note_media_app_running(&id, running);
+                        if matches!(
+                            id.as_str(),
+                            "com.spotify.client" | "com.apple.Music" | "com.apple.Safari"
+                        ) {
+                            nook_core::audio::note_media_event();
+                        }
+                    }
                 });
                 let token: *mut AnyObject = msg_send![
-                    center,
+                    wsnc,
                     addObserverForName: ns_name,
                     object: std::ptr::null_mut::<AnyObject>(),
                     queue: std::ptr::null_mut::<AnyObject>(),

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -28,13 +28,34 @@ static LOGGED_PIN: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
 static OPEN_SETTINGS: AtomicBool = AtomicBool::new(false);
 #[cfg(target_os = "macos")]
+static PIN_NEEDED: AtomicBool = AtomicBool::new(false);
+#[cfg(target_os = "macos")]
 static STATUS_ITEM: std::sync::atomic::AtomicPtr<objc2::runtime::AnyObject> =
     std::sync::atomic::AtomicPtr::new(std::ptr::null_mut());
 
 /// Call once before `open_island`. Safe to call again.
 pub fn install() {
     #[cfg(target_os = "macos")]
-    install_macos();
+    {
+        install_macos();
+        install_mouse_monitors();
+    }
+}
+
+/// Ask the pin backstop loop to restyle/pin island windows. Notification
+/// handlers also pin immediately on the main thread.
+pub fn request_pin() {
+    #[cfg(target_os = "macos")]
+    PIN_NEEDED.store(true, Ordering::Release);
+}
+
+pub fn take_pin_needed() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        return PIN_NEEDED.swap(false, Ordering::AcqRel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    false
 }
 
 #[cfg(target_os = "macos")]
@@ -774,7 +795,16 @@ fn install_app_target() {
         }
         extern "C" fn screen_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
             nook_core::notch::invalidate_screen_cache();
+            request_pin();
             pin_island_windows();
+        }
+        extern "C" fn space_changed(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            nook_core::notch::invalidate_screen_cache();
+            request_pin();
+            pin_island_windows();
+        }
+        extern "C" fn app_activated(_this: *mut AnyObject, _cmd: Sel, _note: *mut AnyObject) {
+            nook_core::occupancy::invalidate();
         }
 
         let super_cls = class!(NSObject) as *const AnyClass as *mut AnyClass;
@@ -790,8 +820,16 @@ fn install_app_target() {
         let imp_screen: Imp = std::mem::transmute(
             screen_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
         );
+        let imp_space: Imp = std::mem::transmute(
+            space_changed as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
+        let imp_app: Imp = std::mem::transmute(
+            app_activated as extern "C" fn(*mut AnyObject, Sel, *mut AnyObject),
+        );
         let _ = class_addMethod(cls, sel!(openSettings:), imp_settings, types.as_ptr());
         let _ = class_addMethod(cls, sel!(screenChanged:), imp_screen, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(spaceChanged:), imp_space, types.as_ptr());
+        let _ = class_addMethod(cls, sel!(appActivated:), imp_app, types.as_ptr());
         objc_registerClassPair(cls);
         observe_screen_changes();
     }
@@ -821,6 +859,78 @@ unsafe fn observe_screen_changes() {
         name: name,
         object: std::ptr::null_mut::<AnyObject>()
     ];
+
+    let workspace: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+    if workspace.is_null() {
+        return;
+    }
+    let wsnc: *mut AnyObject = msg_send![workspace, notificationCenter];
+    if wsnc.is_null() {
+        return;
+    }
+    let space_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceActiveSpaceDidChangeNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(spaceChanged:),
+        name: space_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+    let app_name: *mut AnyObject = msg_send![
+        class!(NSString),
+        stringWithUTF8String: c"NSWorkspaceDidActivateApplicationNotification".as_ptr()
+    ];
+    let _: () = msg_send![
+        wsnc,
+        addObserver: target,
+        selector: sel!(appActivated:),
+        name: app_name,
+        object: std::ptr::null_mut::<AnyObject>()
+    ];
+}
+
+/// NSEvent global + local monitors for mouse moved / left-drag / left-up.
+/// Main thread only. Handlers write the same atomics as the 250 ms backstop
+/// poll in `nook_core::mouse`. Local handler must return the event.
+pub fn install_mouse_monitors() {
+    #[cfg(target_os = "macos")]
+    unsafe {
+        use block2::RcBlock;
+        use objc2::runtime::AnyObject;
+        use objc2::*;
+
+        static INSTALLED: Once = Once::new();
+        INSTALLED.call_once(|| {
+            // MouseMoved | LeftMouseDragged | LeftMouseUp
+            const MASK: u64 = (1 << 5) | (1 << 6) | (1 << 2);
+
+            let global = RcBlock::new(move |_event: *mut AnyObject| {
+                nook_core::mouse::sample_now();
+            });
+            let g: *mut AnyObject = msg_send![
+                class!(NSEvent),
+                addGlobalMonitorForEventsMatchingMask: MASK,
+                handler: &*global
+            ];
+            std::mem::forget(global);
+            let _ = g;
+
+            let local = RcBlock::new(move |event: *mut AnyObject| -> *mut AnyObject {
+                nook_core::mouse::sample_now();
+                event
+            });
+            let l: *mut AnyObject = msg_send![
+                class!(NSEvent),
+                addLocalMonitorForEventsMatchingMask: MASK,
+                handler: &*local
+            ];
+            std::mem::forget(local);
+            let _ = l;
+        });
+    }
 }
 
 /// Hand files to the system AirDrop picker (`NSSharingServiceNameSendViaAirDrop`).


### PR DESCRIPTION
## Summary

Full media player polish plus a Playing Next / Up Next list on the expanded Music pane.

- **Scrubber:** draggable thumb replaces the old discrete seek-hit zones. Elapsed time interpolates locally between MediaRemote / DNC events — no faster poll.
- **Apple Music pseudo-queue:** AppleScript `current playlist` + current track index, next ~10 tracks, play via `play track i of current playlist`. Section label is **Up Next in playlist**. Hidden when shuffle is on or the source looks like radio/autoplay. This is **not** Music's real Playing Next queue (manually queued items are invisible).
- **Spotify queue:** OAuth 2.0 PKCE on `127.0.0.1:43821`, scopes `user-read-playback-state` + `user-modify-playback-state`. `GET /v1/me/player/queue`. Jump = `PUT /v1/me/player/play` with context_uri+offset, else N sequential `POST /next`. Refresh token in Keychain (macOS). User-supplied client ID only — no bundled secret.
- **Fetch policy:** queue is loaded only when the island is expanded, the Music widget is visible, and `show_media_queue` is on — on expand and on track change. No standalone queue timer.
- **Settings:** Show Up Next toggle, Spotify client ID, Connect / Disconnect / status, Premium 403 copy, Automation TCC (-1743) hint. `NSAppleEventsUsageDescription` updated.

Base: `cursor/wp01-media-stream-mouse-a6ea` (WP01 stream + mouse). Does not reintroduce a 400ms perl/osascript poll.

## Honest blockers (expected)

1. **Apple Music's real Playing Next queue is unreadable.** Music.app's AppleScript dictionary omits it; `MRPlaybackQueueRequest` is entitlement-gated and rejected by this package. Shuffle / radio hide the list.
2. **Spotify per-item play is skip-N** (racy if the queue changes mid-jump) or context+offset when we have a context URI. Control endpoints need Premium; 403s degrade in Settings.
3. **No shipped Spotify client ID.** Users paste their own developer-app client ID and register redirect URI `http://127.0.0.1:43821/callback`.
4. **Automation TCC** can deny Music AppleScript; `-1743` surfaces a Settings hint.

## Tests

`cargo test -p nook -p nook-core` on Linux:
- nook-core: **107** passed
- nook: **84** passed

New coverage: PKCE RFC 7636 vector, authorize URL / percent-encode / callback parse, Spotify queue JSON, skip-N math, Music playlist windowing + shuffle hide, scrubber ratio, queue fetch gating (expanded + media card only).

## Battery

No new idle wakeups. Queue artwork: Spotify 64px URLs lazy-cached by track id; Music rows skip artwork.