### PR TITLE
WP19: Meeting controls (Zoom / Teams / Meet)

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -29,6 +29,6 @@
 	<key>NSCameraUsageDescription</key>
 	<string>openNook shows a live camera preview in the Mirror control so you can check yourself before a call.</string>
 	<key>NSAppleEventsUsageDescription</key>
-	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, and to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon when the browser does not provide artwork.</string>
+	<string>openNook uses Automation to pause or skip Music, Spotify, and Safari if system media controls are unavailable, to read the current Safari or Chrome tab URL so the island can show a YouTube thumbnail or site icon, and to find or activate a Google Meet tab and click Zoom menu items via System Events when Accessibility is unavailable.</string>
 </dict>
 </plist>

--- a/crates/nook-core/src/browser_media.rs
+++ b/crates/nook-core/src/browser_media.rs
@@ -7,9 +7,64 @@
 
 use crate::utils::{base64_encode, read_response_limited};
 
+/// Bundle IDs that can report a tab URL via AppleScript.
+pub const BROWSER_BUNDLE_IDS: &[&str] = &[
+    "com.apple.Safari",
+    "com.apple.Safari.WebApp",
+    "com.apple.WebKit.GPU",
+    "com.google.Chrome",
+    "com.google.Chrome.canary",
+    "com.brave.Browser",
+    "com.microsoft.edgemac",
+    "company.thebrowser.Browser",
+    "com.operasoftware.Opera",
+    "com.vivaldi.Vivaldi",
+];
+
 /// Chrome-family and Safari bundle IDs that can report a tab URL.
 pub fn is_browser(app_name: Option<&str>, bundle_id: Option<&str>) -> bool {
     applescript_app(app_name, bundle_id).is_some()
+}
+
+/// True for a browser app or one of its helpers (`com.google.Chrome.helper`).
+pub fn is_browser_bundle(id: &str) -> bool {
+    BROWSER_BUNDLE_IDS
+        .iter()
+        .any(|known| id == *known || id.starts_with(&format!("{known}.")))
+}
+
+/// `https://meet.google.com/xxx-xxxx-xxx` (and the same host with a longer code).
+pub fn is_meet_url(url: &str) -> bool {
+    let Ok(parsed) = reqwest::Url::parse(url) else {
+        return false;
+    };
+    if parsed.scheme() != "http" && parsed.scheme() != "https" {
+        return false;
+    }
+    let host = parsed.host_str().unwrap_or("").trim_start_matches("www.");
+    if !host.eq_ignore_ascii_case("meet.google.com") {
+        return false;
+    }
+    let mut segs = match parsed.path_segments() {
+        Some(s) => s,
+        None => return false,
+    };
+    let code = segs.next().unwrap_or("");
+    is_meet_code(code)
+}
+
+fn is_meet_code(code: &str) -> bool {
+    let parts: Vec<&str> = code.split('-').collect();
+    (2..=4).contains(&parts.len())
+        && parts.iter().all(|p| {
+            (3..=4).contains(&p.len()) && p.chars().all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        })
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MeetTab {
+    pub app: String,
+    pub url: String,
 }
 
 pub fn youtube_video_id(input: &str) -> Option<String> {
@@ -66,7 +121,7 @@ fn valid_video_id(id: &str) -> Option<String> {
     }
 }
 
-fn applescript_app<'a>(app_name: Option<&'a str>, bundle_id: Option<&str>) -> Option<&'a str> {
+pub fn applescript_app<'a>(app_name: Option<&'a str>, bundle_id: Option<&str>) -> Option<&'a str> {
     if let Some(id) = bundle_id {
         let name = match id {
             "com.apple.Safari" | "com.apple.Safari.WebApp" | "com.apple.WebKit.GPU" => "Safari",
@@ -262,6 +317,243 @@ async fn run_osascript(script: &str) -> Option<String> {
     Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
+const MEET_JS_MUTE: &str = r#"(function(){var b=document.querySelector('[data-is-muted]')||document.querySelector('button[aria-label*="microphone" i]');if(!b)return 'missing';b.click();return b.getAttribute('data-is-muted')||'clicked';})()"#;
+const MEET_JS_LEAVE: &str = r#"(function(){var b=document.querySelector('[aria-label*="Leave call" i]')||document.querySelector('button[aria-label*="leave" i]');if(!b)return 'missing';b.click();return 'clicked';})()"#;
+
+fn meet_find_script(app: &str) -> String {
+    if app == "Safari" {
+        r#"tell application "Safari"
+  if (count of windows) is 0 then return ""
+  repeat with w in windows
+    repeat with t in tabs of w
+      try
+        set u to URL of t
+        if u contains "meet.google.com/" then return u
+      end try
+    end repeat
+  end repeat
+  return ""
+end tell"#
+            .into()
+    } else {
+        format!(
+            r#"tell application "{app}"
+  if (count of windows) is 0 then return ""
+  repeat with w in windows
+    repeat with t in tabs of w
+      try
+        set u to URL of t
+        if u contains "meet.google.com/" then return u
+      end try
+    end repeat
+  end repeat
+  return ""
+end tell"#
+        )
+    }
+}
+
+fn meet_activate_script(app: &str) -> String {
+    if app == "Safari" {
+        r#"tell application "Safari"
+  repeat with w in windows
+    repeat with t in tabs of w
+      try
+        if (URL of t) contains "meet.google.com/" then
+          set current tab of w to t
+          set index of w to 1
+          activate
+          return "ok"
+        end if
+      end try
+    end repeat
+  end repeat
+  return ""
+end tell"#
+            .into()
+    } else {
+        format!(
+            r#"tell application "{app}"
+  repeat with w in windows
+    set i to 0
+    repeat with t in tabs of w
+      set i to i + 1
+      try
+        if (URL of t) contains "meet.google.com/" then
+          set active tab index of w to i
+          set index of w to 1
+          activate
+          return "ok"
+        end if
+      end try
+    end repeat
+  end repeat
+  return ""
+end tell"#
+        )
+    }
+}
+
+fn meet_js_script(app: &str, js: &str) -> String {
+    let escaped = applescript_escape(js);
+    if app == "Safari" {
+        format!(
+            r#"tell application "Safari"
+  repeat with w in windows
+    repeat with t in tabs of w
+      try
+        if (URL of t) contains "meet.google.com/" then
+          tell t to do JavaScript "{escaped}"
+          return result as string
+        end if
+      end try
+    end repeat
+  end repeat
+  return ""
+end tell"#
+        )
+    } else {
+        format!(
+            r#"tell application "{app}"
+  repeat with w in windows
+    repeat with t in tabs of w
+      try
+        if (URL of t) contains "meet.google.com/" then
+          tell t to execute javascript "{escaped}"
+          return result as string
+        end if
+      end try
+    end repeat
+  end repeat
+  return ""
+end tell"#
+        )
+    }
+}
+
+fn meet_app_names() -> &'static [&'static str] {
+    &[
+        "Safari",
+        "Google Chrome",
+        "Google Chrome Canary",
+        "Brave Browser",
+        "Microsoft Edge",
+        "Arc",
+        "Opera",
+        "Vivaldi",
+    ]
+}
+
+/// Blocking osascript. Safe inside the Core Tokio runtime (no nested `block_on`).
+pub fn run_osascript_blocking(script: &str) -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let output = std::process::Command::new("/usr/bin/osascript")
+            .arg("-e")
+            .arg(script)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            log::debug!(
+                "osascript failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return None;
+        }
+        let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = script;
+        None
+    }
+}
+
+pub fn find_meet_tab_blocking() -> Option<MeetTab> {
+    for app in meet_app_names() {
+        if let Some(url) = run_osascript_blocking(&meet_find_script(app)) {
+            if is_meet_url(&url) {
+                return Some(MeetTab {
+                    app: (*app).to_string(),
+                    url,
+                });
+            }
+        }
+    }
+    None
+}
+
+pub async fn find_meet_tab() -> Option<MeetTab> {
+    #[cfg(target_os = "macos")]
+    {
+        for app in meet_app_names() {
+            if let Some(url) = run_osascript(&meet_find_script(app)).await {
+                if is_meet_url(&url) {
+                    return Some(MeetTab {
+                        app: (*app).to_string(),
+                        url,
+                    });
+                }
+            }
+        }
+        None
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+pub fn activate_meet_tab_blocking() -> bool {
+    if let Some(tab) = find_meet_tab_blocking() {
+        return run_osascript_blocking(&meet_activate_script(&tab.app))
+            .is_some_and(|s| s == "ok");
+    }
+    false
+}
+
+pub async fn activate_meet_tab() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(tab) = find_meet_tab().await {
+            return run_osascript(&meet_activate_script(&tab.app))
+                .await
+                .is_some_and(|s| s == "ok");
+        }
+        false
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Opt-in: Chrome/Safari "Allow JavaScript from Apple Events".
+pub fn meet_click_mute_js() -> Option<String> {
+    let tab = find_meet_tab_blocking()?;
+    let out = run_osascript_blocking(&meet_js_script(&tab.app, MEET_JS_MUTE))?;
+    if out == "missing" || out.is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
+pub fn meet_click_leave_js() -> bool {
+    let Some(tab) = find_meet_tab_blocking() else {
+        return false;
+    };
+    run_osascript_blocking(&meet_js_script(&tab.app, MEET_JS_LEAVE))
+        .is_some_and(|s| s == "clicked")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -312,5 +604,18 @@ mod tests {
         assert!(is_browser(Some("Safari"), None));
         assert!(!is_browser(Some("Spotify"), Some("com.spotify.client")));
         assert!(!is_browser(None, None));
+        assert!(is_browser_bundle("com.google.Chrome"));
+        assert!(is_browser_bundle("com.google.Chrome.helper"));
+        assert!(!is_browser_bundle("us.zoom.xos"));
+    }
+
+    #[test]
+    fn meet_urls_require_the_code_path() {
+        assert!(is_meet_url("https://meet.google.com/abc-defg-hij"));
+        assert!(is_meet_url("https://www.meet.google.com/aaa-bbbb-ccc"));
+        assert!(!is_meet_url("https://meet.google.com/landing"));
+        assert!(!is_meet_url("https://meet.google.com/"));
+        assert!(!is_meet_url("https://zoom.us/j/123"));
+        assert!(!is_meet_url("https://evil.example/meet.google.com/abc-defg-hij"));
     }
 }

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod files;
 pub mod haptics;
 #[cfg(target_os = "macos")]
 mod mediaremote;
+pub mod meetings;
 pub mod models;
 pub mod mouse;
 pub mod notch;

--- a/crates/nook-core/src/meetings.rs
+++ b/crates/nook-core/src/meetings.rs
@@ -1,0 +1,1645 @@
+//! Zoom / Teams / Google Meet detection and island controls.
+//!
+//! Honest ceiling: Zoom is full (AX menu mute + leave). Teams is a blind
+//! keystroke toggle after the localhost:8124 API retirement. Meet is
+//! best-effort (focus the tab + Cmd+D/E, or opt-in Apple Events JS).
+//!
+//! Event-driven: NSWorkspace launch/terminate + CoreAudio
+//! `DeviceIsRunningSomewhere` (re-armed on default-input change). No poll at
+//! rest. AX / AppleScript run once on a mic-live transition to confirm a
+//! meeting, and Zoom menu-title readback runs only while the meeting face is
+//! shown.
+
+#[cfg(target_os = "macos")]
+use crate::settings::MeetControlMode;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{OnceLock, RwLock};
+use std::time::Instant;
+
+pub const ZOOM_BUNDLE: &str = "us.zoom.xos";
+pub const TEAMS_BUNDLE: &str = "com.microsoft.teams2";
+pub const TEAMS_CLASSIC_BUNDLE: &str = "com.microsoft.teams";
+
+#[cfg(target_os = "macos")]
+const KEY_D: u16 = 0x02;
+#[cfg(target_os = "macos")]
+const KEY_E: u16 = 0x0E;
+#[cfg(target_os = "macos")]
+const KEY_H: u16 = 0x04;
+#[cfg(target_os = "macos")]
+const KEY_M: u16 = 0x2E;
+#[cfg(target_os = "macos")]
+const KEY_W: u16 = 0x0D;
+#[cfg(target_os = "macos")]
+const FLAG_SHIFT: u64 = 0x0002_0000;
+#[cfg(target_os = "macos")]
+const FLAG_CMD: u64 = 0x0010_0000;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MeetingApp {
+    Zoom,
+    Teams,
+    Meet,
+}
+
+impl MeetingApp {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Zoom => "Zoom",
+            Self::Teams => "Teams",
+            Self::Meet => "Meet",
+        }
+    }
+
+    pub fn bundle_id(self) -> &'static str {
+        match self {
+            Self::Zoom => ZOOM_BUNDLE,
+            Self::Teams => TEAMS_BUNDLE,
+            Self::Meet => "com.google.Chrome",
+        }
+    }
+
+    pub fn icon_name(self) -> &'static str {
+        match self {
+            Self::Zoom => "video",
+            Self::Teams => "users",
+            Self::Meet => "video",
+        }
+    }
+
+    pub fn mute_verified(self) -> bool {
+        matches!(self, Self::Zoom)
+    }
+
+    pub fn from_bundle(id: &str) -> Option<Self> {
+        if id == ZOOM_BUNDLE || id.starts_with("us.zoom.") {
+            return Some(Self::Zoom);
+        }
+        if id == TEAMS_BUNDLE || id == TEAMS_CLASSIC_BUNDLE || id.starts_with("com.microsoft.teams")
+        {
+            return Some(Self::Teams);
+        }
+        if crate::browser_media::is_browser_bundle(id) {
+            return Some(Self::Meet);
+        }
+        None
+    }
+}
+
+/// Idle → AppRunning → MicLive → InMeeting. `muted` is `Some` only when the
+/// host can verify it (Zoom AX title). Teams/Meet stay `None`.
+#[derive(Clone, Debug, PartialEq)]
+pub enum MeetingState {
+    Idle,
+    AppRunning {
+        app: MeetingApp,
+        pid: i32,
+    },
+    MicLive {
+        app: MeetingApp,
+        pid: i32,
+    },
+    InMeeting {
+        app: MeetingApp,
+        pid: i32,
+        muted: Option<bool>,
+        started: Instant,
+    },
+}
+
+impl MeetingState {
+    pub fn app(&self) -> Option<MeetingApp> {
+        match *self {
+            Self::Idle => None,
+            Self::AppRunning { app, .. }
+            | Self::MicLive { app, .. }
+            | Self::InMeeting { app, .. } => Some(app),
+        }
+    }
+
+    pub fn pid(&self) -> Option<i32> {
+        match *self {
+            Self::Idle => None,
+            Self::AppRunning { pid, .. }
+            | Self::MicLive { pid, .. }
+            | Self::InMeeting { pid, .. } => Some(pid),
+        }
+    }
+
+    pub fn in_meeting(&self) -> bool {
+        matches!(self, Self::InMeeting { .. })
+    }
+
+    pub fn muted(&self) -> Option<bool> {
+        match *self {
+            Self::InMeeting { muted, .. } => muted,
+            _ => None,
+        }
+    }
+
+    pub fn started(&self) -> Option<Instant> {
+        match *self {
+            Self::InMeeting { started, .. } => Some(started),
+            _ => None,
+        }
+    }
+}
+
+impl Default for MeetingState {
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MeetingSnapshot {
+    pub state: MeetingState,
+    pub accessibility_trusted: bool,
+}
+
+impl Default for MeetingSnapshot {
+    fn default() -> Self {
+        Self {
+            state: MeetingState::Idle,
+            accessibility_trusted: false,
+        }
+    }
+}
+
+impl MeetingSnapshot {
+    pub fn in_meeting(&self) -> bool {
+        self.state.in_meeting()
+    }
+
+    pub fn app(&self) -> Option<MeetingApp> {
+        self.state.app()
+    }
+
+    pub fn muted(&self) -> Option<bool> {
+        self.state.muted()
+    }
+
+    pub fn mute_verified(&self) -> bool {
+        self.app().is_some_and(MeetingApp::mute_verified) && self.muted().is_some()
+    }
+
+    pub fn elapsed_secs(&self) -> u32 {
+        self.state
+            .started()
+            .map(|t| t.elapsed().as_secs() as u32)
+            .unwrap_or(0)
+    }
+}
+
+/// Inputs the state machine needs. Tests drive this directly; macOS fills it
+/// from NSWorkspace + CoreAudio + one-shot confirmation.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct MeetingSignals {
+    pub running: Vec<(MeetingApp, i32)>,
+    pub mic_live: bool,
+    pub attributed: Option<(MeetingApp, i32)>,
+    /// Zoom: `Some(muted)` when the Meeting menu exists; `None` if it does not.
+    pub zoom_confirmed: Option<bool>,
+    pub meet_tab: bool,
+    pub enabled_zoom: bool,
+    pub enabled_teams: bool,
+    pub enabled_meet: bool,
+}
+
+impl MeetingSignals {
+    fn enabled(&self, app: MeetingApp) -> bool {
+        match app {
+            MeetingApp::Zoom => self.enabled_zoom,
+            MeetingApp::Teams => self.enabled_teams,
+            MeetingApp::Meet => self.enabled_meet,
+        }
+    }
+}
+
+/// Pure transition. Confirmation flags are the only place Zoom/Meet become
+/// `InMeeting`; Teams is app + mic.
+pub fn next_state(prev: &MeetingState, sig: &MeetingSignals, now: Instant) -> MeetingState {
+    let Some((app, pid)) = pick_candidate(sig) else {
+        return MeetingState::Idle;
+    };
+    if !sig.mic_live {
+        return MeetingState::AppRunning { app, pid };
+    }
+    match app {
+        MeetingApp::Teams => keep_started(
+            prev,
+            MeetingState::InMeeting {
+                app,
+                pid,
+                muted: None,
+                started: now,
+            },
+            now,
+        ),
+        MeetingApp::Zoom => match sig.zoom_confirmed {
+            Some(muted) => keep_started(
+                prev,
+                MeetingState::InMeeting {
+                    app,
+                    pid,
+                    muted: Some(muted),
+                    started: now,
+                },
+                now,
+            ),
+            None => MeetingState::MicLive { app, pid },
+        },
+        MeetingApp::Meet => {
+            if sig.meet_tab {
+                keep_started(
+                    prev,
+                    MeetingState::InMeeting {
+                        app,
+                        pid,
+                        muted: None,
+                        started: now,
+                    },
+                    now,
+                )
+            } else {
+                MeetingState::MicLive { app, pid }
+            }
+        }
+    }
+}
+
+fn keep_started(prev: &MeetingState, next: MeetingState, now: Instant) -> MeetingState {
+    match (prev, &next) {
+        (
+            MeetingState::InMeeting {
+                app: pa,
+                pid: pp,
+                started,
+                ..
+            },
+            MeetingState::InMeeting { app, pid, muted, .. },
+        ) if pa == app && pp == pid => MeetingState::InMeeting {
+            app: *app,
+            pid: *pid,
+            muted: *muted,
+            started: *started,
+        },
+        _ => match next {
+            MeetingState::InMeeting {
+                app,
+                pid,
+                muted,
+                started: _,
+            } => MeetingState::InMeeting {
+                app,
+                pid,
+                muted,
+                started: now,
+            },
+            other => other,
+        },
+    }
+}
+
+fn pick_candidate(sig: &MeetingSignals) -> Option<(MeetingApp, i32)> {
+    if let Some((app, pid)) = sig.attributed {
+        if sig.enabled(app) && sig.running.iter().any(|(a, p)| *a == app && *p == pid) {
+            return Some((app, pid));
+        }
+        if sig.enabled(app) {
+            if let Some((_, pid)) = sig.running.iter().copied().find(|(a, _)| *a == app) {
+                return Some((app, pid));
+            }
+        }
+    }
+    let rank = |app: MeetingApp| match app {
+        MeetingApp::Zoom => 0,
+        MeetingApp::Teams => 1,
+        MeetingApp::Meet => 2,
+    };
+    sig.running
+        .iter()
+        .copied()
+        .filter(|(app, _)| sig.enabled(*app))
+        .min_by_key(|(app, _)| rank(*app))
+}
+
+/// Locale-aware Zoom "Meeting" menu titles (plus a few structural aliases).
+pub fn title_is_meeting_menu(title: &str) -> bool {
+    let t = normalize_title(title);
+    matches!(
+        t.as_str(),
+        "meeting"
+            | "reunion"
+            | "réunion"
+            | "reunión"
+            | "besprechung"
+            | "reunião"
+            | "riunione"
+            | "vergadering"
+            | "møde"
+            | "møte"
+            | "mote"
+            | "möte"
+            | "kokous"
+            | "toplantı"
+            | "ミーティング"
+            | "会议"
+            | "會議"
+            | "회의"
+    ) || t.contains("meeting")
+}
+
+/// `Some(true)` = currently muted (menu offers Unmute). Unmute is checked
+/// first because it contains "mute".
+pub fn mute_title_state(title: &str) -> Option<bool> {
+    let t = normalize_title(title);
+    if is_unmute_title(&t) {
+        return Some(true);
+    }
+    if is_mute_title(&t) {
+        return Some(false);
+    }
+    None
+}
+
+pub fn title_is_leave(title: &str) -> bool {
+    let t = normalize_title(title);
+    t.contains("leave")
+        || t.contains("end meeting")
+        || t.contains("end the meeting")
+        || t.contains("verlassen")
+        || t.contains("beenden")
+        || t.contains("quitter")
+        || t.contains("salir")
+        || t.contains("terminar")
+        || t.contains("hang up")
+        || t.contains("hangup")
+        || t == "end"
+        || t.contains("退出")
+        || t.contains("離開")
+        || t.contains("离开")
+        || t.contains("終了")
+}
+
+fn is_unmute_title(t: &str) -> bool {
+    t.contains("unmute")
+        || t.contains("un-mute")
+        || t.contains("réactiver")
+        || t.contains("reactiver")
+        || t.contains("aktivieren")
+        || t.contains("stummschaltung aufheben")
+        || t.contains("activar")
+        || t.contains("ativar")
+        || t.contains("riattiva")
+        || t.contains("hef dempen")
+        || t.contains("slå på")
+        || t.contains("ミュート解除")
+        || t.contains("取消静音")
+        || t.contains("取消靜音")
+        || t.contains("음소거 해제")
+}
+
+fn is_mute_title(t: &str) -> bool {
+    t.contains("mute audio")
+        || t.contains("mute microphone")
+        || t.contains("mute mic")
+        || t == "mute"
+        || t.starts_with("mute ")
+        || t.contains("stummschalten")
+        || t.contains("couper le")
+        || t.contains("silenciar")
+        || t.contains("disattiva")
+        || t.contains("dempen")
+        || t.contains("slå av")
+        || t.contains("ミュート")
+        || t.contains("静音")
+        || t.contains("靜音")
+        || t.contains("음소거")
+}
+
+fn normalize_title(title: &str) -> String {
+    title
+        .trim()
+        .trim_end_matches('…')
+        .trim_end_matches("...")
+        .to_lowercase()
+}
+
+fn store() -> &'static RwLock<MeetingSnapshot> {
+    static STORE: OnceLock<RwLock<MeetingSnapshot>> = OnceLock::new();
+    STORE.get_or_init(|| RwLock::new(MeetingSnapshot::default()))
+}
+
+static EVENT: AtomicBool = AtomicBool::new(false);
+static GEN: AtomicU64 = AtomicU64::new(1);
+
+pub fn snapshot() -> MeetingSnapshot {
+    store()
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .clone()
+}
+
+pub fn take_meeting_event() -> bool {
+    EVENT.swap(false, Ordering::SeqCst)
+}
+
+pub fn note_meeting_event() {
+    EVENT.store(true, Ordering::SeqCst);
+    GEN.fetch_add(1, Ordering::Relaxed);
+}
+
+pub fn meeting_generation() -> u64 {
+    GEN.load(Ordering::Relaxed)
+}
+
+fn publish(next: MeetingSnapshot) {
+    let mut guard = store().write().unwrap_or_else(|e| e.into_inner());
+    if *guard != next {
+        *guard = next;
+        drop(guard);
+        note_meeting_event();
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn settings_enabled() -> (bool, bool, bool, bool) {
+    let s = crate::settings::get_app_settings();
+    (
+        s.show_meetings,
+        s.meetings.zoom,
+        s.meetings.teams,
+        s.meetings.meet,
+    )
+}
+
+/// Arm NSWorkspace + CoreAudio listeners. Cheap no-op off macOS and on a
+/// second call.
+pub fn start() {
+    #[cfg(target_os = "macos")]
+    macos::start();
+}
+
+pub fn accessibility_trusted() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::ax_trusted(false)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+pub fn prompt_accessibility() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        macos::ax_trusted(true)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        false
+    }
+}
+
+/// Re-read hardware + confirm a meeting. Safe to call from a background
+/// worker; the CoreAudio callback only flips atomics.
+pub fn refresh() -> MeetingSnapshot {
+    #[cfg(target_os = "macos")]
+    {
+        macos::refresh()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        snapshot()
+    }
+}
+
+/// Zoom menu-title mute readback. Call only while the meeting face is shown.
+pub fn read_zoom_mute() -> Option<bool> {
+    #[cfg(target_os = "macos")]
+    {
+        macos::read_zoom_mute()
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        None
+    }
+}
+
+pub fn apply_zoom_mute(muted: Option<bool>) {
+    let mut snap = snapshot();
+    if let MeetingState::InMeeting {
+        app: MeetingApp::Zoom,
+        muted: slot,
+        ..
+    } = &mut snap.state
+    {
+        if *slot != muted {
+            *slot = muted;
+            publish(snap);
+        }
+    }
+}
+
+pub fn toggle_mute() {
+    let snap = snapshot();
+    let Some(app) = snap.app() else {
+        return;
+    };
+    let Some(pid) = snap.state.pid() else {
+        return;
+    };
+    #[cfg(target_os = "macos")]
+    macos::toggle_mute(app, pid, snap.accessibility_trusted);
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, pid);
+    }
+}
+
+pub fn leave_meeting() {
+    let snap = snapshot();
+    let Some(app) = snap.app() else {
+        return;
+    };
+    let Some(pid) = snap.state.pid() else {
+        return;
+    };
+    #[cfg(target_os = "macos")]
+    macos::leave_meeting(app, pid, snap.accessibility_trusted);
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (app, pid);
+    }
+}
+
+pub fn post_keys_to_pid(pid: i32, keycode: u16, flags: u64) {
+    #[cfg(target_os = "macos")]
+    macos::post_keys_to_pid(pid, keycode, flags);
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (pid, keycode, flags);
+    }
+}
+
+pub fn open_accessibility_settings() {
+    let _ = std::process::Command::new("/usr/bin/open")
+        .arg("x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+        .spawn();
+}
+
+#[cfg(target_os = "macos")]
+fn meet_mode() -> MeetControlMode {
+    crate::settings::get_app_settings().meetings.meet_mode
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use crate::browser_media;
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use std::ffi::{c_void, CStr};
+    use std::ptr;
+
+    const SYS: u32 = 1;
+    const SCOPE_GLOBAL: u32 = 0x676C_6F62;
+    const ELEMENT_MAIN: u32 = 0;
+    const DEFAULT_INPUT: u32 = 0x6449_6E20;
+    const RUNNING_SOMEWHERE: u32 = 0x676F_6E65;
+    const PROCESS_LIST: u32 = 0x7072_7323;
+    const PROC_PID: u32 = 0x7070_6964;
+    const PROC_BUNDLE: u32 = 0x7062_6964;
+    const PROC_RUNNING_INPUT: u32 = 0x7069_7269;
+
+    #[repr(C)]
+    struct AudioObjectPropertyAddress {
+        selector: u32,
+        scope: u32,
+        element: u32,
+    }
+
+    impl AudioObjectPropertyAddress {
+        fn new(selector: u32) -> Self {
+            Self {
+                selector,
+                scope: SCOPE_GLOBAL,
+                element: ELEMENT_MAIN,
+            }
+        }
+    }
+
+    type AudioObjectID = u32;
+    type OSStatus = i32;
+    type AudioListener = Option<
+        unsafe extern "C" fn(
+            AudioObjectID,
+            u32,
+            *const AudioObjectPropertyAddress,
+            *mut c_void,
+        ) -> OSStatus,
+    >;
+
+    #[link(name = "CoreAudio", kind = "framework")]
+    extern "C" {
+        fn AudioObjectGetPropertyDataSize(
+            object: AudioObjectID,
+            address: *const AudioObjectPropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            size: *mut u32,
+        ) -> OSStatus;
+        fn AudioObjectGetPropertyData(
+            object: AudioObjectID,
+            address: *const AudioObjectPropertyAddress,
+            qualifier_size: u32,
+            qualifier: *const c_void,
+            size: *mut u32,
+            data: *mut c_void,
+        ) -> OSStatus;
+        fn AudioObjectAddPropertyListener(
+            object: AudioObjectID,
+            address: *const AudioObjectPropertyAddress,
+            listener: AudioListener,
+            client: *mut c_void,
+        ) -> OSStatus;
+        fn AudioObjectRemovePropertyListener(
+            object: AudioObjectID,
+            address: *const AudioObjectPropertyAddress,
+            listener: AudioListener,
+            client: *mut c_void,
+        ) -> OSStatus;
+    }
+
+    #[link(name = "ApplicationServices", kind = "framework")]
+    extern "C" {
+        fn AXIsProcessTrustedWithOptions(options: *const c_void) -> bool;
+        fn AXUIElementCreateApplication(pid: i32) -> *mut c_void;
+        fn AXUIElementCopyAttributeValue(
+            element: *mut c_void,
+            attribute: *const c_void,
+            value: *mut *const c_void,
+        ) -> i32;
+        fn AXUIElementPerformAction(element: *mut c_void, action: *const c_void) -> i32;
+        static kAXTrustedCheckOptionPrompt: *const c_void;
+        static kAXMenuBarAttribute: *const c_void;
+        static kAXChildrenAttribute: *const c_void;
+        static kAXTitleAttribute: *const c_void;
+        static kAXRoleAttribute: *const c_void;
+        static kAXWindowsAttribute: *const c_void;
+        static kAXPressAction: *const c_void;
+        static kAXIdentifierAttribute: *const c_void;
+    }
+
+    #[link(name = "CoreFoundation", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: *const c_void);
+        fn CFGetTypeID(cf: *const c_void) -> usize;
+        fn CFStringGetTypeID() -> usize;
+        fn CFArrayGetTypeID() -> usize;
+        fn CFStringGetLength(s: *const c_void) -> isize;
+        fn CFStringGetCString(
+            s: *const c_void,
+            buf: *mut i8,
+            size: isize,
+            encoding: u32,
+        ) -> bool;
+        fn CFArrayGetCount(arr: *const c_void) -> isize;
+        fn CFArrayGetValueAtIndex(arr: *const c_void, idx: isize) -> *const c_void;
+        fn CFDictionaryCreate(
+            allocator: *const c_void,
+            keys: *const *const c_void,
+            values: *const *const c_void,
+            n: isize,
+            key_cb: *const c_void,
+            value_cb: *const c_void,
+        ) -> *const c_void;
+        static kCFBooleanTrue: *const c_void;
+        static kCFTypeDictionaryKeyCallBacks: c_void;
+        static kCFTypeDictionaryValueCallBacks: c_void;
+    }
+
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CGEventCreateKeyboardEvent(
+            source: *mut c_void,
+            virtual_key: u16,
+            key_down: bool,
+        ) -> *mut c_void;
+        fn CGEventSetFlags(event: *mut c_void, flags: u64);
+        fn CGEventPostToPid(pid: i32, event: *mut c_void);
+    }
+
+    const UTF8: u32 = 0x0800_0100;
+    static STARTED: Once = Once::new();
+    static INPUT_DEVICE: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+    static MIC_LIVE: AtomicBool = AtomicBool::new(false);
+
+    unsafe extern "C" fn on_audio(
+        _id: AudioObjectID,
+        _n: u32,
+        _addrs: *const AudioObjectPropertyAddress,
+        _client: *mut c_void,
+    ) -> OSStatus {
+        rearm_input_listener();
+        MIC_LIVE.store(input_running_somewhere(), Ordering::Relaxed);
+        super::note_meeting_event();
+        0
+    }
+
+    pub fn start() {
+        STARTED.call_once(|| {
+            install_workspace_observers();
+            install_audio_listeners();
+            MIC_LIVE.store(input_running_somewhere(), Ordering::Relaxed);
+            super::note_meeting_event();
+        });
+    }
+
+    fn install_audio_listeners() {
+        unsafe {
+            let default_addr = AudioObjectPropertyAddress::new(DEFAULT_INPUT);
+            let _ = AudioObjectAddPropertyListener(SYS, &default_addr, Some(on_audio), ptr::null_mut());
+            let list_addr = AudioObjectPropertyAddress::new(PROCESS_LIST);
+            let _ = AudioObjectAddPropertyListener(SYS, &list_addr, Some(on_audio), ptr::null_mut());
+            rearm_input_listener();
+        }
+    }
+
+    fn rearm_input_listener() {
+        unsafe {
+            let new_id = default_input_device();
+            let old = INPUT_DEVICE.swap(new_id, Ordering::Relaxed);
+            let addr = AudioObjectPropertyAddress::new(RUNNING_SOMEWHERE);
+            if old != 0 && old != new_id {
+                let _ = AudioObjectRemovePropertyListener(
+                    old,
+                    &addr,
+                    Some(on_audio),
+                    ptr::null_mut(),
+                );
+            }
+            if new_id != 0 && new_id != old {
+                let _ = AudioObjectAddPropertyListener(
+                    new_id,
+                    &addr,
+                    Some(on_audio),
+                    ptr::null_mut(),
+                );
+            }
+        }
+    }
+
+    fn default_input_device() -> AudioObjectID {
+        unsafe {
+            let addr = AudioObjectPropertyAddress::new(DEFAULT_INPUT);
+            let mut id: AudioObjectID = 0;
+            let mut size = std::mem::size_of::<AudioObjectID>() as u32;
+            if AudioObjectGetPropertyData(
+                SYS,
+                &addr,
+                0,
+                ptr::null(),
+                &mut size,
+                &mut id as *mut _ as *mut c_void,
+            ) == 0
+            {
+                id
+            } else {
+                0
+            }
+        }
+    }
+
+    fn input_running_somewhere() -> bool {
+        let id = default_input_device();
+        if id == 0 {
+            return false;
+        }
+        unsafe {
+            let addr = AudioObjectPropertyAddress::new(RUNNING_SOMEWHERE);
+            let mut value: u32 = 0;
+            let mut size = std::mem::size_of::<u32>() as u32;
+            if AudioObjectGetPropertyData(
+                id,
+                &addr,
+                0,
+                ptr::null(),
+                &mut size,
+                &mut value as *mut _ as *mut c_void,
+            ) != 0
+            {
+                return false;
+            }
+            value != 0
+        }
+    }
+
+    fn process_object_list() -> Vec<AudioObjectID> {
+        unsafe {
+            let addr = AudioObjectPropertyAddress::new(PROCESS_LIST);
+            let mut size = 0u32;
+            if AudioObjectGetPropertyDataSize(SYS, &addr, 0, ptr::null(), &mut size) != 0
+                || size == 0
+            {
+                return Vec::new();
+            }
+            let count = size as usize / std::mem::size_of::<AudioObjectID>();
+            let mut ids = vec![0u32; count];
+            if AudioObjectGetPropertyData(
+                SYS,
+                &addr,
+                0,
+                ptr::null(),
+                &mut size,
+                ids.as_mut_ptr() as *mut c_void,
+            ) != 0
+            {
+                return Vec::new();
+            }
+            ids.into_iter().filter(|id| *id != 0).collect()
+        }
+    }
+
+    fn process_uint(id: AudioObjectID, selector: u32) -> Option<u32> {
+        unsafe {
+            let addr = AudioObjectPropertyAddress::new(selector);
+            let mut value = 0u32;
+            let mut size = std::mem::size_of::<u32>() as u32;
+            if AudioObjectGetPropertyData(
+                id,
+                &addr,
+                0,
+                ptr::null(),
+                &mut size,
+                &mut value as *mut _ as *mut c_void,
+            ) == 0
+            {
+                Some(value)
+            } else {
+                None
+            }
+        }
+    }
+
+    fn process_pid(id: AudioObjectID) -> Option<i32> {
+        unsafe {
+            let addr = AudioObjectPropertyAddress::new(PROC_PID);
+            let mut value: i32 = 0;
+            let mut size = std::mem::size_of::<i32>() as u32;
+            if AudioObjectGetPropertyData(
+                id,
+                &addr,
+                0,
+                ptr::null(),
+                &mut size,
+                &mut value as *mut _ as *mut c_void,
+            ) == 0
+                && value > 0
+            {
+                Some(value)
+            } else {
+                None
+            }
+        }
+    }
+
+    fn process_bundle(id: AudioObjectID) -> Option<String> {
+        unsafe {
+            let addr = AudioObjectPropertyAddress::new(PROC_BUNDLE);
+            let mut cf: *const c_void = ptr::null();
+            let mut size = std::mem::size_of::<*const c_void>() as u32;
+            if AudioObjectGetPropertyData(
+                id,
+                &addr,
+                0,
+                ptr::null(),
+                &mut size,
+                &mut cf as *mut _ as *mut c_void,
+            ) != 0
+                || cf.is_null()
+            {
+                return None;
+            }
+            let s = cf_string(cf);
+            CFRelease(cf);
+            s.filter(|v| !v.is_empty())
+        }
+    }
+
+    fn attribute_mic() -> Option<(MeetingApp, i32)> {
+        for id in process_object_list() {
+            if process_uint(id, PROC_RUNNING_INPUT).unwrap_or(0) == 0 {
+                continue;
+            }
+            let pid = process_pid(id).unwrap_or(0);
+            if let Some(bundle) = process_bundle(id) {
+                if let Some(app) = MeetingApp::from_bundle(&bundle) {
+                    return Some((app, pid));
+                }
+            }
+        }
+        None
+    }
+
+    fn running_meeting_apps() -> Vec<(MeetingApp, i32)> {
+        objc2::rc::autoreleasepool(|_| unsafe {
+            let ws: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+            if ws.is_null() {
+                return Vec::new();
+            }
+            let apps: *mut AnyObject = msg_send![ws, runningApplications];
+            if apps.is_null() {
+                return Vec::new();
+            }
+            let n: usize = msg_send![apps, count];
+            let mut out = Vec::new();
+            for i in 0..n {
+                let app: *mut AnyObject = msg_send![apps, objectAtIndex: i];
+                if app.is_null() {
+                    continue;
+                }
+                let bundle_ns: *mut AnyObject = msg_send![app, bundleIdentifier];
+                if bundle_ns.is_null() {
+                    continue;
+                }
+                let cstr: *const i8 = msg_send![bundle_ns, UTF8String];
+                if cstr.is_null() {
+                    continue;
+                }
+                let id = CStr::from_ptr(cstr).to_string_lossy();
+                if let Some(kind) = MeetingApp::from_bundle(&id) {
+                    let pid: i32 = msg_send![app, processIdentifier];
+                    if pid > 0 {
+                        out.push((kind, pid));
+                    }
+                }
+            }
+            out
+        })
+    }
+
+    fn install_workspace_observers() {
+        unsafe {
+            let center: *mut AnyObject = {
+                let ws: *mut AnyObject = msg_send![class!(NSWorkspace), sharedWorkspace];
+                if ws.is_null() {
+                    return;
+                }
+                msg_send![ws, notificationCenter]
+            };
+            if center.is_null() {
+                return;
+            }
+            for name in [
+                c"NSWorkspaceDidLaunchApplicationNotification",
+                c"NSWorkspaceDidTerminateApplicationNotification",
+            ] {
+                let ns_name: *mut AnyObject =
+                    msg_send![class!(NSString), stringWithUTF8String: name.as_ptr()];
+                let block = block2::RcBlock::new(move |note: *mut AnyObject| {
+                    if !note.is_null() {
+                        let info: *mut AnyObject = msg_send![note, userInfo];
+                        if !info.is_null() {
+                            let key: *mut AnyObject = msg_send![
+                                class!(NSString),
+                                stringWithUTF8String: c"NSWorkspaceApplicationKey".as_ptr()
+                            ];
+                            let app: *mut AnyObject = msg_send![info, objectForKey: key];
+                            if !app.is_null() {
+                                let bundle_ns: *mut AnyObject = msg_send![app, bundleIdentifier];
+                                if !bundle_ns.is_null() {
+                                    let cstr: *const i8 = msg_send![bundle_ns, UTF8String];
+                                    if !cstr.is_null() {
+                                        let id = CStr::from_ptr(cstr).to_string_lossy();
+                                        if MeetingApp::from_bundle(&id).is_none() {
+                                            return;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    super::note_meeting_event();
+                });
+                let token: *mut AnyObject = msg_send![
+                    center,
+                    addObserverForName: ns_name,
+                    object: ptr::null_mut::<AnyObject>(),
+                    queue: ptr::null_mut::<AnyObject>(),
+                    usingBlock: &*block
+                ];
+                std::mem::forget(block);
+                let _ = token;
+            }
+        }
+    }
+
+    pub fn ax_trusted(prompt: bool) -> bool {
+        unsafe {
+            if !prompt {
+                return AXIsProcessTrustedWithOptions(ptr::null());
+            }
+            let key = kAXTrustedCheckOptionPrompt;
+            let val = kCFBooleanTrue;
+            let dict = CFDictionaryCreate(
+                ptr::null(),
+                &key as *const *const c_void,
+                &val as *const *const c_void,
+                1,
+                &kCFTypeDictionaryKeyCallBacks,
+                &kCFTypeDictionaryValueCallBacks,
+            );
+            let ok = AXIsProcessTrustedWithOptions(dict);
+            if !dict.is_null() {
+                CFRelease(dict);
+            }
+            ok
+        }
+    }
+
+    fn cf_string(cf: *const c_void) -> Option<String> {
+        unsafe {
+            if cf.is_null() || CFGetTypeID(cf) != CFStringGetTypeID() {
+                return None;
+            }
+            let len = CFStringGetLength(cf);
+            if len < 0 || len > 8 * 1024 {
+                return None;
+            }
+            let mut buf = vec![0i8; (len as usize) * 4 + 1];
+            if !CFStringGetCString(cf, buf.as_mut_ptr(), buf.len() as isize, UTF8) {
+                return None;
+            }
+            CStr::from_ptr(buf.as_ptr())
+                .to_str()
+                .ok()
+                .map(|s| s.to_string())
+        }
+    }
+
+    fn ax_attr(el: *mut c_void, attr: *const c_void) -> *const c_void {
+        unsafe {
+            if el.is_null() {
+                return ptr::null();
+            }
+            let mut out: *const c_void = ptr::null();
+            if AXUIElementCopyAttributeValue(el, attr, &mut out) != 0 {
+                return ptr::null();
+            }
+            out
+        }
+    }
+
+    fn ax_title(el: *mut c_void) -> Option<String> {
+        unsafe {
+            let cf = ax_attr(el, kAXTitleAttribute);
+            if cf.is_null() {
+                return None;
+            }
+            let s = cf_string(cf);
+            CFRelease(cf);
+            s
+        }
+    }
+
+    fn ax_role(el: *mut c_void) -> Option<String> {
+        unsafe {
+            let cf = ax_attr(el, kAXRoleAttribute);
+            if cf.is_null() {
+                return None;
+            }
+            let s = cf_string(cf);
+            CFRelease(cf);
+            s
+        }
+    }
+
+    fn ax_identifier(el: *mut c_void) -> Option<String> {
+        unsafe {
+            let cf = ax_attr(el, kAXIdentifierAttribute);
+            if cf.is_null() {
+                return None;
+            }
+            let s = cf_string(cf);
+            CFRelease(cf);
+            s
+        }
+    }
+
+    fn ax_children(el: *mut c_void) -> Vec<*mut c_void> {
+        unsafe {
+            let arr = ax_attr(el, kAXChildrenAttribute);
+            if arr.is_null() {
+                return Vec::new();
+            }
+            let kids = ax_array(arr);
+            CFRelease(arr);
+            kids
+        }
+    }
+
+    fn ax_array(arr: *const c_void) -> Vec<*mut c_void> {
+        unsafe {
+            if arr.is_null() || CFGetTypeID(arr) != CFArrayGetTypeID() {
+                return Vec::new();
+            }
+            let n = CFArrayGetCount(arr);
+            if n < 0 || n > 256 {
+                return Vec::new();
+            }
+            (0..n)
+                .filter_map(|i| {
+                    let v = CFArrayGetValueAtIndex(arr, i);
+                    if v.is_null() {
+                        None
+                    } else {
+                        Some(v as *mut c_void)
+                    }
+                })
+                .collect()
+        }
+    }
+
+    fn ax_press(el: *mut c_void) -> bool {
+        unsafe {
+            if el.is_null() {
+                return false;
+            }
+            AXUIElementPerformAction(el, kAXPressAction) == 0
+        }
+    }
+
+    fn zoom_app(pid: i32) -> *mut c_void {
+        unsafe { AXUIElementCreateApplication(pid) }
+    }
+
+    fn find_meeting_menu(pid: i32) -> Option<*mut c_void> {
+        unsafe {
+            let app = zoom_app(pid);
+            if app.is_null() {
+                return None;
+            }
+            let bar = ax_attr(app, kAXMenuBarAttribute);
+            CFRelease(app);
+            if bar.is_null() {
+                return None;
+            }
+            let menus = ax_children(bar as *mut c_void);
+            CFRelease(bar);
+            for menu_extra in menus {
+                let title = ax_title(menu_extra).unwrap_or_default();
+                let kids = ax_children(menu_extra);
+                let menu = kids.first().copied();
+                if title_is_meeting_menu(&title) {
+                    return menu.or(Some(menu_extra));
+                }
+                if let Some(menu) = menu {
+                    if ax_children(menu)
+                        .iter()
+                        .any(|item| mute_title_state(&ax_title(*item).unwrap_or_default()).is_some())
+                    {
+                        return Some(menu);
+                    }
+                }
+            }
+            None
+        }
+    }
+
+    fn zoom_mute_from_menu(pid: i32) -> Option<bool> {
+        let menu = find_meeting_menu(pid)?;
+        for item in ax_children(menu) {
+            if let Some(state) = mute_title_state(&ax_title(item).unwrap_or_default()) {
+                return Some(state);
+            }
+        }
+        None
+    }
+
+    fn zoom_in_meeting(pid: i32) -> Option<bool> {
+        if find_meeting_menu(pid).is_none() {
+            return None;
+        }
+        Some(zoom_mute_from_menu(pid).unwrap_or(false))
+    }
+
+    fn press_zoom_mute(pid: i32) -> bool {
+        let Some(menu) = find_meeting_menu(pid) else {
+            return false;
+        };
+        for item in ax_children(menu) {
+            if mute_title_state(&ax_title(item).unwrap_or_default()).is_some() {
+                return ax_press(item);
+            }
+        }
+        false
+    }
+
+    fn press_zoom_leave_sheet(pid: i32) -> bool {
+        unsafe {
+            let app = zoom_app(pid);
+            if app.is_null() {
+                return false;
+            }
+            let windows = ax_attr(app, kAXWindowsAttribute);
+            CFRelease(app);
+            if windows.is_null() {
+                return false;
+            }
+            let list = ax_array(windows);
+            CFRelease(windows);
+            for win in list {
+                if press_leave_in(win, 0) {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
+    fn press_leave_in(el: *mut c_void, depth: u8) -> bool {
+        if el.is_null() || depth > 6 {
+            return false;
+        }
+        let title = ax_title(el).unwrap_or_default();
+        let role = ax_role(el).unwrap_or_default();
+        let ident = ax_identifier(el).unwrap_or_default();
+        if (role.contains("Button") || role.contains("button"))
+            && (title_is_leave(&title) || ident.to_ascii_lowercase().contains("leave"))
+        {
+            return ax_press(el);
+        }
+        for child in ax_children(el) {
+            if press_leave_in(child, depth + 1) {
+                return true;
+            }
+        }
+        false
+    }
+
+    pub fn post_keys_to_pid(pid: i32, keycode: u16, flags: u64) {
+        if pid <= 0 {
+            return;
+        }
+        unsafe {
+            for down in [true, false] {
+                let ev = CGEventCreateKeyboardEvent(ptr::null_mut(), keycode, down);
+                if ev.is_null() {
+                    continue;
+                }
+                CGEventSetFlags(ev, flags);
+                CGEventPostToPid(pid, ev);
+                CFRelease(ev);
+            }
+        }
+    }
+
+    pub fn read_zoom_mute() -> Option<bool> {
+        let snap = super::snapshot();
+        match snap.state {
+            MeetingState::InMeeting {
+                app: MeetingApp::Zoom,
+                pid,
+                ..
+            } if snap.accessibility_trusted => zoom_mute_from_menu(pid),
+            _ => None,
+        }
+    }
+
+    pub fn refresh() -> MeetingSnapshot {
+        let (master, zoom_on, teams_on, meet_on) = super::settings_enabled();
+        let trusted = ax_trusted(false);
+        if !master {
+            let snap = MeetingSnapshot {
+                state: MeetingState::Idle,
+                accessibility_trusted: trusted,
+            };
+            super::publish(snap.clone());
+            return snap;
+        }
+        let running = running_meeting_apps();
+        let mic_live = MIC_LIVE.load(Ordering::Relaxed) || input_running_somewhere();
+        MIC_LIVE.store(mic_live, Ordering::Relaxed);
+        let attributed = if mic_live { attribute_mic() } else { None };
+        let mut sig = MeetingSignals {
+            running,
+            mic_live,
+            attributed,
+            zoom_confirmed: None,
+            meet_tab: false,
+            enabled_zoom: zoom_on,
+            enabled_teams: teams_on,
+            enabled_meet: meet_on,
+        };
+        if let Some((app, pid)) = pick_candidate(&sig) {
+            if mic_live {
+                match app {
+                    MeetingApp::Zoom if trusted => {
+                        sig.zoom_confirmed = zoom_in_meeting(pid);
+                    }
+                    MeetingApp::Meet => {
+                        sig.meet_tab = browser_media::find_meet_tab_blocking().is_some();
+                    }
+                    _ => {}
+                }
+            }
+        }
+        let prev = super::snapshot();
+        let state = next_state(&prev.state, &sig, Instant::now());
+        let snap = MeetingSnapshot {
+            state,
+            accessibility_trusted: trusted,
+        };
+        super::publish(snap.clone());
+        snap
+    }
+
+    pub fn toggle_mute(app: MeetingApp, pid: i32, trusted: bool) {
+        match app {
+            MeetingApp::Zoom => {
+                if trusted && press_zoom_mute(pid) {
+                    return;
+                }
+                zoom_osascript_mute();
+            }
+            MeetingApp::Teams => {
+                if trusted {
+                    post_keys_to_pid(pid, KEY_M, FLAG_CMD | FLAG_SHIFT);
+                }
+            }
+            MeetingApp::Meet => match super::meet_mode() {
+                MeetControlMode::AppleEventsJs => {
+                    if browser_media::meet_click_mute_js().is_none() {
+                        meet_focus_hotkey(pid, trusted, KEY_D);
+                    }
+                }
+                MeetControlMode::FocusTab => meet_focus_hotkey(pid, trusted, KEY_D),
+            },
+        }
+        super::note_meeting_event();
+    }
+
+    pub fn leave_meeting(app: MeetingApp, pid: i32, trusted: bool) {
+        match app {
+            MeetingApp::Zoom => {
+                if trusted {
+                    post_keys_to_pid(pid, KEY_W, FLAG_CMD);
+                    std::thread::sleep(std::time::Duration::from_millis(280));
+                    let _ = press_zoom_leave_sheet(pid);
+                } else {
+                    zoom_osascript_leave();
+                }
+            }
+            MeetingApp::Teams => {
+                if trusted {
+                    post_keys_to_pid(pid, KEY_H, FLAG_CMD | FLAG_SHIFT);
+                }
+            }
+            MeetingApp::Meet => match super::meet_mode() {
+                MeetControlMode::AppleEventsJs => {
+                    if !browser_media::meet_click_leave_js() {
+                        meet_focus_hotkey(pid, trusted, KEY_E);
+                    }
+                }
+                MeetControlMode::FocusTab => meet_focus_hotkey(pid, trusted, KEY_E),
+            },
+        }
+        super::note_meeting_event();
+    }
+
+    fn meet_focus_hotkey(pid: i32, trusted: bool, key: u16) {
+        let _ = browser_media::activate_meet_tab_blocking();
+        if trusted {
+            std::thread::sleep(std::time::Duration::from_millis(120));
+            post_keys_to_pid(pid, key, FLAG_CMD);
+        } else {
+            let letter = if key == KEY_D { "d" } else { "e" };
+            system_events_keystroke(letter, true, false);
+        }
+    }
+
+    fn zoom_osascript_mute() {
+        let script = r#"tell application "System Events"
+  tell process "zoom.us"
+    try
+      click menu item 1 of menu "Meeting" of menu bar 1
+    end try
+  end tell
+end tell"#;
+        let _ = browser_media::run_osascript_blocking(script);
+    }
+
+    fn zoom_osascript_leave() {
+        let script = r#"tell application "System Events"
+  tell process "zoom.us"
+    keystroke "w" using command down
+  end tell
+end tell"#;
+        let _ = browser_media::run_osascript_blocking(script);
+    }
+
+    fn system_events_keystroke(key: &str, cmd: bool, shift: bool) {
+        let mods = match (cmd, shift) {
+            (true, true) => "command down, shift down",
+            (true, false) => "command down",
+            (false, true) => "shift down",
+            (false, false) => "",
+        };
+        let using = if mods.is_empty() {
+            String::new()
+        } else {
+            format!(" using {mods}")
+        };
+        let script = format!(
+            r#"tell application "System Events" to keystroke "{key}"{using}"#
+        );
+        let _ = browser_media::run_osascript_blocking(&script);
+    }
+
+    #[allow(dead_code)]
+    static _KEEP_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn sig(running: MeetingApp, pid: i32) -> MeetingSignals {
+        MeetingSignals {
+            running: vec![(running, pid)],
+            mic_live: false,
+            attributed: None,
+            zoom_confirmed: None,
+            meet_tab: false,
+            enabled_zoom: true,
+            enabled_teams: true,
+            enabled_meet: true,
+        }
+    }
+
+    #[test]
+    fn idle_without_apps() {
+        let now = Instant::now();
+        assert_eq!(
+            next_state(&MeetingState::Idle, &MeetingSignals::default(), now),
+            MeetingState::Idle
+        );
+    }
+
+    #[test]
+    fn app_running_then_mic_then_zoom_confirm() {
+        let now = Instant::now();
+        let mut s = sig(MeetingApp::Zoom, 9);
+        let running = next_state(&MeetingState::Idle, &s, now);
+        assert_eq!(
+            running,
+            MeetingState::AppRunning {
+                app: MeetingApp::Zoom,
+                pid: 9
+            }
+        );
+        s.mic_live = true;
+        s.attributed = Some((MeetingApp::Zoom, 9));
+        let live = next_state(&running, &s, now);
+        assert_eq!(
+            live,
+            MeetingState::MicLive {
+                app: MeetingApp::Zoom,
+                pid: 9
+            }
+        );
+        s.zoom_confirmed = Some(true);
+        let meet = next_state(&live, &s, now + Duration::from_secs(2));
+        assert!(matches!(
+            meet,
+            MeetingState::InMeeting {
+                app: MeetingApp::Zoom,
+                muted: Some(true),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn teams_is_app_plus_mic_unverified() {
+        let now = Instant::now();
+        let mut s = sig(MeetingApp::Teams, 4);
+        s.mic_live = true;
+        s.attributed = Some((MeetingApp::Teams, 4));
+        let state = next_state(&MeetingState::Idle, &s, now);
+        assert!(matches!(
+            state,
+            MeetingState::InMeeting {
+                app: MeetingApp::Teams,
+                muted: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn meet_needs_tab_url() {
+        let now = Instant::now();
+        let mut s = sig(MeetingApp::Meet, 11);
+        s.mic_live = true;
+        s.attributed = Some((MeetingApp::Meet, 11));
+        assert!(matches!(
+            next_state(&MeetingState::Idle, &s, now),
+            MeetingState::MicLive {
+                app: MeetingApp::Meet,
+                ..
+            }
+        ));
+        s.meet_tab = true;
+        assert!(matches!(
+            next_state(&MeetingState::Idle, &s, now),
+            MeetingState::InMeeting {
+                app: MeetingApp::Meet,
+                muted: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn disabled_app_is_ignored() {
+        let now = Instant::now();
+        let mut s = sig(MeetingApp::Zoom, 1);
+        s.enabled_zoom = false;
+        s.mic_live = true;
+        assert_eq!(next_state(&MeetingState::Idle, &s, now), MeetingState::Idle);
+    }
+
+    #[test]
+    fn zoom_keeps_elapsed_across_mute_flips() {
+        let t0 = Instant::now();
+        let mut s = sig(MeetingApp::Zoom, 3);
+        s.mic_live = true;
+        s.zoom_confirmed = Some(false);
+        let first = next_state(&MeetingState::Idle, &s, t0);
+        s.zoom_confirmed = Some(true);
+        let second = next_state(&first, &s, t0 + Duration::from_secs(40));
+        match (first, second) {
+            (
+                MeetingState::InMeeting { started: a, .. },
+                MeetingState::InMeeting {
+                    started: b,
+                    muted: Some(true),
+                    ..
+                },
+            ) => assert_eq!(a, b),
+            other => panic!("{other:?}"),
+        }
+    }
+
+    #[test]
+    fn mute_titles_prefer_unmute() {
+        assert_eq!(mute_title_state("Unmute audio"), Some(true));
+        assert_eq!(mute_title_state("Mute audio"), Some(false));
+        assert_eq!(mute_title_state("Stummschaltung aufheben"), Some(true));
+        assert_eq!(mute_title_state("Couper le micro"), Some(false));
+        assert_eq!(mute_title_state("ミュート解除"), Some(true));
+        assert_eq!(mute_title_state("View"), None);
+    }
+
+    #[test]
+    fn meeting_menu_locales() {
+        assert!(title_is_meeting_menu("Meeting"));
+        assert!(title_is_meeting_menu("Réunion"));
+        assert!(title_is_meeting_menu("ミーティング"));
+        assert!(!title_is_meeting_menu("View"));
+        assert!(title_is_leave("Leave Meeting"));
+        assert!(title_is_leave("End"));
+        assert!(!title_is_leave("Cancel"));
+    }
+
+    #[test]
+    fn bundle_ids_map() {
+        assert_eq!(MeetingApp::from_bundle(ZOOM_BUNDLE), Some(MeetingApp::Zoom));
+        assert_eq!(
+            MeetingApp::from_bundle(TEAMS_BUNDLE),
+            Some(MeetingApp::Teams)
+        );
+        assert_eq!(
+            MeetingApp::from_bundle("com.google.Chrome"),
+            Some(MeetingApp::Meet)
+        );
+        assert_eq!(
+            MeetingApp::from_bundle("com.google.Chrome.helper"),
+            Some(MeetingApp::Meet)
+        );
+        assert_eq!(MeetingApp::from_bundle("com.spotify.client"), None);
+    }
+
+    #[test]
+    fn snapshot_defaults_idle() {
+        let snap = MeetingSnapshot::default();
+        assert!(!snap.in_meeting());
+        assert!(!snap.mute_verified());
+        assert_eq!(snap.elapsed_secs(), 0);
+    }
+}

--- a/crates/nook-core/src/meetings.rs
+++ b/crates/nook-core/src/meetings.rs
@@ -14,6 +14,8 @@
 use crate::settings::MeetControlMode;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{OnceLock, RwLock};
+#[cfg(target_os = "macos")]
+use std::sync::{Mutex, Once};
 use std::time::Instant;
 
 pub const ZOOM_BUNDLE: &str = "us.zoom.xos";

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -17,10 +17,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    Meeting = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +32,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::Meeting,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -45,7 +47,7 @@ impl WidgetModule {
         match self {
             Self::Calendar | Self::Music => 5,
             Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
-            Self::Timers | Self::Speed | Self::Mirror => 3,
+            Self::Timers | Self::Speed | Self::Mirror | Self::Meeting => 3,
         }
     }
 
@@ -53,13 +55,13 @@ impl WidgetModule {
         match self {
             Self::Calendar => 4,
             Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
-            Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
+            Self::Notes | Self::Timers | Self::Speed | Self::Agents | Self::Meeting => 2,
         }
     }
 
     pub fn max_cells(self) -> u8 {
         match self {
-            Self::Timers | Self::Speed | Self::Agents | Self::Mirror => 6,
+            Self::Timers | Self::Speed | Self::Agents | Self::Mirror | Self::Meeting => 6,
             _ => 8,
         }
     }
@@ -77,6 +79,7 @@ fn default_widget_order() -> Vec<WidgetModule> {
         WidgetModule::Mirror,
         WidgetModule::Files,
         WidgetModule::Agents,
+        WidgetModule::Meeting,
         WidgetModule::Observe,
         WidgetModule::Reminders,
         WidgetModule::Timers,
@@ -142,6 +145,10 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default = "default_true")]
+    pub show_meetings: bool,
+    #[serde(default)]
+    pub meetings: MeetingsConfig,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -213,6 +220,55 @@ pub const ISLAND_SWATCHES: [IslandSwatch; 7] = [
     },
 ];
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum MeetControlMode {
+    /// Activate the Meet tab then send Cmd+D / Cmd+E (focus-stealing).
+    #[default]
+    FocusTab,
+    /// Chrome/Safari `execute javascript` — needs "Allow JavaScript from Apple Events".
+    AppleEventsJs,
+}
+
+impl MeetControlMode {
+    pub fn caption(self) -> &'static str {
+        match self {
+            Self::FocusTab => "Focus tab",
+            Self::AppleEventsJs => "Apple Events JS",
+        }
+    }
+
+    pub fn cycle(self) -> Self {
+        match self {
+            Self::FocusTab => Self::AppleEventsJs,
+            Self::AppleEventsJs => Self::FocusTab,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct MeetingsConfig {
+    #[serde(default = "default_true")]
+    pub zoom: bool,
+    #[serde(default = "default_true")]
+    pub teams: bool,
+    #[serde(default = "default_true")]
+    pub meet: bool,
+    #[serde(default)]
+    pub meet_mode: MeetControlMode,
+}
+
+impl Default for MeetingsConfig {
+    fn default() -> Self {
+        Self {
+            zoom: true,
+            teams: true,
+            meet: true,
+            meet_mode: MeetControlMode::FocusTab,
+        }
+    }
+}
+
 fn default_true() -> bool {
     true
 }
@@ -231,6 +287,8 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            show_meetings: true,
+            meetings: MeetingsConfig::default(),
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +334,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::Meeting => self.show_meetings,
         }
     }
 
@@ -291,6 +350,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::Meeting => self.show_meetings = !self.show_meetings,
         }
     }
 
@@ -611,6 +671,11 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.show_meetings);
+        assert!(parsed.meetings.zoom);
+        assert!(parsed.meetings.teams);
+        assert!(parsed.meetings.meet);
+        assert_eq!(parsed.meetings.meet_mode, MeetControlMode::FocusTab);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +761,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.show_meetings = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook/src/assets/icons/mic-off.svg
+++ b/crates/nook/src/assets/icons/mic-off.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 19v3"/>
+<path d="M15 9.34V5a3 3 0 0 0-5.68-1.33"/>
+<path d="M16.95 16.95A7 7 0 0 1 5 12v-2"/>
+<path d="M18.89 13.23A7 7 0 0 0 19 12v-2"/>
+<path d="m2 2 20 20"/>
+<path d="M9 9v3a3 3 0 0 0 5.12 2.12"/>
+<path d="M9 5a3 3 0 0 1 6 0v5"/>
+</svg>

--- a/crates/nook/src/assets/icons/mic.svg
+++ b/crates/nook/src/assets/icons/mic.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M12 19v3"/>
+<path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+<rect x="9" y="2" width="6" height="13" rx="3"/>
+</svg>

--- a/crates/nook/src/assets/icons/phone-off.svg
+++ b/crates/nook/src/assets/icons/phone-off.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M10.1 13.9a14 14 0 0 0 3.9 3.9"/>
+<path d="m22 2-8.4 8.4"/>
+<path d="M16.5 16.5a15 15 0 0 1-11.2 4.3A2 2 0 0 1 3 18.6l1.4-3.2a2 2 0 0 1 1.8-1.2h.4a13 13 0 0 0 2.1.3"/>
+<path d="M8.5 8.5a13 13 0 0 1 .3-2.1v-.4A2 2 0 0 1 10 4.2L13.2 2.8A2 2 0 0 1 15.4 3a15 15 0 0 1 4.3 11.2"/>
+<path d="m2 2 20 20"/>
+</svg>

--- a/crates/nook/src/assets/icons/users.svg
+++ b/crates/nook/src/assets/icons/users.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"/>
+<path d="M16 3.128a4 4 0 0 1 0 7.744"/>
+<path d="M22 21v-2a4 4 0 0 0-3-3.87"/>
+<circle cx="9" cy="7" r="4"/>
+</svg>

--- a/crates/nook/src/assets/icons/video.svg
+++ b/crates/nook/src/assets/icons/video.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+<path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5"/>
+<rect x="2" y="6" width="14" height="12" rx="2"/>
+</svg>

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -63,6 +63,7 @@ impl Island {
             CompactMode::Observe => {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
+            CompactMode::Meeting => widgets::meeting_compact_left(&self.meeting),
             CompactMode::Onboard => label("openNook", theme::BODY, true).into_any_element(),
             CompactMode::Idle => div().into_any_element(),
         }
@@ -104,6 +105,9 @@ impl Island {
                     _ => self.observe.firing_count().to_string(),
                 };
                 label(text, theme::BODY, true).into_any_element()
+            }
+            CompactMode::Meeting => {
+                widgets::meeting_compact_right(&self.meeting, self.overlay_fade.value)
             }
             CompactMode::Onboard if hovered => div()
                 .id("github")
@@ -147,6 +151,7 @@ impl Island {
                 CompactMode::Files => "files",
                 CompactMode::Timer => "timer",
                 CompactMode::Observe => "observe",
+                CompactMode::Meeting => "meeting",
                 CompactMode::Onboard => "onboard",
             };
             row = row.child(

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, calendar_card, meeting_card, notes_card, observe_card, reminders_card, speed_card,
+    timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -118,6 +119,13 @@ impl Island {
                     cell_pane(
                         self.settings.cells_for(module),
                         agents_card(&self.agents, self.pixel_t, cx),
+                    ),
+                ),
+                WidgetModule::Meeting if self.settings.show_meetings => add(
+                    &mut kids,
+                    cell_pane(
+                        self.settings.cells_for(module),
+                        meeting_card(&self.meeting, cx),
                     ),
                 ),
                 WidgetModule::Observe if self.settings.show_observe => add(

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -25,6 +25,7 @@ use nook_core::calendar::{CalendarEvent, Reminder};
 use nook_core::files::FileTrayItem;
 use nook_core::models::NowPlayingData;
 use nook_core::notch;
+use nook_core::meetings::MeetingSnapshot;
 use nook_core::observe::{MetricHistory, ObserveSnapshot};
 use nook_core::settings::AppSettings;
 use settings::SettingsView;
@@ -38,6 +39,7 @@ pub enum CompactMode {
     Files,
     Timer,
     Observe,
+    Meeting,
     Onboard,
 }
 
@@ -86,6 +88,7 @@ pub struct Island {
     pub observe: ObserveSnapshot,
     observe_history: MetricHistory,
     pub(crate) observe_hover: Option<crate::widgets::ObserveHover>,
+    pub meeting: MeetingSnapshot,
     pub settings: AppSettings,
     pub first_run: bool,
     pub speed_mbps: Option<f64>,
@@ -121,6 +124,8 @@ pub struct Island {
     content_y: SpringValue,
     /// Play/pause scrim over the compact album art, 0..1 on `motion::REVEAL`.
     overlay_fade: SpringValue,
+    /// Mute HUD flash on the meeting face; overlay springs to 1 while this is live.
+    meeting_flash_until: Option<Instant>,
     /// Mirrors Accessibility › Display › "Reduce motion"; refreshed by the
     /// poll loop so springs collapse to a dissolve while it is on.
     reduce_motion: bool,
@@ -213,6 +218,7 @@ impl Island {
             observe: ObserveSnapshot::default(),
             observe_history: nook_core::observe::load_history(),
             observe_hover: None,
+            meeting: MeetingSnapshot::default(),
             settings,
             first_run,
             speed_mbps: None,
@@ -233,6 +239,7 @@ impl Island {
             content_x: SpringValue::at(0.0),
             content_y: SpringValue::at(0.0),
             overlay_fade: SpringValue::at(0.0),
+            meeting_flash_until: None,
             reduce_motion: platform::reduce_motion(),
             blur: 0.0,
             last_expanded: false,
@@ -263,6 +270,7 @@ impl Island {
         this.anim_h.set(h);
 
         platform::install_media_observers();
+        platform::install_meeting_observers();
         nook_core::runtime().spawn(async {
             let _ = nook_core::calendar::request_calendar_access().await;
         });
@@ -690,6 +698,63 @@ impl Island {
                 .await;
         })
         .detach();
+
+        // Meetings: wait on hardware events. The only timed work is a 1–2s
+        // Zoom menu-title readback, and only while the meeting face is shown.
+        cx.spawn(async move |this, cx| loop {
+            let face = this
+                .update(cx, |this, _| this.meeting_face_shown())
+                .unwrap_or(false);
+            let cadence = if face {
+                Duration::from_millis(1500)
+            } else {
+                Duration::from_secs(30)
+            };
+            let slice = Duration::from_millis(250);
+            let mut waited = Duration::ZERO;
+            loop {
+                cx.background_executor().timer(slice).await;
+                waited += slice;
+                if nook_core::meetings::take_meeting_event() || waited >= cadence {
+                    break;
+                }
+            }
+            let zoom_readback = this
+                .update(cx, |this, _| {
+                    this.meeting_face_shown()
+                        && this.meeting.app() == Some(nook_core::meetings::MeetingApp::Zoom)
+                })
+                .unwrap_or(false);
+            let snap = cx
+                .background_executor()
+                .spawn(async move {
+                    if zoom_readback {
+                        if let Some(muted) = nook_core::meetings::read_zoom_mute() {
+                            nook_core::meetings::apply_zoom_mute(Some(muted));
+                        }
+                    }
+                    nook_core::meetings::refresh()
+                })
+                .await;
+            if this
+                .update(cx, |this, cx| {
+                    let was = this.meeting.in_meeting();
+                    let changed = this.meeting != snap;
+                    this.meeting = snap;
+                    if !was && this.meeting.in_meeting() {
+                        this.preferred = Some(CompactMode::Meeting);
+                        nook_core::haptics::trigger(None);
+                    }
+                    if changed {
+                        cx.notify();
+                    }
+                })
+                .is_err()
+            {
+                break;
+            }
+        })
+        .detach();
     }
 
     /// Merge a fresh poll into the island: extend the local sample history and
@@ -860,8 +925,64 @@ impl Island {
         self.settings.show_observe && self.observe.has_outage()
     }
 
+    fn has_meeting(&self) -> bool {
+        self.settings.show_meetings && self.meeting.in_meeting()
+    }
+
+    fn meeting_face_shown(&self) -> bool {
+        self.has_meeting()
+            && (self.mode() == CompactMode::Meeting
+                || (self.expanded && self.settings.show_meetings))
+    }
+
+    pub(crate) fn flash_meeting_mute(&mut self) {
+        self.overlay_fade.set(1.0);
+        self.meeting_flash_until = Some(Instant::now() + Duration::from_millis(450));
+    }
+
+    pub(crate) fn toggle_meeting_mute(&mut self, cx: &mut Context<Self>) {
+        nook_core::meetings::toggle_mute();
+        self.flash_meeting_mute();
+        nook_core::haptics::trigger(None);
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            let snap = cx
+                .background_executor()
+                .spawn(async { nook_core::meetings::refresh() })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.meeting = snap;
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
+    pub(crate) fn leave_meeting(&mut self, cx: &mut Context<Self>) {
+        nook_core::meetings::leave_meeting();
+        nook_core::haptics::trigger(None);
+        cx.notify();
+        cx.spawn(async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(400))
+                .await;
+            let snap = cx
+                .background_executor()
+                .spawn(async { nook_core::meetings::refresh() })
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.meeting = snap;
+                cx.notify();
+            });
+        })
+        .detach();
+    }
+
     fn available_modes(&self) -> Vec<CompactMode> {
         let mut modes = Vec::new();
+        if self.has_meeting() {
+            modes.push(CompactMode::Meeting);
+        }
         if self.has_observe_outage() {
             modes.push(CompactMode::Observe);
         }
@@ -1015,7 +1136,19 @@ impl Island {
         moving |= self
             .content_fade
             .step(motion::CROSSFADE, 1.0, dt, motion::REST_ALPHA);
-        let overlay = media::album_overlay_target(self.hovered);
+        let overlay = if self.mode() == CompactMode::Meeting {
+            if self
+                .meeting_flash_until
+                .is_some_and(|until| Instant::now() < until)
+            {
+                1.0
+            } else {
+                self.meeting_flash_until = None;
+                0.0
+            }
+        } else {
+            media::album_overlay_target(self.hovered)
+        };
         moving |= self
             .overlay_fade
             .step(motion::REVEAL, overlay, dt, motion::REST_ALPHA);
@@ -1452,6 +1585,7 @@ mod tests {
             observe: ObserveSnapshot::default(),
             observe_history: HashMap::new(),
             observe_hover: None,
+            meeting: MeetingSnapshot::default(),
             settings: AppSettings::default(),
             first_run: false,
             speed_mbps: None,
@@ -1472,6 +1606,7 @@ mod tests {
             content_x: SpringValue::at(0.0),
             content_y: SpringValue::at(0.0),
             overlay_fade: SpringValue::at(0.0),
+            meeting_flash_until: None,
             reduce_motion: false,
             blur: 0.0,
             last_expanded: false,
@@ -1739,6 +1874,25 @@ mod tests {
         );
         assert_eq!(island.mode(), CompactMode::Agents);
         island.settings.show_agents = false;
+        assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn available_modes_includes_meeting() {
+        use nook_core::meetings::{MeetingApp, MeetingState};
+        let mut island = test_island();
+        island.meeting.state = MeetingState::InMeeting {
+            app: MeetingApp::Zoom,
+            pid: 7,
+            muted: Some(false),
+            started: Instant::now(),
+        };
+        assert_eq!(
+            island.available_modes(),
+            vec![CompactMode::Meeting, CompactMode::Idle]
+        );
+        assert_eq!(island.mode(), CompactMode::Meeting);
+        island.settings.show_meetings = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
     }
 

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -131,6 +131,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Meeting => "Meetings",
         }
     }
 
@@ -146,6 +147,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::Meeting => "video",
         }
     }
 
@@ -161,6 +163,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::Meeting => "Zoom / Teams / Meet".into(),
         }
     }
 
@@ -184,6 +187,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Meeting => "Meetings",
         }
     }
 }
@@ -998,6 +1002,54 @@ impl SettingsView {
                     .into_any_element(),
                 );
             }
+            WidgetModule::Meeting => {
+                rows.push(
+                    toggle_row("Zoom", settings.meetings.zoom, cx, |s| {
+                        s.meetings.zoom = !s.meetings.zoom;
+                    })
+                    .into_any_element(),
+                );
+                rows.push(
+                    toggle_row("Microsoft Teams", settings.meetings.teams, cx, |s| {
+                        s.meetings.teams = !s.meetings.teams;
+                    })
+                    .into_any_element(),
+                );
+                rows.push(
+                    toggle_row("Google Meet", settings.meetings.meet, cx, |s| {
+                        s.meetings.meet = !s.meetings.meet;
+                    })
+                    .into_any_element(),
+                );
+                rows.push(
+                    action_row(
+                        "meet-mode",
+                        "Meet control",
+                        settings.meetings.meet_mode.caption(),
+                        cx,
+                        |_, _, _| {
+                            nook_core::settings::tweak_app_settings(|s| {
+                                s.meetings.meet_mode = s.meetings.meet_mode.cycle();
+                            });
+                        },
+                    )
+                    .into_any_element(),
+                );
+                let trusted = crate::platform::ax_is_process_trusted();
+                rows.push(
+                    action_row(
+                        "ax-status",
+                        "Accessibility",
+                        if trusted { "Granted" } else { "Denied" },
+                        cx,
+                        |_, _, _| {
+                            crate::platform::ax_prompt_accessibility();
+                            crate::platform::open_accessibility_settings();
+                        },
+                    )
+                    .into_any_element(),
+                );
+            }
             _ => {}
         }
 
@@ -1356,6 +1408,9 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::Meeting => {
+            "Mute and leave from the island. Zoom reads mute from the Meeting menu. Teams is a blind shortcut (the localhost API is gone). Meet focuses the tab unless you enable Apple Events JS.".into()
+        }
     }
 }
 
@@ -1727,6 +1782,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "Meetings",
             ]
         );
         assert!(!names

--- a/crates/nook/src/platform.rs
+++ b/crates/nook/src/platform.rs
@@ -1132,6 +1132,8 @@ fn known_bundle_id(app_name: &str) -> Option<&'static str> {
         "VLC" => "org.videolan.vlc",
         "TIDAL" => "com.tidal.desktop",
         "Arc" => "company.thebrowser.Browser",
+        "zoom.us" | "Zoom" => "us.zoom.xos",
+        "Microsoft Teams" | "Teams" => "com.microsoft.teams2",
         _ => return None,
     })
 }
@@ -1395,6 +1397,31 @@ pub fn reduce_motion() -> bool {
 /// battery cost that matters. Safari/YouTube posts nothing and rides the slow
 /// poll. Blocks only flip an atomic, so the posting thread is fine. Observer
 /// tokens are intentionally leaked — they live for the process.
+/// Accessibility (kTCCServiceAccessibility). Required for AX menu clicks and
+/// `CGEventPostToPid`. Off-macOS this is always false.
+pub fn ax_is_process_trusted() -> bool {
+    nook_core::meetings::accessibility_trusted()
+}
+
+/// Prompt via `AXIsProcessTrustedWithOptions` + `kAXTrustedCheckOptionPrompt`.
+pub fn ax_prompt_accessibility() -> bool {
+    nook_core::meetings::prompt_accessibility()
+}
+
+/// Focus-free keystrokes to another process. Needs Accessibility.
+pub fn post_keys_to_pid(pid: i32, keycode: u16, flags: u64) {
+    nook_core::meetings::post_keys_to_pid(pid, keycode, flags);
+}
+
+pub fn open_accessibility_settings() {
+    nook_core::meetings::open_accessibility_settings();
+}
+
+/// NSWorkspace launch/terminate + CoreAudio mic listeners for WP19.
+pub fn install_meeting_observers() {
+    nook_core::meetings::start();
+}
+
 pub fn install_media_observers() {
     #[cfg(target_os = "macos")]
     unsafe {

--- a/crates/nook/src/theme.rs
+++ b/crates/nook/src/theme.rs
@@ -122,6 +122,13 @@ pub const DESTRUCTIVE: Rgba = Rgba {
     b: 0.227,
     a: 1.0,
 };
+/// systemOrange — muted meeting (Zoom verified).
+pub const WARNING: Rgba = Rgba {
+    r: 1.0,
+    g: 0.624,
+    b: 0.039,
+    a: 1.0,
+};
 #[allow(dead_code)]
 pub const SUCCESS: Rgba = Rgba {
     r: 0.188,

--- a/crates/nook/src/widgets/meeting.rs
+++ b/crates/nook/src/widgets/meeting.rs
@@ -1,0 +1,188 @@
+//! Meeting card: mute + leave for Zoom / Teams / Google Meet.
+
+use crate::icons::lucide_color;
+use crate::island::ui::{label, nook_display, nook_empty, nook_pane};
+use crate::island::Island;
+use crate::theme;
+use gpui::{
+    div, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
+    MouseDownEvent, Rgba,
+};
+use nook_core::meetings::{MeetingApp, MeetingSnapshot};
+
+pub(crate) fn compact_left(snap: &MeetingSnapshot) -> AnyElement {
+    lucide_color(
+        snap.app().map(MeetingApp::icon_name).unwrap_or("video"),
+        theme::COMPACT_FACE,
+        theme::LABEL,
+    )
+    .into_any_element()
+}
+
+pub(crate) fn compact_right(snap: &MeetingSnapshot, flash: f32) -> AnyElement {
+    let (icon, color) = mic_face(snap);
+    let flash = flash.clamp(0.0, 1.0);
+    div()
+        .flex()
+        .items_center()
+        .justify_center()
+        .size(px(theme::COMPACT_FACE))
+        .rounded_full()
+        .bg(rgba(0xffffff00 | ((flash * 72.0) as u32).min(72)))
+        .child(lucide_color(icon, 16.0, color))
+        .into_any_element()
+}
+
+pub(crate) fn meeting_card(snap: &MeetingSnapshot, cx: &mut Context<Island>) -> impl IntoElement {
+    let Some(app) = snap.app().filter(|_| snap.in_meeting()) else {
+        return nook_pane("nook-meeting")
+            .w_full()
+            .child(nook_empty("video", "No meeting"))
+            .into_any_element();
+    };
+    let elapsed = format_elapsed(snap.elapsed_secs());
+    let verified = snap.mute_verified();
+    let muted = snap.muted();
+    let (mic_icon, mic_color) = mic_face(snap);
+    let mute_caption = match muted {
+        Some(true) => "Unmute",
+        Some(false) => "Mute",
+        None => "Mute",
+    };
+    let state_line = if verified {
+        if muted == Some(true) {
+            "Muted"
+        } else {
+            "Live"
+        }
+    } else {
+        "Unverified state"
+    };
+
+    nook_pane("nook-meeting")
+        .w_full()
+        .child(
+            div()
+                .flex()
+                .items_end()
+                .justify_between()
+                .gap(px(10.))
+                .child(nook_display(elapsed))
+                .child(
+                    div()
+                        .pb(px(4.))
+                        .flex()
+                        .items_center()
+                        .gap(px(6.))
+                        .child(lucide_color(app.icon_name(), 14.0, theme::SECONDARY_LABEL))
+                        .child(label(app.label(), theme::CALLOUT, true)),
+                ),
+        )
+        .child(
+            div()
+                .text_size(px(12.))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(if verified {
+                    mic_color
+                } else {
+                    theme::TERTIARY_LABEL
+                })
+                .child(state_line),
+        )
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .gap(px(8.))
+                .pt(px(4.))
+                .child(action_btn(
+                    "meeting-mute",
+                    mic_icon,
+                    mute_caption,
+                    mic_color,
+                    snap.accessibility_trusted || app == MeetingApp::Meet,
+                    cx,
+                    |this, cx| this.toggle_meeting_mute(cx),
+                ))
+                .child(action_btn(
+                    "meeting-leave",
+                    "phone-off",
+                    "Leave",
+                    theme::DESTRUCTIVE,
+                    snap.accessibility_trusted || app == MeetingApp::Meet,
+                    cx,
+                    |this, cx| this.leave_meeting(cx),
+                )),
+        )
+        .into_any_element()
+}
+
+fn action_btn(
+    id: &'static str,
+    icon: &'static str,
+    caption: &'static str,
+    color: Rgba,
+    enabled: bool,
+    cx: &mut Context<Island>,
+    on_click: impl Fn(&mut Island, &mut Context<Island>) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .h(px(theme::HIT_MIN))
+        .px(px(10.))
+        .flex()
+        .items_center()
+        .gap(px(6.))
+        .rounded(px(theme::CONTROL_RADIUS))
+        .bg(theme::FILL)
+        .opacity(if enabled { 1.0 } else { 0.4 })
+        .when(enabled, |d| {
+            d.hover(|s| s.bg(theme::FILL_SECONDARY))
+                .active(|s| s.opacity(0.85))
+                .cursor(CursorStyle::PointingHand)
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                        cx.stop_propagation();
+                        on_click(this, cx);
+                    }),
+                )
+        })
+        .child(lucide_color(icon, 14.0, color))
+        .child(label(caption, theme::CALLOUT, true))
+}
+
+fn mic_face(snap: &MeetingSnapshot) -> (&'static str, Rgba) {
+    if snap.mute_verified() {
+        if snap.muted() == Some(true) {
+            ("mic-off", theme::WARNING)
+        } else {
+            ("mic", theme::SUCCESS)
+        }
+    } else {
+        ("mic", theme::SECONDARY_LABEL)
+    }
+}
+
+fn format_elapsed(secs: u32) -> String {
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{h}:{m:02}:{s:02}")
+    } else {
+        format!("{m}:{s:02}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn elapsed_pads_minutes() {
+        assert_eq!(format_elapsed(0), "0:00");
+        assert_eq!(format_elapsed(65), "1:05");
+        assert_eq!(format_elapsed(3600), "1:00:00");
+    }
+}

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -2,6 +2,7 @@
 
 mod agents;
 mod calendar;
+mod meeting;
 mod notes;
 mod notes_editor;
 mod observe;
@@ -13,6 +14,9 @@ pub(crate) use agents::{
     agents_card, compact_left as agents_compact_left, compact_right as agents_compact_right,
 };
 pub(crate) use calendar::calendar_card;
+pub(crate) use meeting::{
+    compact_left as meeting_compact_left, compact_right as meeting_compact_right, meeting_card,
+};
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};
 pub(crate) use observe::{observe_card, ObserveHover};


### PR DESCRIPTION
Detect Zoom / Teams / Google Meet and offer mute + leave from the island.

Honest ceiling: **Zoom full**, **Teams blind toggle**, **Meet best-effort**.

## Detection (event-driven, no poll at rest)
- NSWorkspace `didLaunch` / `didTerminate` for `us.zoom.xos`, `com.microsoft.teams2`, and browser IDs from `browser_media.rs`.
- CoreAudio listener on `kAudioDevicePropertyDeviceIsRunningSomewhere`, re-armed on default input change. macOS 14+: process-object attribution (PID / bundle / `IsRunningInput`). No TCC for device state. Never `AudioHardwareCreateProcessTap`.
- Meeting confirm: Zoom = AX "Meeting" menu; Meet = tab URL `meet.google.com/xxx-xxxx-xxx`; Teams = app + mic only. No `CGWindowList` titles.

## Control
- **Zoom:** AX menu Mute/Unmute without focus. Menu title is mute-state readback **only while the meeting face is shown** (1–2s). Leave: `CGEventPostToPid` Cmd+W then AXPress Leave/End. Locale-aware matching.
- **Teams:** fire-and-forget Cmd+Shift+M / Cmd+Shift+H via `CGEventPostToPid`. UI shows **unverified state**. Localhost:8124 API is retired — not used.
- **Meet:** default activates the tab + Cmd+D/E (focus-stealing). Optional Settings path: Apple Events JS if the user enabled "Allow JavaScript from Apple Events". No bundled WebExtension.

## Settings
Per-app toggles, Meet control mode, Accessibility permission row. Feature degrades when Accessibility is denied.

## Tests
`cargo +stable test -p nook -p nook-core --locked` green on Linux (macOS APIs cfg-gated).

## Honest blockers
1. Teams localhost:8124 API is gone (MC1266901) — no mute-state readback; fails if the meeting window is minimized.
2. Meet without an extension is focus-stealing, or gated on a hidden browser developer flag.
3. Zoom menu titles are localized and change across Zoom releases.
4. Accessibility TCC resets on ad-hoc re-sign.