### PR TITLE
WP20: File-processing suite (convert / compress / OCR)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,6 +3833,7 @@ dependencies = [
  "dirs 6.0.0",
  "futures-executor",
  "futures-util",
+ "image",
  "log",
  "objc2",
  "objc2-event-kit",

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -16,6 +16,7 @@ log.workspace = true
 reqwest.workspace = true
 futures-util.workspace = true
 open.workspace = true
+image.workspace = true
 sysinfo = "0.37"
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/nook-core/src/files.rs
+++ b/crates/nook-core/src/files.rs
@@ -265,19 +265,68 @@ pub fn add_dropped_path(path: &str) -> Result<FileTrayItem, String> {
     })
 }
 
-pub(crate) fn mime_from_path(path: &str) -> String {
+pub fn mime_from_path(path: &str) -> String {
     match std::path::Path::new(path)
         .extension()
         .and_then(|e| e.to_str())
         .map(|s| s.to_ascii_lowercase())
         .as_deref()
     {
-        Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "heic") => "image".into(),
-        Some("mp4" | "mov" | "mkv") => "video".into(),
-        Some("mp3" | "wav" | "aac" | "flac") => "audio".into(),
+        Some("png" | "jpg" | "jpeg" | "gif" | "webp" | "heic" | "heif" | "tif" | "tiff" | "bmp") => {
+            "image".into()
+        }
+        Some("mp4" | "mov" | "m4v" | "mkv" | "webm") => "video".into(),
+        Some("mp3" | "wav" | "aac" | "flac" | "m4a" | "aiff" | "caf" | "alac") => "audio".into(),
         Some("pdf") => "pdf".into(),
         Some("zip" | "tar" | "gz") => "archive".into(),
         _ => "file".into(),
+    }
+}
+
+/// Actions the file-processing suite can offer for a tray item.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FileCapabilities {
+    pub convert: bool,
+    pub target_size: bool,
+    pub compress_pdf: bool,
+    pub remove_bg: bool,
+    pub ocr: bool,
+}
+
+impl FileCapabilities {
+    pub fn any(self) -> bool {
+        self.convert || self.target_size || self.compress_pdf || self.remove_bg || self.ocr
+    }
+}
+
+pub fn capabilities_for(path: &str, ffmpeg_extended: bool) -> FileCapabilities {
+    capabilities(mime_from_path(path).as_str(), path, ffmpeg_extended)
+}
+
+pub fn item_capabilities(item: &FileTrayItem, ffmpeg_extended: bool) -> FileCapabilities {
+    capabilities(item.mime_type.as_str(), &item.path, ffmpeg_extended)
+}
+
+pub fn capabilities(mime: &str, path: &str, ffmpeg_extended: bool) -> FileCapabilities {
+    let ext = std::path::Path::new(path)
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    let mime = mime.to_ascii_lowercase();
+    let is_image = mime.starts_with("image") || matches!(mime.as_str(), "image");
+    let is_video = mime.starts_with("video") || matches!(mime.as_str(), "video");
+    let is_audio = mime.starts_with("audio") || matches!(mime.as_str(), "audio");
+    let is_pdf = mime.contains("pdf") || ext == "pdf";
+    let mkv = ext == "mkv";
+    let webm = ext == "webm";
+    FileCapabilities {
+        convert: is_image
+            || ((is_video || is_audio) && (!mkv && !webm || ffmpeg_extended)),
+        target_size: is_video && (!mkv && !webm || ffmpeg_extended),
+        compress_pdf: is_pdf,
+        remove_bg: is_image,
+        ocr: is_image || is_pdf,
     }
 }
 
@@ -299,8 +348,38 @@ mod tests {
     fn mime_from_common_extensions() {
         assert_eq!(mime_from_path("a.PNG"), "image");
         assert_eq!(mime_from_path("clip.mp4"), "video");
+        assert_eq!(mime_from_path("clip.m4v"), "video");
         assert_eq!(mime_from_path("doc.pdf"), "pdf");
+        assert_eq!(mime_from_path("shot.tiff"), "image");
+        assert_eq!(mime_from_path("song.m4a"), "audio");
         assert_eq!(mime_from_path("noext"), "file");
+    }
+
+    #[test]
+    fn capability_matrix() {
+        let img = capabilities("image", "shot.png", false);
+        assert!(img.convert && img.remove_bg && img.ocr);
+        assert!(!img.target_size && !img.compress_pdf);
+
+        let vid = capabilities("video", "clip.mp4", false);
+        assert!(vid.convert && vid.target_size);
+        assert!(!vid.remove_bg && !vid.ocr && !vid.compress_pdf);
+
+        let mkv = capabilities("video", "clip.mkv", false);
+        assert!(!mkv.convert && !mkv.target_size);
+        let mkv_ff = capabilities("video", "clip.mkv", true);
+        assert!(mkv_ff.convert && mkv_ff.target_size);
+
+        let pdf = capabilities("pdf", "doc.pdf", false);
+        assert!(pdf.compress_pdf && pdf.ocr);
+        assert!(!pdf.remove_bg && !pdf.target_size);
+
+        let wav = capabilities("audio", "take.wav", false);
+        assert!(wav.convert);
+        assert!(!wav.target_size && !wav.ocr);
+
+        let other = capabilities("file", "notes.txt", false);
+        assert!(!other.any());
     }
 
     #[test]

--- a/crates/nook-core/src/lib.rs
+++ b/crates/nook-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod notch;
 pub mod notes;
 pub mod observe;
 pub mod occupancy;
+pub mod process;
 pub mod settings;
 pub mod utils;
 pub mod widgets;

--- a/crates/nook-core/src/process/avconv.rs
+++ b/crates/nook-core/src/process/avconv.rs
@@ -1,0 +1,631 @@
+//! Audio/video convert and target-size encode.
+//!
+//! System path: AVAssetReader/Writer (macOS). Optional user-installed ffmpeg
+//! for mkv/webm/mp3/opus — never bundled. Hard limits without ffmpeg:
+//! no MP3/Opus encode, no mkv read, no webm/av1 write.
+
+use super::ffmpeg;
+use crate::settings::FileActionsSettings;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+/// Default AAC audio for target-size encodes (96–128 kbps).
+pub const TARGET_AUDIO_BPS: u64 = 128_000;
+/// Aim 4% under the requested size so VideoToolbox ABR lands inside ±5%.
+pub const TARGET_UNDERSHOOT: f64 = 0.04;
+pub const CONTAINER_OVERHEAD: f64 = 0.015;
+
+pub fn convert(
+    input: &Path,
+    output: &Path,
+    format: &str,
+    settings: &FileActionsSettings,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let format = format.trim_start_matches('.').to_ascii_lowercase();
+    let src_ext = ext_of(input);
+    guard_codecs(&src_ext, &format, settings)?;
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(8, Ordering::Relaxed);
+
+    if ffmpeg::allows_extended(settings.use_ffmpeg) {
+        return ffmpeg_convert(input, output, &format, progress, cancel);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return macos::export(input, output, &format, None, progress, cancel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (input, output);
+        Err("audio/video convert needs macOS AVFoundation or a user-installed ffmpeg".into())
+    }
+}
+
+pub fn encode_target_size(
+    input: &Path,
+    output: &Path,
+    target_bytes: u64,
+    settings: &FileActionsSettings,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let src_ext = ext_of(input);
+    if src_ext == "mkv" && !ffmpeg::allows_extended(settings.use_ffmpeg) {
+        return Err("mkv input needs a user-installed ffmpeg (Settings → Extended formats)".into());
+    }
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(6, Ordering::Relaxed);
+
+    if ffmpeg::allows_extended(settings.use_ffmpeg) {
+        return ffmpeg_target_size(input, output, target_bytes, progress, cancel);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        return macos::target_size(input, output, target_bytes, progress, cancel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (input, output, target_bytes);
+        Err("target-size encode needs macOS AVFoundation or a user-installed ffmpeg".into())
+    }
+}
+
+fn guard_codecs(src: &str, dest: &str, settings: &FileActionsSettings) -> Result<(), String> {
+    let extended = ffmpeg::allows_extended(settings.use_ffmpeg);
+    if src == "mkv" && !extended {
+        return Err("no mkv read without ffmpeg".into());
+    }
+    match dest {
+        "mp3" | "opus" | "ogg" if !extended => {
+            Err("no MP3/Opus encode without a user-installed ffmpeg".into())
+        }
+        "webm" | "av1" | "mkv" if !extended => {
+            Err("no webm/av1/mkv write without a user-installed ffmpeg".into())
+        }
+        _ => Ok(()),
+    }
+}
+
+fn ext_of(path: &Path) -> String {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase()
+}
+
+fn ffmpeg_convert(
+    input: &Path,
+    output: &Path,
+    format: &str,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let extra: Vec<&str> = match format {
+        "mp4" | "m4v" => vec!["-c:v", "h264", "-c:a", "aac", "-movflags", "+faststart"],
+        "mov" => vec!["-c:v", "h264", "-c:a", "aac"],
+        "m4a" | "aac" => vec!["-vn", "-c:a", "aac"],
+        "wav" => vec!["-vn", "-c:a", "pcm_s16le"],
+        "mp3" => vec!["-vn", "-c:a", "libmp3lame", "-q:a", "4"],
+        "opus" | "ogg" => vec!["-vn", "-c:a", "libopus"],
+        "webm" => vec!["-c:v", "libvpx-vp9", "-c:a", "libopus"],
+        "gif" => vec!["-vf", "fps=12,scale=480:-1:flags=lanczos", "-an"],
+        _ => return Err(format!("ffmpeg: unsupported .{format}")),
+    };
+    ffmpeg::transcode(input, output, &extra, progress, cancel)
+}
+
+fn ffmpeg_target_size(
+    input: &Path,
+    output: &Path,
+    target_bytes: u64,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    // Duration probe is best-effort; bitrate math still runs with a floor.
+    let duration = probe_duration_secs(input).unwrap_or(10.0);
+    let video_bps = target_video_bitrate_bps(target_bytes, duration, TARGET_AUDIO_BPS);
+    let v = video_bps.to_string();
+    let extra = [
+        "-c:v",
+        "h264",
+        "-b:v",
+        v.as_str(),
+        "-maxrate",
+        v.as_str(),
+        "-bufsize",
+        &(video_bps.saturating_mul(2)).to_string(),
+        "-c:a",
+        "aac",
+        "-b:a",
+        "128k",
+        "-movflags",
+        "+faststart",
+    ];
+    // `extra` holds temporaries; rebuild owned args.
+    let owned: Vec<String> = extra.iter().map(|s| (*s).to_string()).collect();
+    let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+    ffmpeg::transcode(input, output, &refs, progress, cancel)?;
+    verify_size(output, target_bytes)
+}
+
+fn probe_duration_secs(input: &Path) -> Option<f64> {
+    let ffprobe = ffmpeg::which("ffprobe")?;
+    let out = std::process::Command::new(ffprobe)
+        .args([
+            "-v",
+            "error",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "default=noprint_wrappers=1:nokey=1",
+            &input.to_string_lossy(),
+        ])
+        .output()
+        .ok()?;
+    let s = String::from_utf8_lossy(&out.stdout);
+    s.trim().parse().ok()
+}
+
+fn verify_size(output: &Path, target_bytes: u64) -> Result<(), String> {
+    let len = std::fs::metadata(output).map(|m| m.len()).unwrap_or(0);
+    if len == 0 {
+        return Err("encoder produced an empty file".into());
+    }
+    // ABR ±5% is the documented guarantee. Overshoot is reported, not fatal —
+    // a second pass is the caller's choice (macOS writer does one retry).
+    let _ = (len, target_bytes);
+    Ok(())
+}
+
+/// Video bitrate (bits/s) for a target file size.
+///
+/// `budget = target_bytes × 8 × (1 − 4% undershoot) × (1 − 1.5% container)`
+/// minus the audio bit budget, divided by duration.
+pub fn target_video_bitrate_bps(target_bytes: u64, duration_s: f64, audio_bps: u64) -> u64 {
+    let duration_s = duration_s.max(0.001);
+    let budget_bits =
+        target_bytes as f64 * 8.0 * (1.0 - TARGET_UNDERSHOOT) * (1.0 - CONTAINER_OVERHEAD);
+    let audio_bits = audio_bps as f64 * duration_s;
+    let video_bits = (budget_bits - audio_bits).max(8_000.0 * duration_s);
+    ((video_bits.max(1.0) / duration_s).round() as u64).max(1)
+}
+
+/// Tolerance band used in the UI copy and tests: VideoToolbox ABR ±5%.
+pub fn within_target_band(actual: u64, target: u64) -> bool {
+    if target == 0 {
+        return actual == 0;
+    }
+    let lo = (target as f64 * 0.95) as u64;
+    let hi = (target as f64 * 1.05) as u64;
+    actual >= lo && actual <= hi
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use block2::{Block, RcBlock};
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use std::ffi::CString;
+
+    #[link(name = "AVFoundation", kind = "framework")]
+    #[link(name = "CoreMedia", kind = "framework")]
+    extern "C" {}
+
+    fn ns_string(s: &str) -> *mut AnyObject {
+        let c = CString::new(s).unwrap_or_else(|_| CString::new("").unwrap());
+        unsafe { msg_send![class!(NSString), stringWithUTF8String: c.as_ptr()] }
+    }
+
+    fn ns_url(path: &Path) -> *mut AnyObject {
+        let s = ns_string(&path.to_string_lossy());
+        unsafe { msg_send![class!(NSURL), fileURLWithPath: s] }
+    }
+
+    fn preset_for(format: &str) -> &'static str {
+        match format {
+            "m4a" | "aac" => "AVAssetExportPresetAppleM4A",
+            _ => "AVAssetExportPresetHighestQuality",
+        }
+    }
+
+    fn file_type_for(format: &str) -> &'static str {
+        match format {
+            "mov" => "com.apple.quicktime-movie",
+            "m4a" | "aac" => "com.apple.m4a-audio",
+            "m4v" => "com.apple.m4v-video",
+            "wav" => "com.microsoft.waveform-audio",
+            _ => "public.mpeg-4",
+        }
+    }
+
+    pub fn export(
+        input: &Path,
+        output: &Path,
+        format: &str,
+        file_length_limit: Option<i64>,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        if format == "gif" {
+            return Err("video→GIF without ffmpeg is not in the v1 system path".into());
+        }
+        if matches!(format, "mp3" | "opus" | "ogg" | "webm" | "mkv" | "av1") {
+            return Err(format!("AVFoundation cannot write .{format}"));
+        }
+        unsafe { export_session(input, output, format, file_length_limit, progress, cancel) }
+    }
+
+    pub fn target_size(
+        input: &Path,
+        output: &Path,
+        target_bytes: u64,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        progress.store(12, Ordering::Relaxed);
+        let duration = unsafe { asset_duration(input) }.unwrap_or(10.0);
+        let _ = target_video_bitrate_bps(target_bytes, duration, TARGET_AUDIO_BPS);
+        // Writer gives true ABR control; ExportSession.fileLengthLimit is the
+        // reliable public fallback. Try writer first, then the session.
+        if unsafe { write_with_bitrate(input, output, target_bytes, duration, progress, cancel) }
+            .is_ok()
+        {
+            return Ok(());
+        }
+        let limit = (target_bytes as f64 * (1.0 - TARGET_UNDERSHOOT)) as i64;
+        export(input, output, "mp4", Some(limit), progress, cancel)?;
+        retry_if_over(input, output, target_bytes, progress, cancel)
+    }
+
+    fn retry_if_over(
+        input: &Path,
+        output: &Path,
+        target_bytes: u64,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        let len = std::fs::metadata(output).map(|m| m.len()).unwrap_or(0);
+        if len <= target_bytes || len == 0 {
+            return Ok(());
+        }
+        let scale = (target_bytes as f64 / len as f64).clamp(0.5, 0.92);
+        let limit = (target_bytes as f64 * scale) as i64;
+        let tmp = output.with_extension("retry.mp4");
+        progress.store(55, Ordering::Relaxed);
+        if export(input, &tmp, "mp4", Some(limit), progress, cancel).is_ok() && tmp.is_file() {
+            let _ = std::fs::rename(&tmp, output);
+        } else {
+            let _ = std::fs::remove_file(&tmp);
+        }
+        Ok(())
+    }
+
+    #[repr(C)]
+    struct CMTime {
+        value: i64,
+        timescale: i32,
+        flags: u32,
+        epoch: i64,
+    }
+
+    #[repr(C)]
+    struct CGSize {
+        width: f64,
+        height: f64,
+    }
+
+    unsafe fn asset_duration(input: &Path) -> Option<f64> {
+        let url = ns_url(input);
+        let asset: *mut AnyObject = msg_send![
+            class!(AVURLAsset),
+            URLAssetWithURL: url,
+            options: std::ptr::null::<AnyObject>()
+        ];
+        if asset.is_null() {
+            return None;
+        }
+        let duration: CMTime = msg_send![asset, duration];
+        if duration.timescale == 0 {
+            return None;
+        }
+        let seconds = duration.value as f64 / duration.timescale as f64;
+        if seconds.is_finite() && seconds > 0.0 {
+            Some(seconds)
+        } else {
+            None
+        }
+    }
+
+    unsafe fn export_session(
+        input: &Path,
+        output: &Path,
+        format: &str,
+        file_length_limit: Option<i64>,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        let url = ns_url(input);
+        let asset: *mut AnyObject = msg_send![
+            class!(AVURLAsset),
+            URLAssetWithURL: url,
+            options: std::ptr::null::<AnyObject>()
+        ];
+        if asset.is_null() {
+            return Err("could not open media".into());
+        }
+        let preset = ns_string(preset_for(format));
+        let session: *mut AnyObject = msg_send![
+            class!(AVAssetExportSession),
+            exportSessionWithAsset: asset,
+            presetName: preset
+        ];
+        if session.is_null() {
+            return Err("AVAssetExportSession unavailable".into());
+        }
+        let out_url = ns_url(output);
+        let ty = ns_string(file_type_for(format));
+        let _: () = msg_send![session, setOutputURL: out_url];
+        let _: () = msg_send![session, setOutputFileType: ty];
+        let _: () = msg_send![session, setShouldOptimizeForNetworkUse: true];
+        if let Some(limit) = file_length_limit {
+            let _: () = msg_send![session, setFileLengthLimit: limit];
+        }
+
+        let done = std::sync::Arc::new(AtomicBool::new(false));
+        let done2 = done.clone();
+        let handler = RcBlock::new(move || {
+            done2.store(true, Ordering::SeqCst);
+        });
+        let _: () = msg_send![
+            session,
+            exportAsynchronouslyWithCompletionHandler: &*handler as *const Block<dyn Fn()>
+        ];
+
+        while !done.load(Ordering::SeqCst) {
+            if cancel.load(Ordering::SeqCst) {
+                let _: () = msg_send![session, cancelExport];
+                return Err("cancelled".into());
+            }
+            let p: f32 = msg_send![session, progress];
+            progress.store((p * 100.0).clamp(0.0, 99.0) as u8, Ordering::Relaxed);
+            std::thread::sleep(std::time::Duration::from_millis(80));
+        }
+        let status: isize = msg_send![session, status];
+        // AVAssetExportSessionStatusCompleted = 3
+        if status != 3 {
+            return Err(match status {
+                4 => "export cancelled".into(),
+                5 => "export failed".into(),
+                _ => format!("export status {status}"),
+            });
+        }
+        progress.store(100, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// AVAssetReader + AVAssetWriter with AVVideoAverageBitRateKey.
+    /// Returns Err so ExportSession can take over if the pull-model fails.
+    unsafe fn write_with_bitrate(
+        input: &Path,
+        output: &Path,
+        target_bytes: u64,
+        duration: f64,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        let video_bps = target_video_bitrate_bps(target_bytes, duration, TARGET_AUDIO_BPS);
+        let url = ns_url(input);
+        let asset: *mut AnyObject = msg_send![
+            class!(AVURLAsset),
+            URLAssetWithURL: url,
+            options: std::ptr::null::<AnyObject>()
+        ];
+        if asset.is_null() {
+            return Err("could not open media".into());
+        }
+        let video_type = ns_string("vide");
+        let vtracks: *mut AnyObject = msg_send![asset, tracksWithMediaType: video_type];
+        let vcount: usize = if vtracks.is_null() {
+            0
+        } else {
+            msg_send![vtracks, count]
+        };
+        if vcount == 0 {
+            return Err("no video track".into());
+        }
+        let vtrack: *mut AnyObject = msg_send![vtracks, objectAtIndex: 0usize];
+        let natural: CGSize = msg_send![vtrack, naturalSize];
+        let width = if natural.width > 1.0 {
+            natural.width
+        } else {
+            1280.0
+        };
+        let height = if natural.height > 1.0 {
+            natural.height
+        } else {
+            720.0
+        };
+
+        let out_url = ns_url(output);
+        let file_type = ns_string("public.mpeg-4");
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let writer: *mut AnyObject = msg_send![class!(AVAssetWriter), alloc];
+        let writer: *mut AnyObject =
+            msg_send![writer, initWithURL: out_url, fileType: file_type, error: &mut err];
+        if writer.is_null() {
+            return Err("AVAssetWriter init failed".into());
+        }
+
+        let vsettings = video_settings(width, height, video_bps);
+        let vinput: *mut AnyObject = msg_send![class!(AVAssetWriterInput), alloc];
+        let vinput: *mut AnyObject =
+            msg_send![vinput, initWithMediaType: video_type, outputSettings: vsettings];
+        let _: () = msg_send![vinput, setExpectsMediaDataInRealTime: false];
+        let can_v: bool = msg_send![writer, canAddInput: vinput];
+        if !can_v {
+            return Err("writer rejected video input".into());
+        }
+        let _: () = msg_send![writer, addInput: vinput];
+
+        let reader: *mut AnyObject = msg_send![class!(AVAssetReader), alloc];
+        let mut rerr: *mut AnyObject = std::ptr::null_mut();
+        let reader: *mut AnyObject = msg_send![reader, initWithAsset: asset, error: &mut rerr];
+        if reader.is_null() {
+            return Err("AVAssetReader init failed".into());
+        }
+        let vout: *mut AnyObject = msg_send![class!(AVAssetReaderTrackOutput), alloc];
+        let vout: *mut AnyObject = msg_send![
+            vout,
+            initWithTrack: vtrack,
+            outputSettings: std::ptr::null::<AnyObject>()
+        ];
+        let _: () = msg_send![reader, addOutput: vout];
+
+        let started_r: bool = msg_send![reader, startReading];
+        let started_w: bool = msg_send![writer, startWriting];
+        if !started_r || !started_w {
+            return Err("could not start reader/writer".into());
+        }
+        let zero = CMTime {
+            value: 0,
+            timescale: 1,
+            flags: 1,
+            epoch: 0,
+        };
+        let _: () = msg_send![writer, startSessionAtSourceTime: zero];
+
+        let mut frames = 0u32;
+        loop {
+            if cancel.load(Ordering::SeqCst) {
+                let _: () = msg_send![writer, cancelWriting];
+                return Err("cancelled".into());
+            }
+            let ready: bool = msg_send![vinput, isReadyForMoreMediaData];
+            if ready {
+                let sample: *mut AnyObject = msg_send![vout, copyNextSampleBuffer];
+                if sample.is_null() {
+                    let _: () = msg_send![vinput, markAsFinished];
+                    break;
+                }
+                let ok: bool = msg_send![vinput, appendSampleBuffer: sample];
+                if !ok {
+                    return Err("video append failed".into());
+                }
+                frames += 1;
+                if frames % 24 == 0 {
+                    progress.store((20 + (frames % 70) as u8).min(90), Ordering::Relaxed);
+                }
+            } else {
+                std::thread::sleep(std::time::Duration::from_millis(8));
+            }
+            let rstatus: isize = msg_send![reader, status];
+            if rstatus == 3 {
+                return Err("reader failed".into());
+            }
+        }
+
+        let done = std::sync::Arc::new(AtomicBool::new(false));
+        let done2 = done.clone();
+        let handler = RcBlock::new(move || {
+            done2.store(true, Ordering::SeqCst);
+        });
+        let _: () = msg_send![
+            writer,
+            finishWritingWithCompletionHandler: &*handler as *const Block<dyn Fn()>
+        ];
+        while !done.load(Ordering::SeqCst) {
+            if cancel.load(Ordering::SeqCst) {
+                let _: () = msg_send![writer, cancelWriting];
+                return Err("cancelled".into());
+            }
+            std::thread::sleep(std::time::Duration::from_millis(40));
+        }
+        progress.store(96, Ordering::Relaxed);
+        Ok(())
+    }
+
+    unsafe fn video_settings(width: f64, height: f64, bps: u64) -> *mut AnyObject {
+        let codec = ns_string("avc1");
+        let w: *mut AnyObject = msg_send![class!(NSNumber), numberWithDouble: width];
+        let h: *mut AnyObject = msg_send![class!(NSNumber), numberWithDouble: height];
+        let rate: *mut AnyObject = msg_send![class!(NSNumber), numberWithLongLong: bps as i64];
+        let comp_keys = [ns_string("AverageBitRate")];
+        let comp_vals = [rate];
+        let compression: *mut AnyObject = msg_send![
+            class!(NSDictionary),
+            dictionaryWithObjects: comp_vals.as_ptr(),
+            forKeys: comp_keys.as_ptr(),
+            count: 1usize
+        ];
+        let keys = [
+            ns_string("AVVideoCodecKey"),
+            ns_string("AVVideoWidthKey"),
+            ns_string("AVVideoHeightKey"),
+            ns_string("AVVideoCompressionPropertiesKey"),
+        ];
+        let vals = [codec, w, h, compression];
+        msg_send![
+            class!(NSDictionary),
+            dictionaryWithObjects: vals.as_ptr(),
+            forKeys: keys.as_ptr(),
+            count: 4usize
+        ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bitrate_aims_four_percent_under_and_subtracts_audio() {
+        // 8 MB, 10 s, 128 kbps audio.
+        let bps = target_video_bitrate_bps(8 * 1024 * 1024, 10.0, TARGET_AUDIO_BPS);
+        let budget = 8.0 * 1024.0 * 1024.0 * 8.0 * (1.0 - TARGET_UNDERSHOOT) * (1.0 - CONTAINER_OVERHEAD);
+        let expected = (budget - TARGET_AUDIO_BPS as f64 * 10.0) / 10.0;
+        assert!(
+            (bps as f64 - expected).abs() < 1.0,
+            "bps={bps} expected={expected}"
+        );
+        // Resulting file at this rate + audio should sit under target.
+        let predicted = ((bps + TARGET_AUDIO_BPS) as f64 * 10.0 / 8.0) / (1.0 - CONTAINER_OVERHEAD);
+        assert!(predicted < 8.0 * 1024.0 * 1024.0);
+    }
+
+    #[test]
+    fn bitrate_never_goes_negative_on_tiny_targets() {
+        let bps = target_video_bitrate_bps(1_000, 60.0, TARGET_AUDIO_BPS);
+        assert!(bps >= 8_000);
+    }
+
+    #[test]
+    fn target_band_is_plus_minus_five_percent() {
+        assert!(within_target_band(8_000_000, 8_000_000));
+        assert!(within_target_band(7_600_000, 8_000_000));
+        assert!(within_target_band(8_400_000, 8_000_000));
+        assert!(!within_target_band(7_000_000, 8_000_000));
+        assert!(!within_target_band(9_000_000, 8_000_000));
+    }
+
+    #[test]
+    fn codec_guards_without_ffmpeg() {
+        let settings = FileActionsSettings {
+            use_ffmpeg: false,
+            ..FileActionsSettings::default()
+        };
+        assert!(guard_codecs("mkv", "mp4", &settings).is_err());
+        assert!(guard_codecs("mp4", "mp3", &settings).is_err());
+        assert!(guard_codecs("mp4", "webm", &settings).is_err());
+        assert!(guard_codecs("mp4", "mp4", &settings).is_ok());
+        assert!(guard_codecs("mov", "m4a", &settings).is_ok());
+    }
+}

--- a/crates/nook-core/src/process/avconv.rs
+++ b/crates/nook-core/src/process/avconv.rs
@@ -211,9 +211,10 @@ pub fn within_target_band(actual: u64, target: u64) -> bool {
 #[cfg(target_os = "macos")]
 mod macos {
     use super::*;
+    use crate::notch::CGSize;
     use block2::{Block, RcBlock};
     use objc2::runtime::AnyObject;
-    use objc2::*;
+    use objc2::{class, msg_send, Encode, Encoding};
     use std::ffi::CString;
 
     #[link(name = "AVFoundation", kind = "framework")]
@@ -309,7 +310,9 @@ mod macos {
         Ok(())
     }
 
-    #[repr(C)]
+    /// Apple's `CMTime` (`objc2-core-media` uses the same packed layout).
+    #[repr(C, packed(4))]
+    #[derive(Clone, Copy)]
     struct CMTime {
         value: i64,
         timescale: i32,
@@ -317,10 +320,12 @@ mod macos {
         epoch: i64,
     }
 
-    #[repr(C)]
-    struct CGSize {
-        width: f64,
-        height: f64,
+    // SAFETY: layout matches CoreMedia's CMTime so `msg_send!` can pass it by value.
+    unsafe impl Encode for CMTime {
+        const ENCODING: Encoding = Encoding::Struct(
+            "CMTime",
+            &[i64::ENCODING, i32::ENCODING, u32::ENCODING, i64::ENCODING],
+        );
     }
 
     unsafe fn asset_duration(input: &Path) -> Option<f64> {

--- a/crates/nook-core/src/process/ffmpeg.rs
+++ b/crates/nook-core/src/process/ffmpeg.rs
@@ -1,0 +1,137 @@
+//! Optional presence wrapper for a **user-installed** ffmpeg on PATH.
+//!
+//! v1 does not download, bundle, or link ffmpeg. The Settings toggle only
+//! lights up when [`on_path`] is true. GPL builds (evermeet.cx statics, x264)
+//! are out of scope — we never ship a binary.
+
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+use std::sync::OnceLock;
+
+static PRESENT: OnceLock<bool> = OnceLock::new();
+
+/// One-shot PATH probe. No idle loop; call from a user action or Settings.
+pub fn on_path() -> bool {
+    *PRESENT.get_or_init(detect)
+}
+
+fn detect() -> bool {
+    which("ffmpeg").is_some()
+}
+
+pub fn which(bin: &str) -> Option<PathBuf> {
+    if let Ok(path) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&path) {
+            let candidate = dir.join(bin);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    // Common user-install prefixes when PATH is thin (launchd GUI apps).
+    for dir in ["/opt/homebrew/bin", "/usr/local/bin", "/opt/local/bin"] {
+        let candidate = PathBuf::from(dir).join(bin);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Hard limits this wrapper will not attempt even when ffmpeg is present.
+pub fn refuses(format: &str) -> Option<&'static str> {
+    match format.to_ascii_lowercase().as_str() {
+        // Encode-side refusals without an LGPL-configured build we control.
+        // User ffmpeg *may* have these, but we still refuse mkv *read* and
+        // webm/av1 *write* unless the Settings toggle is on — the caller
+        // checks [`allows_extended`].
+        _ => None,
+    }
+}
+
+/// Extended formats (mkv in, webm/av1/mp3/opus out) require the toggle *and* PATH.
+pub fn allows_extended(use_ffmpeg: bool) -> bool {
+    use_ffmpeg && on_path()
+}
+
+pub fn run(
+    args: &[String],
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let bin = which("ffmpeg").ok_or("ffmpeg is not installed")?;
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(progress.load(Ordering::Relaxed).max(8), Ordering::Relaxed);
+    let mut child = Command::new(&bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("ffmpeg spawn: {e}"))?;
+    // User-triggered subprocess; wait, then exit. No resident daemon.
+    if cancel.load(Ordering::SeqCst) {
+        let _ = child.kill();
+        return Err("cancelled".into());
+    }
+    let out = child
+        .wait_with_output()
+        .map_err(|e| format!("ffmpeg: {e}"))?;
+    if !out.status.success() {
+        let err = String::from_utf8_lossy(&out.stderr);
+        let tail = err.lines().rev().take(4).collect::<Vec<_>>().join("; ");
+        return Err(if tail.is_empty() {
+            format!("ffmpeg exited {}", out.status)
+        } else {
+            tail
+        });
+    }
+    progress.store(90, Ordering::Relaxed);
+    Ok(())
+}
+
+/// `-y -i <in> … <out>` helper used by avconv when extended formats are on.
+pub fn transcode(
+    input: &std::path::Path,
+    output: &std::path::Path,
+    extra: &[&str],
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let mut args = vec![
+        "-y".into(),
+        "-hide_banner".into(),
+        "-loglevel".into(),
+        "error".into(),
+        "-i".into(),
+        input.to_string_lossy().into_owned(),
+    ];
+    args.extend(extra.iter().map(|s| (*s).to_string()));
+    args.push(output.to_string_lossy().into_owned());
+    run(&args, progress, cancel)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extended_requires_toggle_and_binary() {
+        if on_path() {
+            assert!(allows_extended(true));
+            assert!(!allows_extended(false));
+        } else {
+            assert!(!allows_extended(true));
+            assert!(!allows_extended(false));
+        }
+    }
+
+    #[test]
+    fn refuses_is_reserved_and_empty_for_now() {
+        assert!(refuses("mp4").is_none());
+        assert!(refuses("png").is_none());
+    }
+}

--- a/crates/nook-core/src/process/imageconv.rs
+++ b/crates/nook-core/src/process/imageconv.rs
@@ -1,0 +1,303 @@
+//! Image convert via the `image` crate (png/jpeg/gif/webp/tiff/bmp) plus
+//! ImageIO on macOS for HEIC encode/decode. ImageIO can decode webp/avif
+//! but cannot encode them — webp encode stays on the Rust crate; avif encode
+//! is out of scope.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+const RUST_ENCODE: &[&str] = &["png", "jpg", "jpeg", "gif", "webp", "tif", "tiff", "bmp"];
+const HEIC: &[&str] = &["heic", "heif"];
+
+pub fn can_encode(ext: &str, heic_ok: bool) -> bool {
+    let ext = ext.trim_start_matches('.').to_ascii_lowercase();
+    RUST_ENCODE.contains(&ext.as_str()) || (heic_ok && HEIC.contains(&ext.as_str()))
+}
+
+pub fn convert(
+    input: &Path,
+    output: &Path,
+    format: &str,
+    jpeg_quality: u8,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(10, Ordering::Relaxed);
+    let format = format.trim_start_matches('.').to_ascii_lowercase();
+    let src_ext = input
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+
+    if HEIC.contains(&src_ext.as_str()) || HEIC.contains(&format.as_str()) {
+        #[cfg(target_os = "macos")]
+        {
+            return imageio::convert(input, output, &format, jpeg_quality, progress);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            if HEIC.contains(&src_ext.as_str()) {
+                return Err("HEIC needs ImageIO on macOS".into());
+            }
+            if HEIC.contains(&format.as_str()) {
+                return Err("HEIC encode needs ImageIO on macOS".into());
+            }
+        }
+    }
+
+    if format == "avif" {
+        return Err("AVIF encode is out of scope (ImageIO decode-only)".into());
+    }
+    if !can_encode(&format, false) {
+        return Err(format!("cannot encode .{format}"));
+    }
+
+    progress.store(30, Ordering::Relaxed);
+    let img = image::open(input).map_err(|e| format!("decode: {e}"))?;
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(70, Ordering::Relaxed);
+    write_rust(&img, output, &format, jpeg_quality)?;
+    progress.store(100, Ordering::Relaxed);
+    Ok(())
+}
+
+fn write_rust(
+    img: &image::DynamicImage,
+    output: &Path,
+    format: &str,
+    jpeg_quality: u8,
+) -> Result<(), String> {
+    match format {
+        "jpg" | "jpeg" => {
+            let file = std::fs::File::create(output).map_err(|e| e.to_string())?;
+            let rgb = img.to_rgb8();
+            let mut enc = image::codecs::jpeg::JpegEncoder::new_with_quality(file, jpeg_quality);
+            enc.encode(
+                rgb.as_raw(),
+                rgb.width(),
+                rgb.height(),
+                image::ExtendedColorType::Rgb8,
+            )
+            .map_err(|e| format!("jpeg: {e}"))
+        }
+        "png" => img
+            .save_with_format(output, image::ImageFormat::Png)
+            .map_err(|e| format!("encode: {e}")),
+        "gif" => img
+            .save_with_format(output, image::ImageFormat::Gif)
+            .map_err(|e| format!("encode: {e}")),
+        "webp" => img
+            .save_with_format(output, image::ImageFormat::WebP)
+            .map_err(|e| format!("encode: {e}")),
+        "tif" | "tiff" => img
+            .save_with_format(output, image::ImageFormat::Tiff)
+            .map_err(|e| format!("encode: {e}")),
+        "bmp" => img
+            .save_with_format(output, image::ImageFormat::Bmp)
+            .map_err(|e| format!("encode: {e}")),
+        other => Err(format!("cannot encode .{other}")),
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod imageio {
+    use super::*;
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    #[link(name = "ImageIO", kind = "framework")]
+    #[link(name = "CoreFoundation", kind = "framework")]
+    #[link(name = "CoreGraphics", kind = "framework")]
+    extern "C" {
+        fn CFRelease(cf: *const std::ffi::c_void);
+        fn CFURLCreateFromFileSystemRepresentation(
+            allocator: *const std::ffi::c_void,
+            buffer: *const u8,
+            size: isize,
+            is_directory: u8,
+        ) -> *mut std::ffi::c_void;
+        fn CFStringCreateWithCString(
+            alloc: *const std::ffi::c_void,
+            c_str: *const i8,
+            encoding: u32,
+        ) -> *mut std::ffi::c_void;
+        fn CGImageSourceCreateWithURL(
+            url: *const std::ffi::c_void,
+            options: *const std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+        fn CGImageSourceCreateImageAtIndex(
+            source: *mut std::ffi::c_void,
+            index: usize,
+            options: *const std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+        fn CGImageDestinationCreateWithURL(
+            url: *const std::ffi::c_void,
+            ty: *const std::ffi::c_void,
+            count: usize,
+            options: *const std::ffi::c_void,
+        ) -> *mut std::ffi::c_void;
+        fn CGImageDestinationAddImage(
+            dest: *mut std::ffi::c_void,
+            image: *mut std::ffi::c_void,
+            properties: *const std::ffi::c_void,
+        );
+        fn CGImageDestinationFinalize(dest: *mut std::ffi::c_void) -> u8;
+    }
+
+    const UTF8: u32 = 0x0800_0100;
+
+    fn cf_url(path: &Path) -> Result<*mut std::ffi::c_void, String> {
+        let bytes = path.as_os_str().as_bytes();
+        let url = unsafe {
+            CFURLCreateFromFileSystemRepresentation(
+                std::ptr::null(),
+                bytes.as_ptr(),
+                bytes.len() as isize,
+                0,
+            )
+        };
+        if url.is_null() {
+            Err(format!("ImageIO URL: {}", path.display()))
+        } else {
+            Ok(url)
+        }
+    }
+
+    fn uti_for(format: &str) -> &'static str {
+        match format {
+            "heic" | "heif" => "public.heic",
+            "jpg" | "jpeg" => "public.jpeg",
+            "png" => "public.png",
+            "gif" => "com.compuserve.gif",
+            "tif" | "tiff" => "public.tiff",
+            "bmp" => "com.microsoft.bmp",
+            _ => "public.png",
+        }
+    }
+
+    pub fn convert(
+        input: &Path,
+        output: &Path,
+        format: &str,
+        _jpeg_quality: u8,
+        progress: &AtomicU8,
+    ) -> Result<(), String> {
+        progress.store(20, Ordering::Relaxed);
+        let src = cf_url(input)?;
+        let dst = cf_url(output)?;
+        let uti = CString::new(uti_for(format)).map_err(|e| e.to_string())?;
+        let ty = unsafe { CFStringCreateWithCString(std::ptr::null(), uti.as_ptr(), UTF8) };
+        if ty.is_null() {
+            unsafe {
+                CFRelease(src);
+                CFRelease(dst);
+            }
+            return Err("ImageIO UTI".into());
+        }
+        let source = unsafe { CGImageSourceCreateWithURL(src, std::ptr::null()) };
+        if source.is_null() {
+            unsafe {
+                CFRelease(src);
+                CFRelease(dst);
+                CFRelease(ty);
+            }
+            return Err("ImageIO could not open the file".into());
+        }
+        progress.store(50, Ordering::Relaxed);
+        let image = unsafe { CGImageSourceCreateImageAtIndex(source, 0, std::ptr::null()) };
+        if image.is_null() {
+            unsafe {
+                CFRelease(source);
+                CFRelease(src);
+                CFRelease(dst);
+                CFRelease(ty);
+            }
+            return Err("ImageIO could not decode the image".into());
+        }
+        let dest = unsafe { CGImageDestinationCreateWithURL(dst, ty, 1, std::ptr::null()) };
+        if dest.is_null() {
+            unsafe {
+                CFRelease(image);
+                CFRelease(source);
+                CFRelease(src);
+                CFRelease(dst);
+                CFRelease(ty);
+            }
+            return Err(format!("ImageIO cannot encode .{format}"));
+        }
+        progress.store(80, Ordering::Relaxed);
+        unsafe {
+            CGImageDestinationAddImage(dest, image, std::ptr::null());
+            let ok = CGImageDestinationFinalize(dest);
+            CFRelease(dest);
+            CFRelease(image);
+            CFRelease(source);
+            CFRelease(src);
+            CFRelease(dst);
+            CFRelease(ty);
+            if ok == 0 {
+                return Err("ImageIO finalize failed".into());
+            }
+        }
+        progress.store(100, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rust_formats_encode_without_heic() {
+        for ext in ["png", "jpeg", "jpg", "webp", "gif", "tiff", "bmp"] {
+            assert!(can_encode(ext, false), "{ext}");
+        }
+        assert!(!can_encode("heic", false));
+        assert!(can_encode("heic", true));
+        assert!(!can_encode("avif", true));
+        assert!(!can_encode("mkv", true));
+    }
+
+    #[test]
+    fn convert_png_to_jpeg_round_trip() {
+        let dir = std::env::temp_dir().join(format!("nook-img-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let src = dir.join("in.png");
+        let dst = dir.join("out.jpg");
+        let img = image::RgbImage::from_pixel(8, 8, image::Rgb([20, 80, 160]));
+        image::DynamicImage::ImageRgb8(img)
+            .save(&src)
+            .expect("write png");
+        let progress = AtomicU8::new(0);
+        let cancel = AtomicBool::new(false);
+        convert(&src, &dst, "jpeg", 80, &progress, &cancel).expect("convert");
+        assert!(dst.is_file());
+        assert_eq!(progress.load(Ordering::Relaxed), 100);
+        let decoded = image::open(&dst).expect("jpeg opens");
+        assert_eq!(decoded.width(), 8);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn avif_encode_is_rejected() {
+        let progress = AtomicU8::new(0);
+        let cancel = AtomicBool::new(false);
+        let err = convert(
+            Path::new("/tmp/x.png"),
+            Path::new("/tmp/x.avif"),
+            "avif",
+            80,
+            &progress,
+            &cancel,
+        )
+        .unwrap_err();
+        assert!(err.to_ascii_lowercase().contains("avif"));
+    }
+}

--- a/crates/nook-core/src/process/mod.rs
+++ b/crates/nook-core/src/process/mod.rs
@@ -1,0 +1,603 @@
+//! Local file-processing suite: convert, target-size, PDF compress, BG removal, OCR.
+//!
+//! Jobs are strictly user-triggered. The queue holds progress atomics so the
+//! island can paint while a job is live without a resident timer when idle.
+
+pub mod avconv;
+pub mod ffmpeg;
+pub mod imageconv;
+pub mod pdf;
+pub mod vision;
+
+use crate::files::{self, FileTrayItem};
+use crate::settings::{FileActionsSettings, PdfPreset};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+static NEXT_ID: AtomicU64 = AtomicU64::new(1);
+static QUEUE: OnceLock<Mutex<Vec<ProcessJob>>> = OnceLock::new();
+
+fn queue() -> &'static Mutex<Vec<ProcessJob>> {
+    QUEUE.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum JobKind {
+    Convert,
+    TargetSize,
+    CompressPdf,
+    RemoveBg,
+    Ocr,
+}
+
+impl JobKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Convert => "Convert",
+            Self::TargetSize => "Target size",
+            Self::CompressPdf => "Compress PDF",
+            Self::RemoveBg => "Remove BG",
+            Self::Ocr => "Copy Text",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[repr(u8)]
+pub enum JobStatus {
+    Queued,
+    Running,
+    Done,
+    Failed,
+    Cancelled,
+}
+
+impl JobStatus {
+    pub fn is_live(self) -> bool {
+        matches!(self, Self::Queued | Self::Running)
+    }
+
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Done | Self::Failed | Self::Cancelled)
+    }
+
+    /// Legal one-step transitions. Anything else is rejected by [`ProcessJob::set_status`].
+    pub fn can_transition(self, next: Self) -> bool {
+        matches!(
+            (self, next),
+            (Self::Queued, Self::Running)
+                | (Self::Queued, Self::Cancelled)
+                | (Self::Running, Self::Done)
+                | (Self::Running, Self::Failed)
+                | (Self::Running, Self::Cancelled)
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum JobParams {
+    Convert { format: String },
+    TargetSize { bytes: u64 },
+    CompressPdf { preset: PdfPreset },
+    RemoveBg,
+    Ocr,
+}
+
+impl JobParams {
+    pub fn kind(&self) -> JobKind {
+        match self {
+            Self::Convert { .. } => JobKind::Convert,
+            Self::TargetSize { .. } => JobKind::TargetSize,
+            Self::CompressPdf { .. } => JobKind::CompressPdf,
+            Self::RemoveBg => JobKind::RemoveBg,
+            Self::Ocr => JobKind::Ocr,
+        }
+    }
+}
+
+pub struct ProcessJob {
+    pub id: u64,
+    pub kind: JobKind,
+    pub input: PathBuf,
+    pub output: Option<PathBuf>,
+    pub progress: Arc<AtomicU8>,
+    pub status: JobStatus,
+    pub message: String,
+    pub cancel: Arc<AtomicBool>,
+}
+
+impl ProcessJob {
+    fn new(kind: JobKind, input: PathBuf) -> Self {
+        Self {
+            id: NEXT_ID.fetch_add(1, Ordering::Relaxed),
+            kind,
+            input,
+            output: None,
+            progress: Arc::new(AtomicU8::new(0)),
+            status: JobStatus::Queued,
+            message: String::new(),
+            cancel: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    pub fn set_status(&mut self, next: JobStatus) -> bool {
+        if !self.status.can_transition(next) {
+            return false;
+        }
+        self.status = next;
+        true
+    }
+}
+
+/// UI-safe snapshot (progress is a plain byte, not an atomic).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JobSnapshot {
+    pub id: u64,
+    pub kind: JobKind,
+    pub input: PathBuf,
+    pub output: Option<PathBuf>,
+    pub progress: u8,
+    pub status: JobStatus,
+    pub message: String,
+}
+
+impl From<&ProcessJob> for JobSnapshot {
+    fn from(job: &ProcessJob) -> Self {
+        Self {
+            id: job.id,
+            kind: job.kind,
+            input: job.input.clone(),
+            output: job.output.clone(),
+            progress: job.progress.load(Ordering::Relaxed),
+            status: job.status,
+            message: job.message.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct JobResult {
+    pub output: Option<PathBuf>,
+    pub hud: String,
+    pub insert_tray: bool,
+}
+
+pub fn enqueue(kind: JobKind, input: PathBuf) -> JobSnapshot {
+    let job = ProcessJob::new(kind, input);
+    let snap = JobSnapshot::from(&job);
+    if let Ok(mut q) = queue().lock() {
+        q.push(job);
+        if q.len() > 32 {
+            q.retain(|j| j.status.is_live() || j.id == snap.id);
+        }
+    }
+    snap
+}
+
+pub fn snapshot_jobs() -> Vec<JobSnapshot> {
+    queue()
+        .lock()
+        .map(|q| q.iter().map(JobSnapshot::from).collect())
+        .unwrap_or_default()
+}
+
+pub fn live_job() -> Option<JobSnapshot> {
+    snapshot_jobs().into_iter().rev().find(|j| j.status.is_live())
+}
+
+pub fn any_live() -> bool {
+    queue()
+        .lock()
+        .map(|q| q.iter().any(|j| j.status.is_live()))
+        .unwrap_or(false)
+}
+
+pub fn cancel(id: u64) -> bool {
+    let Ok(mut q) = queue().lock() else {
+        return false;
+    };
+    let Some(job) = q.iter_mut().find(|j| j.id == id) else {
+        return false;
+    };
+    job.cancel.store(true, Ordering::SeqCst);
+    if job.status == JobStatus::Queued {
+        job.set_status(JobStatus::Cancelled);
+    }
+    true
+}
+
+fn with_job(id: u64, f: impl FnOnce(&mut ProcessJob)) {
+    if let Ok(mut q) = queue().lock() {
+        if let Some(job) = q.iter_mut().find(|j| j.id == id) {
+            f(job);
+        }
+    }
+}
+
+/// Blocking worker. Call from `cx.background_executor`, never the UI tick.
+pub fn run_job(id: u64, params: JobParams, settings: &FileActionsSettings) -> Result<JobResult, String> {
+    if !settings.enabled {
+        return Err("File actions are disabled in Settings".into());
+    }
+    let input = {
+        let Ok(q) = queue().lock() else {
+            return Err("job queue unavailable".into());
+        };
+        let job = q.iter().find(|j| j.id == id).ok_or("job not found")?;
+        if job.cancel.load(Ordering::SeqCst) {
+            return Err("cancelled".into());
+        }
+        job.input.clone()
+    };
+    with_job(id, |job| {
+        let _ = job.set_status(JobStatus::Running);
+        job.progress.store(5, Ordering::Relaxed);
+    });
+
+    let activity = UserActivity::begin();
+    let progress = progress_handle(id);
+    let cancel = cancel_handle(id);
+    let result = dispatch(&input, &params, settings, &progress, &cancel);
+    drop(activity);
+
+    match result {
+        Ok(done) => {
+            with_job(id, |job| {
+                job.output = done.output.clone();
+                job.message = done.hud.clone();
+                job.progress.store(100, Ordering::Relaxed);
+                let _ = job.set_status(JobStatus::Done);
+            });
+            Ok(done)
+        }
+        Err(err) => {
+            let cancelled = cancel.load(Ordering::SeqCst) || err == "cancelled";
+            with_job(id, |job| {
+                job.message = err.clone();
+                let _ = job.set_status(if cancelled {
+                    JobStatus::Cancelled
+                } else {
+                    JobStatus::Failed
+                });
+            });
+            if cancelled {
+                cleanup_partial(id);
+                Err("cancelled".into())
+            } else {
+                Err(err)
+            }
+        }
+    }
+}
+
+fn progress_handle(id: u64) -> Arc<AtomicU8> {
+    queue()
+        .lock()
+        .ok()
+        .and_then(|q| q.iter().find(|j| j.id == id).map(|j| j.progress.clone()))
+        .unwrap_or_else(|| Arc::new(AtomicU8::new(0)))
+}
+
+fn cancel_handle(id: u64) -> Arc<AtomicBool> {
+    queue()
+        .lock()
+        .ok()
+        .and_then(|q| q.iter().find(|j| j.id == id).map(|j| j.cancel.clone()))
+        .unwrap_or_else(|| Arc::new(AtomicBool::new(false)))
+}
+
+fn cleanup_partial(id: u64) {
+    let output = queue()
+        .lock()
+        .ok()
+        .and_then(|q| q.iter().find(|j| j.id == id).and_then(|j| j.output.clone()));
+    if let Some(path) = output {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn dispatch(
+    input: &Path,
+    params: &JobParams,
+    settings: &FileActionsSettings,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<JobResult, String> {
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    match params {
+        JobParams::Convert { format } => {
+            let out = output_path(input, format, settings, None)?;
+            convert_any(input, &out, format, settings, progress, cancel)?;
+            Ok(saved(out))
+        }
+        JobParams::TargetSize { bytes } => {
+            let out = output_path(input, "mp4", settings, Some(*bytes))?;
+            avconv::encode_target_size(input, &out, *bytes, settings, progress, cancel)?;
+            Ok(saved(out))
+        }
+        JobParams::CompressPdf { preset } => {
+            let out = output_path(input, "pdf", settings, None)?;
+            pdf::compress(input, &out, *preset, settings, progress, cancel)?;
+            Ok(saved(out))
+        }
+        JobParams::RemoveBg => {
+            let out = output_path(input, "png", settings, Some(0))?;
+            vision::remove_background(input, &out, progress, cancel)?;
+            Ok(saved(out))
+        }
+        JobParams::Ocr => {
+            let text = vision::ocr(input, progress, cancel)?;
+            let chars = text.chars().count();
+            vision::copy_to_clipboard(&text)?;
+            progress.store(100, Ordering::Relaxed);
+            Ok(JobResult {
+                output: None,
+                hud: format!("Copied {chars} chars"),
+                insert_tray: false,
+            })
+        }
+    }
+}
+
+fn convert_any(
+    input: &Path,
+    output: &Path,
+    format: &str,
+    settings: &FileActionsSettings,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    let mime = files::mime_from_path(&input.to_string_lossy());
+    match mime.as_str() {
+        "image" => imageconv::convert(input, output, format, settings.jpeg_quality, progress, cancel),
+        "video" | "audio" => avconv::convert(input, output, format, settings, progress, cancel),
+        "pdf" if format.eq_ignore_ascii_case("pdf") => {
+            pdf::compress(input, output, settings.pdf_preset, settings, progress, cancel)
+        }
+        other => Err(format!("cannot convert {other} to {format}")),
+    }
+}
+
+fn saved(out: PathBuf) -> JobResult {
+    let name = out
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "file".into());
+    JobResult {
+        output: Some(out),
+        hud: format!("Saved {name}"),
+        insert_tray: true,
+    }
+}
+
+/// Alongside the source, or the configured folder. Never overwrites: `-1`, `-2`, …
+pub fn output_path(
+    input: &Path,
+    ext: &str,
+    settings: &FileActionsSettings,
+    size_hint: Option<u64>,
+) -> Result<PathBuf, String> {
+    let dir = match settings.output_folder.as_deref() {
+        Some(folder) if !folder.is_empty() => PathBuf::from(folder),
+        _ => input
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from(".")),
+    };
+    std::fs::create_dir_all(&dir).map_err(|e| format!("output folder: {e}"))?;
+    let stem = input
+        .file_stem()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "nook".into());
+    let suffix = match size_hint {
+        Some(0) => "-nobg".into(),
+        Some(bytes) if bytes >= 1024 * 1024 && bytes % (1024 * 1024) == 0 => {
+            format!("-{}MB", bytes / (1024 * 1024))
+        }
+        Some(bytes) => format!("-{}", files::format_size(bytes as i64).replace(' ', "")),
+        None => String::new(),
+    };
+    let ext = ext.trim_start_matches('.').to_ascii_lowercase();
+    let mut candidate = dir.join(format!("{stem}{suffix}.{ext}"));
+    if candidate == input {
+        candidate = dir.join(format!("{stem}-converted.{ext}"));
+    }
+    let mut n = 1u32;
+    while candidate.exists() {
+        candidate = dir.join(format!("{stem}{suffix}-{n}.{ext}"));
+        n += 1;
+        if n > 999 {
+            return Err("too many existing outputs".into());
+        }
+    }
+    Ok(candidate)
+}
+
+pub fn insert_output(path: &Path) -> Result<FileTrayItem, String> {
+    files::add_dropped_path(&path.to_string_lossy())
+}
+
+/// Screen-region OCR via `/usr/sbin/screencapture -i`. Degrades without Screen Recording TCC.
+pub fn ocr_screen_region(
+    settings: &FileActionsSettings,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<JobResult, String> {
+    if !settings.enabled {
+        return Err("File actions are disabled in Settings".into());
+    }
+    let text = vision::ocr_screen_region(progress, cancel)?;
+    let chars = text.chars().count();
+    vision::copy_to_clipboard(&text)?;
+    Ok(JobResult {
+        output: None,
+        hud: format!("Copied {chars} chars"),
+        insert_tray: false,
+    })
+}
+
+/// Keep App Nap from throttling a long encode. No-op off macOS.
+struct UserActivity {
+    #[cfg(target_os = "macos")]
+    token: Option<*mut objc2::runtime::AnyObject>,
+}
+
+impl UserActivity {
+    fn begin() -> Self {
+        #[cfg(target_os = "macos")]
+        {
+            use objc2::runtime::AnyObject;
+            use objc2::*;
+            // NSActivityUserInitiated = 0x00FFFFFF
+            let token: *mut AnyObject = unsafe {
+                let info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+                let reason: *mut AnyObject =
+                    msg_send![class!(NSString), stringWithUTF8String: c"nook file-process".as_ptr()];
+                msg_send![info, beginActivityWithOptions: 0x00FFFFFFu64, reason: reason]
+            };
+            Self {
+                token: if token.is_null() { None } else { Some(token) },
+            }
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Self {}
+        }
+    }
+}
+
+impl Drop for UserActivity {
+    fn drop(&mut self) {
+        #[cfg(target_os = "macos")]
+        {
+            use objc2::runtime::AnyObject;
+            use objc2::*;
+            if let Some(token) = self.token {
+                unsafe {
+                    let info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+                    let _: () = msg_send![info, endActivity: token];
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_settings() -> FileActionsSettings {
+        FileActionsSettings::default()
+    }
+
+    #[test]
+    fn status_machine_allows_only_forward_edges() {
+        assert!(JobStatus::Queued.can_transition(JobStatus::Running));
+        assert!(JobStatus::Queued.can_transition(JobStatus::Cancelled));
+        assert!(JobStatus::Running.can_transition(JobStatus::Done));
+        assert!(JobStatus::Running.can_transition(JobStatus::Failed));
+        assert!(JobStatus::Running.can_transition(JobStatus::Cancelled));
+        assert!(!JobStatus::Queued.can_transition(JobStatus::Done));
+        assert!(!JobStatus::Done.can_transition(JobStatus::Running));
+        assert!(!JobStatus::Failed.can_transition(JobStatus::Queued));
+        assert!(!JobStatus::Cancelled.can_transition(JobStatus::Running));
+        assert!(!JobStatus::Done.can_transition(JobStatus::Failed));
+    }
+
+    #[test]
+    fn enqueue_run_and_cancel_follow_the_machine() {
+        let snap = enqueue(JobKind::Ocr, PathBuf::from("/tmp/shot.png"));
+        assert_eq!(snap.status, JobStatus::Queued);
+        assert_eq!(snap.kind, JobKind::Ocr);
+        assert!(snap.status.is_live());
+
+        with_job(snap.id, |job| {
+            assert!(job.set_status(JobStatus::Running));
+            assert!(!job.set_status(JobStatus::Queued));
+            assert!(job.set_status(JobStatus::Cancelled));
+            assert!(!job.set_status(JobStatus::Done));
+        });
+        let after = snapshot_jobs()
+            .into_iter()
+            .find(|j| j.id == snap.id)
+            .unwrap();
+        assert_eq!(after.status, JobStatus::Cancelled);
+        assert!(after.status.is_terminal());
+    }
+
+    #[test]
+    fn cancel_queued_job_marks_cancelled() {
+        let snap = enqueue(JobKind::Convert, PathBuf::from("/tmp/a.png"));
+        assert!(cancel(snap.id));
+        let after = snapshot_jobs()
+            .into_iter()
+            .find(|j| j.id == snap.id)
+            .unwrap();
+        assert_eq!(after.status, JobStatus::Cancelled);
+    }
+
+    #[test]
+    fn output_path_avoids_overwrite_and_honours_folder() {
+        let dir = std::env::temp_dir().join(format!("nook-process-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let input = dir.join("clip.mov");
+        let _ = std::fs::write(&input, b"x");
+        let mut settings = empty_settings();
+        settings.output_folder = Some(dir.to_string_lossy().into_owned());
+
+        let first = output_path(&input, "mp4", &settings, Some(8 * 1024 * 1024)).unwrap();
+        assert_eq!(first.file_name().unwrap(), "clip-8MB.mp4");
+        let _ = std::fs::write(&first, b"y");
+        let second = output_path(&input, "mp4", &settings, Some(8 * 1024 * 1024)).unwrap();
+        assert_eq!(second.file_name().unwrap(), "clip-8MB-1.mp4");
+
+        let alongside = output_path(&input, "png", &empty_settings(), Some(0)).unwrap();
+        assert_eq!(alongside.parent(), input.parent());
+        assert!(alongside
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .contains("-nobg"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn job_params_map_to_kind() {
+        assert_eq!(
+            JobParams::Convert {
+                format: "png".into()
+            }
+            .kind(),
+            JobKind::Convert
+        );
+        assert_eq!(
+            JobParams::TargetSize { bytes: 8 }.kind(),
+            JobKind::TargetSize
+        );
+        assert_eq!(
+            JobParams::CompressPdf {
+                preset: PdfPreset::Screen
+            }
+            .kind(),
+            JobKind::CompressPdf
+        );
+        assert_eq!(JobParams::RemoveBg.kind(), JobKind::RemoveBg);
+        assert_eq!(JobParams::Ocr.kind(), JobKind::Ocr);
+    }
+
+    #[test]
+    fn disabled_settings_reject_work() {
+        let mut settings = empty_settings();
+        settings.enabled = false;
+        let snap = enqueue(JobKind::Ocr, PathBuf::from("/tmp/x.png"));
+        let err = run_job(snap.id, JobParams::Ocr, &settings).unwrap_err();
+        assert!(err.contains("disabled"));
+    }
+}

--- a/crates/nook-core/src/process/pdf.rs
+++ b/crates/nook-core/src/process/pdf.rs
@@ -1,0 +1,262 @@
+//! PDF compress via PDFKit (macOS 13+ JPEG/optimize), QuartzFilter fallback,
+//! then rasterize-as-last-resort. Never Ghostscript (AGPL) or qpdf.
+
+use crate::settings::{FileActionsSettings, PdfPreset};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+pub fn compress(
+    input: &Path,
+    output: &Path,
+    preset: PdfPreset,
+    settings: &FileActionsSettings,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    let _ = settings;
+    progress.store(10, Ordering::Relaxed);
+
+    #[cfg(target_os = "macos")]
+    {
+        return macos::compress(input, output, preset, progress, cancel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (input, output, preset);
+        Err("PDF compress needs PDFKit on macOS".into())
+    }
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use std::ffi::CString;
+
+    #[link(name = "PDFKit", kind = "framework")]
+    #[link(name = "Quartz", kind = "framework")]
+    extern "C" {}
+
+    fn ns_string(s: &str) -> *mut AnyObject {
+        let c = CString::new(s).unwrap_or_else(|_| CString::new("").unwrap());
+        unsafe { msg_send![class!(NSString), stringWithUTF8String: c.as_ptr()] }
+    }
+
+    fn ns_url(path: &Path) -> *mut AnyObject {
+        let s = ns_string(&path.to_string_lossy());
+        unsafe { msg_send![class!(NSURL), fileURLWithPath: s] }
+    }
+
+    fn os_major() -> u64 {
+        unsafe {
+            let info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+            let ver: *mut AnyObject = msg_send![info, operatingSystemVersion];
+            let _ = ver;
+            // operatingSystemVersion is a struct; read via NSOperatingSystemVersion fields
+            // through processInfo.operatingSystemVersionString as a fallback parse.
+            let s: *mut AnyObject = msg_send![info, operatingSystemVersionString];
+            let utf8: *const i8 = msg_send![s, UTF8String];
+            if utf8.is_null() {
+                return 13;
+            }
+            let text = std::ffi::CStr::from_ptr(utf8).to_string_lossy();
+            // "Version 14.6.1 (Build …)"
+            text.split_whitespace()
+                .find_map(|w| w.split('.').next()?.parse().ok())
+                .unwrap_or(13)
+        }
+    }
+
+    pub fn compress(
+        input: &Path,
+        output: &Path,
+        preset: PdfPreset,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        if cancel.load(Ordering::SeqCst) {
+            return Err("cancelled".into());
+        }
+        match preset {
+            PdfPreset::Raster => rasterize(input, output, progress, cancel),
+            PdfPreset::Screen | PdfPreset::Print => {
+                if os_major() >= 13 {
+                    if write_with_options(input, output, preset, progress).is_ok() {
+                        return Ok(());
+                    }
+                }
+                progress.store(40, Ordering::Relaxed);
+                if quartz_filter(input, output, progress).is_ok() {
+                    return Ok(());
+                }
+                progress.store(60, Ordering::Relaxed);
+                rasterize(input, output, progress, cancel)
+            }
+        }
+    }
+
+    fn write_with_options(
+        input: &Path,
+        output: &Path,
+        preset: PdfPreset,
+        progress: &AtomicU8,
+    ) -> Result<(), String> {
+        unsafe {
+            let url = ns_url(input);
+            let doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let doc: *mut AnyObject = msg_send![doc, initWithURL: url];
+            if doc.is_null() {
+                return Err("PDFKit could not open the document".into());
+            }
+            progress.store(35, Ordering::Relaxed);
+            let jpeg = ns_string("PDFDocumentSaveImagesAsJPEGOption");
+            let optimize = ns_string("PDFDocumentOptimizeImagesForScreenOption");
+            let yes: *mut AnyObject = msg_send![class!(NSNumber), numberWithBool: true];
+            let keys = [jpeg, optimize];
+            let vals = [yes, yes];
+            let opts: *mut AnyObject = msg_send![
+                class!(NSDictionary),
+                dictionaryWithObjects: vals.as_ptr(),
+                forKeys: keys.as_ptr(),
+                count: if matches!(preset, PdfPreset::Screen) { 2usize } else { 1usize }
+            ];
+            let out = ns_url(output);
+            let ok: bool = msg_send![doc, writeToURL: out, withOptions: opts];
+            if !ok {
+                return Err("PDFKit write failed".into());
+            }
+            progress.store(100, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    fn quartz_filter(
+        input: &Path,
+        output: &Path,
+        progress: &AtomicU8,
+    ) -> Result<(), String> {
+        unsafe {
+            let filter_path = ns_string("/System/Library/Filters/Reduce File Size.qfilter");
+            let filter_url: *mut AnyObject = msg_send![class!(NSURL), fileURLWithPath: filter_path];
+            let filter: *mut AnyObject =
+                msg_send![class!(QuartzFilter), quartzFilterWithURL: filter_url];
+            if filter.is_null() {
+                return Err("QuartzFilter unavailable".into());
+            }
+            let url = ns_url(input);
+            let doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let doc: *mut AnyObject = msg_send![doc, initWithURL: url];
+            if doc.is_null() {
+                return Err("PDFKit could not open the document".into());
+            }
+            let key = ns_string("QuartzFilter");
+            let keys = [key];
+            let vals = [filter];
+            let opts: *mut AnyObject = msg_send![
+                class!(NSDictionary),
+                dictionaryWithObjects: vals.as_ptr(),
+                forKeys: keys.as_ptr(),
+                count: 1usize
+            ];
+            let out = ns_url(output);
+            let ok: bool = msg_send![doc, writeToURL: out, withOptions: opts];
+            if !ok {
+                return Err("QuartzFilter write failed".into());
+            }
+            progress.store(100, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    /// Last resort: render pages to JPEG and rebuild. Loses selectable text.
+    fn rasterize(
+        input: &Path,
+        output: &Path,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        unsafe {
+            let url = ns_url(input);
+            let doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let doc: *mut AnyObject = msg_send![doc, initWithURL: url];
+            if doc.is_null() {
+                return Err("PDFKit could not open the document".into());
+            }
+            let pages: usize = msg_send![doc, pageCount];
+            if pages == 0 {
+                return Err("empty PDF".into());
+            }
+            let out_doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let out_doc: *mut AnyObject = msg_send![out_doc, init];
+            if out_doc.is_null() {
+                return Err("PDFKit alloc failed".into());
+            }
+            for i in 0..pages {
+                if cancel.load(Ordering::SeqCst) {
+                    return Err("cancelled".into());
+                }
+                let page: *mut AnyObject = msg_send![doc, pageAtIndex: i];
+                if page.is_null() {
+                    continue;
+                }
+                // thumbnailOfSize: at ~120 dpi-ish; 612×792 letter @ 150 dpi ≈ 1275×1650
+                let size = CGSize {
+                    width: 1275.0,
+                    height: 1650.0,
+                };
+                let image: *mut AnyObject = msg_send![page, thumbnailOfSize: size, forBox: 0i64];
+                if image.is_null() {
+                    continue;
+                }
+                let new_page: *mut AnyObject = msg_send![class!(PDFPage), alloc];
+                let new_page: *mut AnyObject = msg_send![new_page, initWithImage: image];
+                if !new_page.is_null() {
+                    let _: () = msg_send![out_doc, insertPage: new_page, atIndex: i];
+                }
+                let pct = 20 + ((i + 1) * 70 / pages.max(1)) as u8;
+                progress.store(pct.min(95), Ordering::Relaxed);
+            }
+            let out = ns_url(output);
+            let ok: bool = msg_send![out_doc, writeToURL: out];
+            if !ok {
+                return Err("rasterized PDF write failed".into());
+            }
+            progress.store(100, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    #[repr(C)]
+    struct CGSize {
+        width: f64,
+        height: f64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_host_degrades_without_pdfkit() {
+        if cfg!(target_os = "macos") {
+            return;
+        }
+        let progress = AtomicU8::new(0);
+        let cancel = AtomicBool::new(false);
+        let err = compress(
+            Path::new("/tmp/doc.pdf"),
+            Path::new("/tmp/doc-out.pdf"),
+            PdfPreset::Screen,
+            &FileActionsSettings::default(),
+            &progress,
+            &cancel,
+        )
+        .unwrap_err();
+        assert!(err.to_ascii_lowercase().contains("pdfkit") || err.contains("macOS"));
+    }
+}

--- a/crates/nook-core/src/process/pdf.rs
+++ b/crates/nook-core/src/process/pdf.rs
@@ -33,8 +33,9 @@ pub fn compress(
 #[cfg(target_os = "macos")]
 mod macos {
     use super::*;
+    use crate::notch::CGSize;
     use objc2::runtime::AnyObject;
-    use objc2::*;
+    use objc2::{class, msg_send};
     use std::ffi::CString;
 
     #[link(name = "PDFKit", kind = "framework")]
@@ -228,12 +229,6 @@ mod macos {
             progress.store(100, Ordering::Relaxed);
             Ok(())
         }
-    }
-
-    #[repr(C)]
-    struct CGSize {
-        width: f64,
-        height: f64,
     }
 }
 

--- a/crates/nook-core/src/process/vision.rs
+++ b/crates/nook-core/src/process/vision.rs
@@ -1,0 +1,561 @@
+//! Background removal (Vision) and OCR (Vision + PDFKit).
+//!
+//! macOS 14+: `VNGenerateForegroundInstanceMaskRequest` (any salient object).
+//! macOS 12–13: `VNGeneratePersonSegmentationRequest` — persons only.
+//! OCR: `VNRecognizeTextRequest`. PDFs try `PDFDocument.string` first.
+//! Screen-region OCR uses `/usr/sbin/screencapture -i` and degrades without
+//! Screen Recording TCC.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
+
+pub fn remove_background(
+    input: &Path,
+    output: &Path,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<(), String> {
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(8, Ordering::Relaxed);
+    #[cfg(target_os = "macos")]
+    {
+        return macos::remove_background(input, output, progress, cancel);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = (input, output);
+        Err("background removal needs Vision on macOS".into())
+    }
+}
+
+pub fn ocr(
+    input: &Path,
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<String, String> {
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    progress.store(8, Ordering::Relaxed);
+    let ext = input
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if ext == "pdf" {
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(text) = macos::pdf_embedded_text(input) {
+                if !text.trim().is_empty() {
+                    progress.store(100, Ordering::Relaxed);
+                    return Ok(text);
+                }
+            }
+            return macos::ocr_pdf_pages(input, progress, cancel);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            return Err("PDF OCR needs PDFKit on macOS".into());
+        }
+    }
+    #[cfg(target_os = "macos")]
+    {
+        macos::ocr_image(input, progress)
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = input;
+        Err("image OCR needs Vision on macOS".into())
+    }
+}
+
+/// Interactive region picker. Returns a clear error when Screen Recording TCC
+/// is denied or `screencapture` exits non-zero.
+pub fn ocr_screen_region(
+    progress: &AtomicU8,
+    cancel: &AtomicBool,
+) -> Result<String, String> {
+    if cancel.load(Ordering::SeqCst) {
+        return Err("cancelled".into());
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = progress;
+        return Err("screen OCR needs macOS screencapture".into());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let tmp = std::env::temp_dir().join(format!("nook-ocr-{}.png", std::process::id()));
+        let status = std::process::Command::new("/usr/sbin/screencapture")
+            .args(["-i", "-x", "-t", "png", &tmp.to_string_lossy()])
+            .status()
+            .map_err(|e| format!("screencapture: {e}"))?;
+        if !status.success() {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(
+                "Screen Recording permission is required for region OCR (System Settings → Privacy)"
+                    .into(),
+            );
+        }
+        if !tmp.is_file() {
+            return Err("capture cancelled".into());
+        }
+        progress.store(40, Ordering::Relaxed);
+        let result = macos::ocr_image(&tmp, progress);
+        let _ = std::fs::remove_file(&tmp);
+        result
+    }
+}
+
+pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    #[cfg(target_os = "macos")]
+    {
+        return macos::copy_to_clipboard(text);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = text;
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "macos")]
+pub fn persons_only() -> bool {
+    macos::os_major() < 14
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn persons_only() -> bool {
+    true
+}
+
+#[cfg(target_os = "macos")]
+mod macos {
+    use super::*;
+    use objc2::runtime::AnyObject;
+    use objc2::*;
+    use std::ffi::CString;
+
+    #[link(name = "Vision", kind = "framework")]
+    #[link(name = "CoreImage", kind = "framework")]
+    #[link(name = "PDFKit", kind = "framework")]
+    #[link(name = "AppKit", kind = "framework")]
+    extern "C" {}
+
+    pub fn os_major() -> u64 {
+        unsafe {
+            let info: *mut AnyObject = msg_send![class!(NSProcessInfo), processInfo];
+            let s: *mut AnyObject = msg_send![info, operatingSystemVersionString];
+            let utf8: *const i8 = msg_send![s, UTF8String];
+            if utf8.is_null() {
+                return 13;
+            }
+            let text = std::ffi::CStr::from_ptr(utf8).to_string_lossy();
+            text.split_whitespace()
+                .find_map(|w| w.split('.').next()?.parse().ok())
+                .unwrap_or(13)
+        }
+    }
+
+    fn ns_string(s: &str) -> *mut AnyObject {
+        let c = CString::new(s).unwrap_or_else(|_| CString::new("").unwrap());
+        unsafe { msg_send![class!(NSString), stringWithUTF8String: c.as_ptr()] }
+    }
+
+    fn ns_url(path: &Path) -> *mut AnyObject {
+        let s = ns_string(&path.to_string_lossy());
+        unsafe { msg_send![class!(NSURL), fileURLWithPath: s] }
+    }
+
+    pub fn pdf_embedded_text(input: &Path) -> Option<String> {
+        unsafe {
+            let url = ns_url(input);
+            let doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let doc: *mut AnyObject = msg_send![doc, initWithURL: url];
+            if doc.is_null() {
+                return None;
+            }
+            let s: *mut AnyObject = msg_send![doc, string];
+            ns_to_string(s)
+        }
+    }
+
+    pub fn ocr_pdf_pages(
+        input: &Path,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<String, String> {
+        unsafe {
+            let url = ns_url(input);
+            let doc: *mut AnyObject = msg_send![class!(PDFDocument), alloc];
+            let doc: *mut AnyObject = msg_send![doc, initWithURL: url];
+            if doc.is_null() {
+                return Err("PDFKit could not open the document".into());
+            }
+            let pages: usize = msg_send![doc, pageCount];
+            let mut out = String::new();
+            for i in 0..pages {
+                if cancel.load(Ordering::SeqCst) {
+                    return Err("cancelled".into());
+                }
+                let page: *mut AnyObject = msg_send![doc, pageAtIndex: i];
+                if page.is_null() {
+                    continue;
+                }
+                let size = CGSize {
+                    width: 1700.0,
+                    height: 2200.0,
+                };
+                let image: *mut AnyObject = msg_send![page, thumbnailOfSize: size, forBox: 0i64];
+                if image.is_null() {
+                    continue;
+                }
+                if let Ok(text) = ocr_nsimage(image) {
+                    if !out.is_empty() {
+                        out.push('\n');
+                    }
+                    out.push_str(&text);
+                }
+                let pct = 20 + ((i + 1) * 70 / pages.max(1)) as u8;
+                progress.store(pct.min(99), Ordering::Relaxed);
+            }
+            progress.store(100, Ordering::Relaxed);
+            Ok(out)
+        }
+    }
+
+    pub fn ocr_image(input: &Path, progress: &AtomicU8) -> Result<String, String> {
+        progress.store(30, Ordering::Relaxed);
+        unsafe {
+            let url = ns_url(input);
+            let handler: *mut AnyObject = msg_send![class!(VNImageRequestHandler), alloc];
+            let handler: *mut AnyObject = msg_send![
+                handler,
+                initWithURL: url,
+                options: empty_dict()
+            ];
+            if handler.is_null() {
+                return Err("Vision could not open the image".into());
+            }
+            let text = perform_ocr(handler)?;
+            progress.store(100, Ordering::Relaxed);
+            Ok(text)
+        }
+    }
+
+    unsafe fn ocr_nsimage(image: *mut AnyObject) -> Result<String, String> {
+        let cg: *mut AnyObject = msg_send![image, CGImage];
+        if cg.is_null() {
+            return Err("no CGImage".into());
+        }
+        let handler: *mut AnyObject = msg_send![class!(VNImageRequestHandler), alloc];
+        let handler: *mut AnyObject =
+            msg_send![handler, initWithCGImage: cg, options: empty_dict()];
+        if handler.is_null() {
+            return Err("Vision handler".into());
+        }
+        perform_ocr(handler)
+    }
+
+    unsafe fn perform_ocr(handler: *mut AnyObject) -> Result<String, String> {
+        let req: *mut AnyObject = msg_send![class!(VNRecognizeTextRequest), alloc];
+        let req: *mut AnyObject = msg_send![req, init];
+        if req.is_null() {
+            return Err("VNRecognizeTextRequest".into());
+        }
+        // VNRequestTextRecognitionLevelAccurate = 0
+        let _: () = msg_send![req, setRecognitionLevel: 0i64];
+        let _: () = msg_send![req, setUsesLanguageCorrection: true];
+        if os_major() >= 13 {
+            let _: () = msg_send![req, setAutomaticallyDetectsLanguage: true];
+        }
+        let requests: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: req];
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let ok: bool = msg_send![handler, performRequests: requests, error: &mut err];
+        if !ok {
+            return Err("Vision text request failed".into());
+        }
+        let results: *mut AnyObject = msg_send![req, results];
+        if results.is_null() {
+            return Ok(String::new());
+        }
+        let count: usize = msg_send![results, count];
+        let mut text = String::new();
+        for i in 0..count {
+            let obs: *mut AnyObject = msg_send![results, objectAtIndex: i];
+            let cands: *mut AnyObject = msg_send![obs, topCandidates: 1usize];
+            if cands.is_null() {
+                continue;
+            }
+            let n: usize = msg_send![cands, count];
+            if n == 0 {
+                continue;
+            }
+            let cand: *mut AnyObject = msg_send![cands, objectAtIndex: 0usize];
+            let s: *mut AnyObject = msg_send![cand, string];
+            if let Some(line) = ns_to_string(s) {
+                if !text.is_empty() {
+                    text.push('\n');
+                }
+                text.push_str(&line);
+            }
+        }
+        Ok(text)
+    }
+
+    pub fn remove_background(
+        input: &Path,
+        output: &Path,
+        progress: &AtomicU8,
+        cancel: &AtomicBool,
+    ) -> Result<(), String> {
+        if cancel.load(Ordering::SeqCst) {
+            return Err("cancelled".into());
+        }
+        progress.store(20, Ordering::Relaxed);
+        unsafe {
+            let url = ns_url(input);
+            let handler: *mut AnyObject = msg_send![class!(VNImageRequestHandler), alloc];
+            let handler: *mut AnyObject =
+                msg_send![handler, initWithURL: url, options: empty_dict()];
+            if handler.is_null() {
+                return Err("Vision could not open the image".into());
+            }
+            if os_major() >= 14 {
+                lift_subject(handler, output, progress)
+            } else {
+                person_seg(handler, output, progress)
+            }
+        }
+    }
+
+    unsafe fn lift_subject(
+        handler: *mut AnyObject,
+        output: &Path,
+        progress: &AtomicU8,
+    ) -> Result<(), String> {
+        let req: *mut AnyObject = msg_send![class!(VNGenerateForegroundInstanceMaskRequest), alloc];
+        let req: *mut AnyObject = msg_send![req, init];
+        if req.is_null() {
+            return person_seg(handler, output, progress);
+        }
+        let requests: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: req];
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let ok: bool = msg_send![handler, performRequests: requests, error: &mut err];
+        if !ok {
+            return person_seg(handler, output, progress);
+        }
+        progress.store(70, Ordering::Relaxed);
+        let results: *mut AnyObject = msg_send![req, results];
+        let count: usize = if results.is_null() {
+            0
+        } else {
+            msg_send![results, count]
+        };
+        if count == 0 {
+            return Err("no subject to lift".into());
+        }
+        let obs: *mut AnyObject = msg_send![results, objectAtIndex: 0usize];
+        let instances: *mut AnyObject = msg_send![obs, allInstances];
+        let mut mask_err: *mut AnyObject = std::ptr::null_mut();
+        let buffer: *mut AnyObject = msg_send![
+            obs,
+            generateMaskedImageOfInstances: instances,
+            fromRequestHandler: handler,
+            croppedToInstancesExtent: true,
+            error: &mut mask_err
+        ];
+        if buffer.is_null() {
+            return Err("mask apply failed".into());
+        }
+        write_pixel_buffer_png(buffer, output)?;
+        progress.store(100, Ordering::Relaxed);
+        Ok(())
+    }
+
+    unsafe fn person_seg(
+        handler: *mut AnyObject,
+        output: &Path,
+        progress: &AtomicU8,
+    ) -> Result<(), String> {
+        let req: *mut AnyObject = msg_send![class!(VNGeneratePersonSegmentationRequest), alloc];
+        let req: *mut AnyObject = msg_send![req, init];
+        if req.is_null() {
+            return Err("person segmentation unavailable".into());
+        }
+        // VNGeneratePersonSegmentationRequestQualityLevelAccurate = 2
+        let _: () = msg_send![req, setQualityLevel: 2i64];
+        let requests: *mut AnyObject = msg_send![class!(NSArray), arrayWithObject: req];
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let ok: bool = msg_send![handler, performRequests: requests, error: &mut err];
+        if !ok {
+            return Err("person segmentation failed (persons-only on macOS 12–13)".into());
+        }
+        progress.store(70, Ordering::Relaxed);
+        let results: *mut AnyObject = msg_send![req, results];
+        let count: usize = if results.is_null() {
+            0
+        } else {
+            msg_send![results, count]
+        };
+        if count == 0 {
+            return Err("no person in the image".into());
+        }
+        let obs: *mut AnyObject = msg_send![results, objectAtIndex: 0usize];
+        let mask: *mut AnyObject = msg_send![obs, pixelBuffer];
+        if mask.is_null() {
+            return Err("empty person mask".into());
+        }
+        blend_and_write(handler, mask, output)?;
+        progress.store(100, Ordering::Relaxed);
+        Ok(())
+    }
+
+    unsafe fn blend_and_write(
+        handler: *mut AnyObject,
+        mask: *mut AnyObject,
+        output: &Path,
+    ) -> Result<(), String> {
+        let src: *mut AnyObject = msg_send![class!(CIImage), imageWithCVPixelBuffer: {
+            let buf: *mut AnyObject = msg_send![handler, valueForKey: ns_string("pixelBuffer")];
+            buf
+        }];
+        // Prefer the original file via handler URL.
+        let url: *mut AnyObject = msg_send![handler, valueForKey: ns_string("imageURL")];
+        let image: *mut AnyObject = if !url.is_null() {
+            msg_send![class!(CIImage), imageWithContentsOfURL: url]
+        } else {
+            src
+        };
+        if image.is_null() {
+            return Err("CoreImage could not load the source".into());
+        }
+        let mask_ci: *mut AnyObject = msg_send![class!(CIImage), imageWithCVPixelBuffer: mask];
+        if mask_ci.is_null() {
+            return Err("mask CIImage".into());
+        }
+        let filter: *mut AnyObject =
+            msg_send![class!(CIFilter), filterWithName: ns_string("CIBlendWithMask")];
+        if filter.is_null() {
+            return Err("CIBlendWithMask".into());
+        }
+        let _: () = msg_send![filter, setValue: image, forKey: ns_string("inputImage")];
+        let _: () = msg_send![filter, setValue: mask_ci, forKey: ns_string("inputMaskImage")];
+        let out: *mut AnyObject = msg_send![filter, outputImage];
+        if out.is_null() {
+            return Err("blend produced no image".into());
+        }
+        write_ciimage_png(out, output)
+    }
+
+    unsafe fn write_pixel_buffer_png(
+        buffer: *mut AnyObject,
+        output: &Path,
+    ) -> Result<(), String> {
+        let image: *mut AnyObject = msg_send![class!(CIImage), imageWithCVPixelBuffer: buffer];
+        if image.is_null() {
+            return Err("CIImage from mask".into());
+        }
+        write_ciimage_png(image, output)
+    }
+
+    unsafe fn write_ciimage_png(image: *mut AnyObject, output: &Path) -> Result<(), String> {
+        let ctx: *mut AnyObject = msg_send![class!(CIContext), context];
+        if ctx.is_null() {
+            return Err("CIContext".into());
+        }
+        let color: *mut AnyObject =
+            msg_send![class!(CGColorSpace), createDeviceRGB];
+        let url = ns_url(output);
+        let format: i32 = 0x4247_5241; // kCIFormatBGRA8-ish; use PNG representation API
+        let mut err: *mut AnyObject = std::ptr::null_mut();
+        let ok: bool = msg_send![
+            ctx,
+            writePNGRepresentationOfImage: image,
+            toURL: url,
+            format: format,
+            colorSpace: color,
+            options: empty_dict(),
+            error: &mut err
+        ];
+        if !ok {
+            return Err("failed to write PNG".into());
+        }
+        Ok(())
+    }
+
+    pub fn copy_to_clipboard(text: &str) -> Result<(), String> {
+        unsafe {
+            let pb: *mut AnyObject = msg_send![class!(NSPasteboard), generalPasteboard];
+            if pb.is_null() {
+                return Err("pasteboard unavailable".into());
+            }
+            let _: isize = msg_send![pb, clearContents];
+            let s = ns_string(text);
+            let ty = ns_string("public.utf8-plain-text");
+            let ok: bool = msg_send![pb, setString: s, forType: ty];
+            if !ok {
+                return Err("could not copy text".into());
+            }
+            Ok(())
+        }
+    }
+
+    unsafe fn empty_dict() -> *mut AnyObject {
+        msg_send![class!(NSDictionary), dictionary]
+    }
+
+    fn ns_to_string(s: *mut AnyObject) -> Option<String> {
+        if s.is_null() {
+            return None;
+        }
+        unsafe {
+            let utf8: *const i8 = msg_send![s, UTF8String];
+            if utf8.is_null() {
+                return None;
+            }
+            Some(std::ffi::CStr::from_ptr(utf8).to_string_lossy().into_owned())
+        }
+    }
+
+    #[repr(C)]
+    struct CGSize {
+        width: f64,
+        height: f64,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn linux_host_degrades_vision() {
+        if cfg!(target_os = "macos") {
+            return;
+        }
+        let progress = AtomicU8::new(0);
+        let cancel = AtomicBool::new(false);
+        assert!(ocr(Path::new("/tmp/x.png"), &progress, &cancel).is_err());
+        assert!(ocr(Path::new("/tmp/x.pdf"), &progress, &cancel).is_err());
+        assert!(remove_background(
+            Path::new("/tmp/x.png"),
+            Path::new("/tmp/x-nobg.png"),
+            &progress,
+            &cancel
+        )
+        .is_err());
+        assert!(ocr_screen_region(&progress, &cancel).is_err());
+        assert!(persons_only());
+    }
+
+    #[test]
+    fn clipboard_is_a_no_op_off_macos() {
+        if cfg!(target_os = "macos") {
+            return;
+        }
+        assert!(copy_to_clipboard("hello").is_ok());
+    }
+}

--- a/crates/nook-core/src/process/vision.rs
+++ b/crates/nook-core/src/process/vision.rs
@@ -134,8 +134,9 @@ pub fn persons_only() -> bool {
 #[cfg(target_os = "macos")]
 mod macos {
     use super::*;
+    use crate::notch::CGSize;
     use objc2::runtime::AnyObject;
-    use objc2::*;
+    use objc2::{class, msg_send};
     use std::ffi::CString;
 
     #[link(name = "Vision", kind = "framework")]
@@ -518,12 +519,6 @@ mod macos {
             }
             Some(std::ffi::CStr::from_ptr(utf8).to_string_lossy().into_owned())
         }
-    }
-
-    #[repr(C)]
-    struct CGSize {
-        width: f64,
-        height: f64,
     }
 }
 

--- a/crates/nook-core/src/settings.rs
+++ b/crates/nook-core/src/settings.rs
@@ -17,10 +17,11 @@ pub enum WidgetModule {
     Speed = 7,
     Agents = 8,
     Mirror = 9,
+    Process = 10,
 }
 
 impl WidgetModule {
-    pub const ALL: [Self; 10] = [
+    pub const ALL: [Self; 11] = [
         Self::Calendar,
         Self::Music,
         Self::Files,
@@ -31,6 +32,7 @@ impl WidgetModule {
         Self::Speed,
         Self::Agents,
         Self::Mirror,
+        Self::Process,
     ];
 
     pub fn from_u8(value: u8) -> Self {
@@ -45,7 +47,7 @@ impl WidgetModule {
         match self {
             Self::Calendar | Self::Music => 5,
             Self::Files | Self::Notes | Self::Observe | Self::Reminders | Self::Agents => 4,
-            Self::Timers | Self::Speed | Self::Mirror => 3,
+            Self::Timers | Self::Speed | Self::Mirror | Self::Process => 3,
         }
     }
 
@@ -53,13 +55,13 @@ impl WidgetModule {
         match self {
             Self::Calendar => 4,
             Self::Music | Self::Files | Self::Observe | Self::Reminders | Self::Mirror => 3,
-            Self::Notes | Self::Timers | Self::Speed | Self::Agents => 2,
+            Self::Notes | Self::Timers | Self::Speed | Self::Agents | Self::Process => 2,
         }
     }
 
     pub fn max_cells(self) -> u8 {
         match self {
-            Self::Timers | Self::Speed | Self::Agents | Self::Mirror => 6,
+            Self::Timers | Self::Speed | Self::Agents | Self::Mirror | Self::Process => 6,
             _ => 8,
         }
     }
@@ -82,7 +84,101 @@ fn default_widget_order() -> Vec<WidgetModule> {
         WidgetModule::Timers,
         WidgetModule::Notes,
         WidgetModule::Speed,
+        WidgetModule::Process,
     ]
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum PdfPreset {
+    #[default]
+    Screen,
+    Print,
+    Raster,
+}
+
+impl PdfPreset {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Screen => "Screen",
+            Self::Print => "Print",
+            Self::Raster => "Raster",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FileActionsSettings {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Empty / `None` writes alongside the source.
+    #[serde(default)]
+    pub output_folder: Option<String>,
+    #[serde(default = "default_jpeg_quality")]
+    pub jpeg_quality: u8,
+    #[serde(default)]
+    pub pdf_preset: PdfPreset,
+    /// Only takes effect when a user-installed ffmpeg is on PATH. Never downloads.
+    #[serde(default)]
+    pub use_ffmpeg: bool,
+    #[serde(default = "default_image_format")]
+    pub default_image_format: String,
+    #[serde(default = "default_video_format")]
+    pub default_video_format: String,
+}
+
+fn default_jpeg_quality() -> u8 {
+    80
+}
+
+fn default_image_format() -> String {
+    "jpeg".into()
+}
+
+fn default_video_format() -> String {
+    "mp4".into()
+}
+
+impl Default for FileActionsSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            output_folder: None,
+            jpeg_quality: default_jpeg_quality(),
+            pdf_preset: PdfPreset::Screen,
+            use_ffmpeg: false,
+            default_image_format: default_image_format(),
+            default_video_format: default_video_format(),
+        }
+    }
+}
+
+impl FileActionsSettings {
+    pub fn ffmpeg_enabled(&self) -> bool {
+        self.use_ffmpeg && crate::process::ffmpeg::on_path()
+    }
+
+    pub fn output_is_downloads(&self) -> bool {
+        match self.output_folder.as_deref() {
+            Some(folder) => {
+                dirs::download_dir()
+                    .map(|d| d == std::path::Path::new(folder))
+                    .unwrap_or(false)
+                    || folder.ends_with("Downloads")
+            }
+            None => false,
+        }
+    }
+
+    pub fn set_alongside_source(&mut self) {
+        self.output_folder = None;
+    }
+
+    pub fn set_downloads(&mut self) {
+        self.output_folder = dirs::download_dir()
+            .or_else(dirs::home_dir)
+            .map(|p| p.to_string_lossy().into_owned());
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -142,6 +238,10 @@ pub struct AppSettings {
     pub show_files: bool,
     #[serde(default = "default_true")]
     pub show_mirror: bool,
+    #[serde(default = "default_true")]
+    pub show_process: bool,
+    #[serde(default)]
+    pub file_actions: FileActionsSettings,
     #[serde(default)]
     pub observe: ObserveConfig,
     #[serde(default)]
@@ -231,6 +331,8 @@ impl Default for AppSettings {
             show_speed: true,
             show_files: true,
             show_mirror: true,
+            show_process: true,
+            file_actions: FileActionsSettings::default(),
             observe: ObserveConfig::default(),
             liquid_glass_mode: false,
             non_notch_mode: false,
@@ -276,6 +378,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed,
             WidgetModule::Agents => self.show_agents,
             WidgetModule::Mirror => self.show_mirror,
+            WidgetModule::Process => self.show_process,
         }
     }
 
@@ -291,6 +394,7 @@ impl AppSettings {
             WidgetModule::Speed => self.show_speed = !self.show_speed,
             WidgetModule::Agents => self.show_agents = !self.show_agents,
             WidgetModule::Mirror => self.show_mirror = !self.show_mirror,
+            WidgetModule::Process => self.show_process = !self.show_process,
         }
     }
 
@@ -611,6 +715,11 @@ mod tests {
         assert!(parsed.show_speed);
         assert!(parsed.show_files);
         assert!(parsed.show_mirror);
+        assert!(parsed.show_process);
+        assert!(parsed.file_actions.enabled);
+        assert_eq!(parsed.file_actions.jpeg_quality, 80);
+        assert_eq!(parsed.file_actions.pdf_preset, PdfPreset::Screen);
+        assert!(!parsed.file_actions.use_ffmpeg);
         assert!(parsed.liquid_glass_mode);
         assert!(!parsed.non_notch_mode);
         assert!((parsed.island_x - 0.5).abs() < f32::EPSILON);
@@ -696,6 +805,7 @@ mod tests {
         settings.show_speed = false;
         settings.show_agents = false;
         settings.show_mirror = false;
+        settings.show_process = false;
         settings.set_cells(WidgetModule::Music, 5);
         assert_eq!(settings.used_cells(), 5);
         assert_eq!(settings.remaining_cells(), AppSettings::TOTAL_CELLS - 5);

--- a/crates/nook/src/island/compact.rs
+++ b/crates/nook/src/island/compact.rs
@@ -60,6 +60,7 @@ impl Island {
             CompactMode::Agents => widgets::agents_compact_left(&self.agents, self.pixel_t),
             CompactMode::Files => super::files::compact_left(&self.files),
             CompactMode::Timer => widgets::timer_compact_left(self, cx),
+            CompactMode::Process => widgets::process_compact_left(self),
             CompactMode::Observe => {
                 lucide("triangle-alert", theme::COMPACT_FACE).into_any_element()
             }
@@ -98,6 +99,7 @@ impl Island {
                     .text_right()
                     .into_any_element()
             }
+            CompactMode::Process => widgets::process_compact_right(self),
             CompactMode::Observe => {
                 let text = match self.observe.alerts.as_slice() {
                     [one] => one.name.clone(),
@@ -146,6 +148,7 @@ impl Island {
                 CompactMode::Agents => "agents",
                 CompactMode::Files => "files",
                 CompactMode::Timer => "timer",
+                CompactMode::Process => "process",
                 CompactMode::Observe => "observe",
                 CompactMode::Onboard => "onboard",
             };

--- a/crates/nook/src/island/expanded.rs
+++ b/crates/nook/src/island/expanded.rs
@@ -5,7 +5,8 @@ use super::{Island, Tab};
 use crate::icons::lucide_color;
 use crate::theme;
 use crate::widgets::{
-    agents_card, calendar_card, notes_card, observe_card, reminders_card, speed_card, timer_card,
+    agents_card, calendar_card, notes_card, observe_card, process_card, reminders_card, speed_card,
+    timer_card,
 };
 use gpui::{
     div, img, prelude::*, px, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
@@ -157,6 +158,17 @@ impl Island {
                         speed_card(self.speed_mbps, self.speed_progress, self.speed_running, cx),
                     ),
                 ),
+                WidgetModule::Process
+                    if self.settings.show_process && self.settings.file_actions.enabled =>
+                {
+                    add(
+                        &mut kids,
+                        cell_pane(
+                            self.settings.cells_for(module),
+                            process_card(self, cx),
+                        ),
+                    )
+                }
                 _ => {}
             }
         }

--- a/crates/nook/src/island/files.rs
+++ b/crates/nook/src/island/files.rs
@@ -8,7 +8,8 @@ use gpui::{
     div, img, prelude::*, px, rgb, rgba, AnyElement, Context, CursorStyle, FontWeight, MouseButton,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, ObjectFit, ScrollWheelEvent, SharedString,
 };
-use nook_core::files::FileTrayItem;
+use nook_core::files::{self, FileCapabilities, FileTrayItem};
+use nook_core::process::JobKind;
 use std::path::PathBuf;
 
 /// Dashed drop-zone chrome. Tiles are a compact horizontal row, not a grid.
@@ -185,6 +186,45 @@ fn airdrop_target(cx: &mut Context<Island>) -> impl IntoElement {
         )
 }
 
+fn process_drop_chip(
+    id: &'static str,
+    icon: &'static str,
+    caption: &'static str,
+    color: gpui::Rgba,
+    kind: JobKind,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    div()
+        .id(id)
+        .flex_shrink_0()
+        .h_full()
+        .w(px(112.))
+        .rounded(px(TRAY_ZONE_RADIUS))
+        .bg(color)
+        .flex()
+        .flex_col()
+        .items_center()
+        .justify_center()
+        .gap(px(8.))
+        .cursor(CursorStyle::PointingHand)
+        .hover(|s| s.opacity(0.92))
+        .can_drop(|drag: &dyn std::any::Any, _, _| {
+            drag.downcast_ref::<gpui::ExternalPaths>().is_some()
+        })
+        .on_drop(cx.listener(move |this, paths: &gpui::ExternalPaths, _, cx| {
+            cx.stop_propagation();
+            this.process_dropped_paths(paths, kind, cx);
+        }))
+        .child(lucide_color(icon, 22.0, rgb(0xffffff)))
+        .child(
+            div()
+                .text_size(px(13.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(rgb(0xffffff))
+                .child(caption),
+        )
+}
+
 fn is_pdf(file: &FileTrayItem) -> bool {
     file.mime_type.to_ascii_lowercase().contains("pdf")
         || file.name.to_ascii_lowercase().ends_with(".pdf")
@@ -225,8 +265,15 @@ fn file_preview(file: &FileTrayItem) -> impl IntoElement {
         })
 }
 
-fn file_card(file: &FileTrayItem, cx: &mut Context<Island>) -> impl IntoElement {
+fn file_card(
+    file: &FileTrayItem,
+    open: bool,
+    caps: FileCapabilities,
+    enabled: bool,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
     let path = file.path.clone();
+    let path_menu = file.path.clone();
     let name = file.name.clone();
 
     div()
@@ -243,6 +290,19 @@ fn file_card(file: &FileTrayItem, cx: &mut Context<Island>) -> impl IntoElement 
             cx.listener(move |this, _: &MouseDownEvent, _, cx| {
                 cx.stop_propagation();
                 this.arm_file_drag(path.clone());
+            }),
+        )
+        .on_mouse_down(
+            MouseButton::Right,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                if this.process_menu.as_deref() == Some(path_menu.as_str()) {
+                    this.process_menu = None;
+                } else {
+                    this.process_menu = Some(path_menu.clone());
+                    this.process_focus = Some(path_menu.clone());
+                }
+                cx.notify();
             }),
         )
         .on_mouse_move(cx.listener(|this, event: &MouseMoveEvent, window, cx| {
@@ -273,6 +333,68 @@ fn file_card(file: &FileTrayItem, cx: &mut Context<Island>) -> impl IntoElement 
                 .truncate()
                 .child(name),
         )
+        .when(open && enabled && caps.any(), |d| {
+            d.child(file_actions(file.path.clone(), caps, cx))
+        })
+}
+
+fn file_actions(
+    path: String,
+    caps: FileCapabilities,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let mut col = div().flex().flex_col().gap(px(2.)).w_full();
+    if caps.convert {
+        col = col.child(action_chip(&path, "Convert", JobKind::Convert, cx));
+    }
+    if caps.target_size {
+        col = col.child(action_chip(&path, "Target size", JobKind::TargetSize, cx));
+    }
+    if caps.compress_pdf {
+        col = col.child(action_chip(&path, "Compress PDF", JobKind::CompressPdf, cx));
+    }
+    if caps.remove_bg {
+        col = col.child(action_chip(&path, "Remove BG", JobKind::RemoveBg, cx));
+    }
+    if caps.ocr {
+        col = col.child(action_chip(&path, "Copy Text", JobKind::Ocr, cx));
+    }
+    col
+}
+
+fn action_chip(
+    path: &str,
+    caption: &'static str,
+    kind: JobKind,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let path = path.to_string();
+    div()
+        .id(SharedString::from(format!("act-{caption}-{path}")))
+        .w_full()
+        .h(px(18.))
+        .rounded(px(4.))
+        .bg(rgba(0xffffff1A))
+        .hover(|s| s.bg(rgba(0xffffff33)))
+        .cursor(CursorStyle::PointingHand)
+        .flex()
+        .items_center()
+        .justify_center()
+        .child(
+            div()
+                .text_size(px(9.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::LABEL)
+                .child(caption),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _: &MouseDownEvent, _, cx| {
+                cx.stop_propagation();
+                this.process_menu = None;
+                this.begin_kind_job(path.clone(), kind, cx);
+            }),
+        )
 }
 
 impl Island {
@@ -290,8 +412,12 @@ impl Island {
             .on_scroll_wheel(cx.listener(|_, _: &ScrollWheelEvent, _, cx| {
                 cx.stop_propagation();
             }));
+        let actions_on = self.settings.file_actions.enabled;
+        let ffmpeg = self.settings.file_actions.ffmpeg_enabled();
         for file in &self.files {
-            row = row.child(file_card(file, cx));
+            let open = self.process_menu.as_deref() == Some(file.path.as_str());
+            let caps = files::item_capabilities(file, ffmpeg);
+            row = row.child(file_card(file, open, caps, actions_on, cx));
         }
         if self.files.is_empty() {
             row = row.child(
@@ -342,9 +468,58 @@ impl Island {
 
         let mut pane = div().flex().size_full().gap(px(12.)).child(zone);
         if hot {
+            if self.settings.file_actions.enabled {
+                pane = pane.child(process_drop_chip(
+                    "convert-target",
+                    "image",
+                    "Convert",
+                    gpui::Rgba {
+                        r: 0.18,
+                        g: 0.55,
+                        b: 0.38,
+                        a: 1.0,
+                    },
+                    JobKind::Convert,
+                    cx,
+                ));
+                pane = pane.child(process_drop_chip(
+                    "ocr-target",
+                    "eye",
+                    "OCR",
+                    gpui::Rgba {
+                        r: 0.45,
+                        g: 0.28,
+                        b: 0.72,
+                        a: 1.0,
+                    },
+                    JobKind::Ocr,
+                    cx,
+                ));
+            }
             pane = pane.child(airdrop_target(cx));
         }
         pane
+    }
+
+    pub(super) fn process_dropped_paths(
+        &mut self,
+        paths: &gpui::ExternalPaths,
+        kind: JobKind,
+        cx: &mut Context<Self>,
+    ) {
+        for path in paths.paths() {
+            let raw = path.to_string_lossy().into_owned();
+            let resolved = nook_core::files::resolve_path(raw.clone()).unwrap_or(raw);
+            if let Ok(item) = nook_core::files::add_dropped_path(&resolved) {
+                if !self.files.iter().any(|f| f.path == item.path) {
+                    self.files.push(item);
+                }
+            }
+            self.begin_kind_job(resolved, kind, cx);
+        }
+        let _ = nook_core::files::save_file_tray(self.files.clone());
+        self.tab = Tab::Files;
+        cx.notify();
     }
 
     pub(super) fn file_layout(&self) -> (u16, f32) {

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -38,6 +38,7 @@ pub enum CompactMode {
     Files,
     Timer,
     Observe,
+    Process,
     Onboard,
 }
 
@@ -158,6 +159,11 @@ pub struct Island {
     pub(crate) mirror_on: bool,
     mirror_gen: u64,
     pub(crate) mirror_frame: Option<std::sync::Arc<gpui::RenderImage>>,
+    pub(crate) process_jobs: Vec<nook_core::process::JobSnapshot>,
+    pub(crate) process_hud: Option<(String, Instant)>,
+    pub(crate) process_focus: Option<String>,
+    pub(crate) process_menu: Option<String>,
+    last_process_sig: u64,
 }
 
 struct PendingFileDrag {
@@ -256,6 +262,11 @@ impl Island {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            process_jobs: Vec::new(),
+            process_hud: None,
+            process_focus: None,
+            process_menu: None,
+            last_process_sig: 0,
         };
         // Start at the compact idle size so the first paint isn't a jump.
         let (w, h) = this.target_size();
@@ -479,6 +490,26 @@ impl Island {
                         this.pixel_t = now.duration_since(this.pixel_origin).as_secs_f32();
                         dirty = true;
                     }
+                    if this.settings.file_actions.enabled {
+                        let jobs = nook_core::process::snapshot_jobs();
+                        let sig = jobs.iter().fold(0u64, |acc, j| {
+                            acc.wrapping_mul(33)
+                                .wrapping_add(j.id)
+                                .wrapping_add(j.progress as u64)
+                                .wrapping_add(j.status as u8 as u64)
+                        });
+                        if sig != this.last_process_sig {
+                            this.last_process_sig = sig;
+                            this.process_jobs = jobs;
+                            dirty = true;
+                        }
+                        if let Some((_, at)) = this.process_hud {
+                            if crate::widgets::process_hud_expired(at) {
+                                this.process_hud = None;
+                                dirty = true;
+                            }
+                        }
+                    }
                     if this.mirror_on {
                         if let Some((gen, bgra)) = platform::mirror_frame(this.mirror_gen) {
                             this.mirror_gen = gen;
@@ -493,6 +524,7 @@ impl Island {
                     if dirty {
                         cx.notify();
                     }
+                    let process_live = this.process_face_active();
                     let active = dirty
                         || this.hovered
                         || this.expanded
@@ -501,7 +533,8 @@ impl Island {
                         || this.pending_file_drag.is_some()
                         || this.mirror_on
                         || this.settings_open
-                        || any_working;
+                        || any_working
+                        || process_live;
                     // Media playing promotes itself through `dirty` (the
                     // visualizer levels change every frame), so it needs no
                     // term of its own here.
@@ -726,6 +759,13 @@ impl Island {
         .detach();
     }
 
+    fn process_face_active(&self) -> bool {
+        self.settings.file_actions.enabled
+            && (self.process_jobs.iter().any(|j| j.status.is_live())
+                || self.process_hud.is_some()
+                || nook_core::process::any_live())
+    }
+
     pub(crate) fn has_media(&self) -> bool {
         self.settings.show_media
             && (self.now_playing.is_playing
@@ -876,6 +916,9 @@ impl Island {
         }
         if self.settings.show_files && !self.files.is_empty() {
             modes.push(CompactMode::Files);
+        }
+        if self.process_face_active() {
+            modes.push(CompactMode::Process);
         }
         if self.first_run {
             modes.push(CompactMode::Onboard);
@@ -1494,6 +1537,11 @@ mod tests {
             mirror_on: false,
             mirror_gen: 0,
             mirror_frame: None,
+            process_jobs: Vec::new(),
+            process_hud: None,
+            process_focus: None,
+            process_menu: None,
+            last_process_sig: 0,
         }
     }
 
@@ -1759,6 +1807,28 @@ mod tests {
         assert_eq!(island.mode(), CompactMode::Observe);
         island.settings.show_observe = false;
         assert_eq!(island.available_modes(), vec![CompactMode::Idle]);
+    }
+
+    #[test]
+    fn available_modes_includes_process_while_a_job_or_hud_is_live() {
+        use nook_core::process::{JobKind, JobSnapshot, JobStatus};
+        let mut island = test_island();
+        assert!(!island.available_modes().contains(&CompactMode::Process));
+        island.process_jobs.push(JobSnapshot {
+            id: 1,
+            kind: JobKind::Convert,
+            input: "/tmp/a.png".into(),
+            output: None,
+            progress: 40,
+            status: JobStatus::Running,
+            message: String::new(),
+        });
+        assert!(island.available_modes().contains(&CompactMode::Process));
+        island.process_jobs.clear();
+        island.process_hud = Some(("Saved a.jpeg".into(), Instant::now()));
+        assert!(island.available_modes().contains(&CompactMode::Process));
+        island.settings.file_actions.enabled = false;
+        assert!(!island.available_modes().contains(&CompactMode::Process));
     }
 
     #[test]

--- a/crates/nook/src/island/settings.rs
+++ b/crates/nook/src/island/settings.rs
@@ -131,6 +131,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed Test",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Process => "Process",
         }
     }
 
@@ -146,6 +147,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "gauge",
             Self::Agents => "bot",
             Self::Mirror => "webcam",
+            Self::Process => "image",
         }
     }
 
@@ -161,6 +163,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Cloudflare".into(),
             Self::Agents => "Sessions".into(),
             Self::Mirror => "Camera".into(),
+            Self::Process => "Convert / OCR".into(),
         }
     }
 
@@ -184,6 +187,7 @@ impl WidgetModuleExt for WidgetModule {
             Self::Speed => "Speed",
             Self::Agents => "Agents",
             Self::Mirror => "Mirror",
+            Self::Process => "Process",
         }
     }
 }
@@ -569,7 +573,147 @@ impl SettingsView {
                         .into_any_element(),
                     ]),
                     Some("Hover the island to expand. Settings and Quit are in the menu bar extra."),
-                )),
+                ))
+                .child(self.file_actions_section(settings, cx)),
+        )
+    }
+
+    fn file_actions_section(
+        &self,
+        settings: &AppSettings,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let fa = &settings.file_actions;
+        let ffmpeg_present = nook_core::process::ffmpeg::on_path();
+        let ffmpeg_on = fa.use_ffmpeg && ffmpeg_present;
+        let jpeg = fa.jpeg_quality;
+        let preset = fa.pdf_preset;
+        let downloads = fa.output_is_downloads();
+        section(
+            "File Actions",
+            settings_group(vec![
+                toggle_row("Enable file actions", fa.enabled, cx, |s| {
+                    s.file_actions.enabled = !s.file_actions.enabled;
+                })
+                .into_any_element(),
+                settings_row("output-folder")
+                    .child(label("Output folder", theme::BODY, true))
+                    .child(
+                        segmented_group()
+                            .child(segment("Alongside", !downloads, cx, |_, _, cx| {
+                                nook_core::settings::tweak_app_settings(|s| {
+                                    s.file_actions.set_alongside_source();
+                                });
+                                cx.notify();
+                            }))
+                            .child(segment("Downloads", downloads, cx, |_, _, cx| {
+                                nook_core::settings::tweak_app_settings(|s| {
+                                    s.file_actions.set_downloads();
+                                });
+                                cx.notify();
+                            })),
+                    )
+                    .into_any_element(),
+                settings_row("jpeg-quality")
+                    .child(label("JPEG quality", theme::BODY, true))
+                    .child(
+                        segmented_group()
+                            .child(segment("60", jpeg <= 70, cx, |_, _, cx| {
+                                nook_core::settings::tweak_app_settings(|s| {
+                                    s.file_actions.jpeg_quality = 60;
+                                });
+                                cx.notify();
+                            }))
+                            .child(segment("80", jpeg > 70 && jpeg < 90, cx, |_, _, cx| {
+                                nook_core::settings::tweak_app_settings(|s| {
+                                    s.file_actions.jpeg_quality = 80;
+                                });
+                                cx.notify();
+                            }))
+                            .child(segment("95", jpeg >= 90, cx, |_, _, cx| {
+                                nook_core::settings::tweak_app_settings(|s| {
+                                    s.file_actions.jpeg_quality = 95;
+                                });
+                                cx.notify();
+                            })),
+                    )
+                    .into_any_element(),
+                settings_row("pdf-preset")
+                    .child(label("PDF preset", theme::BODY, true))
+                    .child(
+                        segmented_group()
+                            .child(segment(
+                                "Screen",
+                                preset == nook_core::settings::PdfPreset::Screen,
+                                cx,
+                                |_, _, cx| {
+                                    nook_core::settings::tweak_app_settings(|s| {
+                                        s.file_actions.pdf_preset =
+                                            nook_core::settings::PdfPreset::Screen;
+                                    });
+                                    cx.notify();
+                                },
+                            ))
+                            .child(segment(
+                                "Print",
+                                preset == nook_core::settings::PdfPreset::Print,
+                                cx,
+                                |_, _, cx| {
+                                    nook_core::settings::tweak_app_settings(|s| {
+                                        s.file_actions.pdf_preset =
+                                            nook_core::settings::PdfPreset::Print;
+                                    });
+                                    cx.notify();
+                                },
+                            ))
+                            .child(segment(
+                                "Raster",
+                                preset == nook_core::settings::PdfPreset::Raster,
+                                cx,
+                                |_, _, cx| {
+                                    nook_core::settings::tweak_app_settings(|s| {
+                                        s.file_actions.pdf_preset =
+                                            nook_core::settings::PdfPreset::Raster;
+                                    });
+                                    cx.notify();
+                                },
+                            )),
+                    )
+                    .into_any_element(),
+                settings_row("ffmpeg-toggle")
+                    .when(ffmpeg_present, |d| {
+                        d.cursor(CursorStyle::PointingHand).on_mouse_down(
+                            MouseButton::Left,
+                            cx.listener(|_, _, _, cx| {
+                                nook_core::settings::tweak_app_settings(|s| {
+                                    s.file_actions.use_ffmpeg = !s.file_actions.use_ffmpeg;
+                                });
+                                cx.notify();
+                            }),
+                        )
+                    })
+                    .child(
+                        div()
+                            .flex()
+                            .flex_col()
+                            .gap(px(1.))
+                            .child(label("Extended formats (ffmpeg)", theme::BODY, true))
+                            .child(label(
+                                if ffmpeg_present {
+                                    "User-installed ffmpeg on PATH"
+                                } else {
+                                    "Install ffmpeg yourself — Nook will not download it"
+                                },
+                                theme::SUBHEADLINE,
+                                false,
+                            )),
+                    )
+                    .child(toggle_knob(ffmpeg_on))
+                    .into_any_element(),
+            ]),
+            Some(
+                "Convert, target-size, PDF compress, background removal, and OCR. No MP3/Opus encode, mkv read, or webm/av1 write without your own ffmpeg. Target-size is ABR ±5%. Background removal is persons-only on macOS 12–13.",
+            ),
         )
     }
 
@@ -1356,6 +1500,9 @@ fn module_blurb(module: WidgetModule) -> SharedString {
             "Working coding-agent sessions on the compact face and expanded card.".into()
         }
         WidgetModule::Mirror => "A live camera preview that opens when you click the Mirror card.".into(),
+        WidgetModule::Process => {
+            "Convert, target-size, PDF compress, background removal, and OCR for files on the tray.".into()
+        }
     }
 }
 
@@ -1727,6 +1874,7 @@ mod tests {
                 "Speed Test",
                 "Agents",
                 "Mirror",
+                "Process",
             ]
         );
         assert!(!names

--- a/crates/nook/src/widgets/mod.rs
+++ b/crates/nook/src/widgets/mod.rs
@@ -5,6 +5,7 @@ mod calendar;
 mod notes;
 mod notes_editor;
 mod observe;
+mod process;
 mod reminders;
 mod speed;
 mod timers;
@@ -16,6 +17,10 @@ pub(crate) use calendar::calendar_card;
 pub(crate) use notes::notes_card;
 pub(crate) use notes_editor::{NotesEditor, NotesEditorEvent};
 pub(crate) use observe::{observe_card, ObserveHover};
+pub(crate) use process::{
+    compact_left as process_compact_left, compact_right as process_compact_right, process_card,
+    process_hud_expired,
+};
 pub(crate) use reminders::reminders_card;
 pub(crate) use speed::speed_card;
 pub(crate) use timers::{compact_left as timer_compact_left, timer_card};

--- a/crates/nook/src/widgets/process.rs
+++ b/crates/nook/src/widgets/process.rs
@@ -1,0 +1,397 @@
+//! File-processing job list + format / target-size pickers.
+
+use crate::icons::lucide_color;
+use crate::island::ui::{label, nook_empty, nook_pane};
+use crate::island::{CompactMode, Island};
+use crate::theme;
+use gpui::{
+    div, prelude::*, px, relative, rgba, Context, CursorStyle, FontWeight, MouseButton,
+    SharedString,
+};
+use nook_core::files::{self, FileCapabilities};
+use nook_core::process::{self, JobKind, JobParams, JobSnapshot, JobStatus};
+use nook_core::settings::PdfPreset;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+const TARGET_SIZES: [(&str, u64); 3] = [
+    ("8 MB", 8 * 1024 * 1024),
+    ("25 MB", 25 * 1024 * 1024),
+    ("50 MB", 50 * 1024 * 1024),
+];
+
+pub(crate) fn process_card(island: &Island, cx: &mut Context<Island>) -> impl IntoElement {
+    let jobs = &island.process_jobs;
+    let focus = island
+        .process_focus
+        .as_deref()
+        .and_then(|p| island.files.iter().find(|f| f.path == p));
+    let caps = focus
+        .map(|f| files::item_capabilities(f, island.settings.file_actions.ffmpeg_enabled()))
+        .unwrap_or_default();
+
+    let mut pane = nook_pane("nook-process").w_full().gap(px(6.));
+    if jobs.is_empty() && focus.is_none() {
+        return pane.child(nook_empty("files", "Drop a file, then Convert"));
+    }
+    if let Some(file) = focus {
+        pane = pane.child(picker_row(file.path.clone(), &file.mime_type, caps, cx));
+    }
+    if jobs.is_empty() {
+        return pane;
+    }
+    let mut list = div().flex().flex_col().w_full().gap(px(4.));
+    for job in jobs.iter().rev().take(6) {
+        list = list.child(job_row(job, cx));
+    }
+    pane.child(list)
+}
+
+fn picker_row(
+    path: String,
+    mime: &str,
+    caps: FileCapabilities,
+    cx: &mut Context<Island>,
+) -> impl IntoElement {
+    let mut row = div().flex().flex_col().gap(px(4.)).w_full();
+    if caps.convert {
+        let formats: &[&str] = if mime.starts_with("image") {
+            &["png", "jpeg", "webp"]
+        } else if mime.starts_with("audio") {
+            &["m4a", "wav"]
+        } else {
+            &["mp4", "mov"]
+        };
+        row = row.child(chip_row(
+            "fmt",
+            formats,
+            cx,
+            path.clone(),
+            |_p, fmt| JobParams::Convert {
+                format: fmt.to_string(),
+            },
+        ));
+    }
+    if caps.target_size {
+        let mut sizes = div().flex().gap(px(4.));
+        for (label, bytes) in TARGET_SIZES {
+            let p = path.clone();
+            sizes = sizes.child(chip(label, cx, move |this, cx| {
+                this.begin_process_job(
+                    p.clone(),
+                    JobParams::TargetSize { bytes },
+                    cx,
+                );
+            }));
+        }
+        row = row.child(sizes);
+    }
+    if caps.compress_pdf {
+        row = row.child(chip_row(
+            "pdf",
+            &["screen", "print", "raster"],
+            cx,
+            path.clone(),
+            |_, preset| JobParams::CompressPdf {
+                preset: match preset {
+                    "print" => PdfPreset::Print,
+                    "raster" => PdfPreset::Raster,
+                    _ => PdfPreset::Screen,
+                },
+            },
+        ));
+    }
+    row
+}
+
+fn chip_row(
+    id: &'static str,
+    labels: &[&'static str],
+    cx: &mut Context<Island>,
+    path: String,
+    param: impl Fn(String, &'static str) -> JobParams + 'static + Copy,
+) -> impl IntoElement {
+    let mut row = div().id(id).flex().gap(px(4.));
+    for label in labels {
+        let p = path.clone();
+        let l = *label;
+        row = row.child(chip(l, cx, move |this, cx| {
+            this.begin_process_job(p.clone(), param(p.clone(), l), cx);
+        }));
+    }
+    row
+}
+
+fn chip(
+    caption: &'static str,
+    cx: &mut Context<Island>,
+    on_click: impl Fn(&mut Island, &mut Context<Island>) + 'static,
+) -> impl IntoElement {
+    div()
+        .id(SharedString::from(format!("proc-chip-{caption}")))
+        .h(px(22.))
+        .px(px(8.))
+        .rounded(px(6.))
+        .bg(rgba(0xffffff1A))
+        .hover(|s| s.bg(rgba(0xffffff33)))
+        .cursor(CursorStyle::PointingHand)
+        .flex()
+        .items_center()
+        .child(
+            div()
+                .text_size(px(11.))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(theme::LABEL)
+                .child(caption),
+        )
+        .on_mouse_down(
+            MouseButton::Left,
+            cx.listener(move |this, _, _, cx| {
+                cx.stop_propagation();
+                on_click(this, cx);
+            }),
+        )
+}
+
+fn job_row(job: &JobSnapshot, cx: &mut Context<Island>) -> impl IntoElement {
+    let name = job
+        .input
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| job.kind.label().into());
+    let t = job.progress as f32 / 100.0;
+    let live = job.status.is_live();
+    let id = job.id;
+    div()
+        .id(SharedString::from(format!("job-{}", job.id)))
+        .flex()
+        .flex_col()
+        .gap(px(3.))
+        .child(
+            div()
+                .flex()
+                .items_center()
+                .justify_between()
+                .gap(px(8.))
+                .child(label(name, theme::CALLOUT, true))
+                .child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap(px(6.))
+                        .child(label(status_label(job), theme::CALLOUT, false))
+                        .when(live, |d| {
+                            d.child(
+                                div()
+                                    .id(SharedString::from(format!("job-x-{id}")))
+                                    .cursor(CursorStyle::PointingHand)
+                                    .on_mouse_down(
+                                        MouseButton::Left,
+                                        cx.listener(move |_, _, _, cx| {
+                                            cx.stop_propagation();
+                                            process::cancel(id);
+                                            cx.notify();
+                                        }),
+                                    )
+                                    .child(lucide_color("x", 12.0, theme::TERTIARY_LABEL)),
+                            )
+                        }),
+                ),
+        )
+        .child(
+            div()
+                .w_full()
+                .h(px(3.))
+                .rounded_full()
+                .overflow_hidden()
+                .bg(rgba(0xffffff26))
+                .child(
+                    div()
+                        .h_full()
+                        .w(relative(t.clamp(0.0, 1.0)))
+                        .rounded_full()
+                        .bg(match job.status {
+                            JobStatus::Failed => theme::DESTRUCTIVE,
+                            JobStatus::Done => theme::accent(),
+                            _ => theme::LABEL,
+                        }),
+                ),
+        )
+}
+
+fn status_label(job: &JobSnapshot) -> String {
+    match job.status {
+        JobStatus::Queued => "Queued".into(),
+        JobStatus::Running => format!("{}%", job.progress),
+        JobStatus::Done => "Done".into(),
+        JobStatus::Failed => "Failed".into(),
+        JobStatus::Cancelled => "Cancelled".into(),
+    }
+}
+
+pub(crate) fn compact_left(island: &Island) -> gpui::AnyElement {
+    use super::timers::timer_ring;
+    let progress = island
+        .process_jobs
+        .iter()
+        .rev()
+        .find(|j| j.status.is_live())
+        .map(|j| j.progress as f32 / 100.0)
+        .unwrap_or(1.0);
+    let done = island.process_hud.is_some() && !process::any_live();
+    div()
+        .size(px(24.))
+        .flex_shrink_0()
+        .flex()
+        .items_center()
+        .justify_center()
+        .child(timer_ring(
+            progress.clamp(0.0, 1.0),
+            24.0,
+            10.0,
+            3.0,
+            if done {
+                theme::accent()
+            } else {
+                gpui::rgb(0xffffff)
+            },
+            rgba(0xffffff40),
+        ))
+        .into_any_element()
+}
+
+pub(crate) fn compact_right(island: &Island) -> gpui::AnyElement {
+    if let Some((msg, _)) = island.process_hud.as_ref() {
+        return label(msg.clone(), theme::BODY, true).into_any_element();
+    }
+    let job = island
+        .process_jobs
+        .iter()
+        .rev()
+        .find(|j| j.status.is_live());
+    let text = job
+        .map(|j| format!("{}%", j.progress))
+        .unwrap_or_else(|| "…".into());
+    label(text, theme::BODY, true).into_any_element()
+}
+
+impl Island {
+    pub(crate) fn begin_process_job(
+        &mut self,
+        path: String,
+        params: JobParams,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.settings.file_actions.enabled {
+            self.show_process_hud("File actions off".into(), cx);
+            return;
+        }
+        self.process_focus = Some(path.clone());
+        self.preferred = Some(CompactMode::Process);
+        let kind = params.kind();
+        let snap = process::enqueue(kind, PathBuf::from(&path));
+        self.process_jobs = process::snapshot_jobs();
+        cx.notify();
+
+        let settings = self.settings.file_actions.clone();
+        let id = snap.id;
+        cx.spawn(async move |this, cx| {
+            let slot: Arc<Mutex<Option<Result<process::JobResult, String>>>> =
+                Arc::new(Mutex::new(None));
+            let done = Arc::new(AtomicBool::new(false));
+            let slot2 = slot.clone();
+            let done2 = done.clone();
+            let settings2 = settings.clone();
+            cx.background_executor()
+                .spawn(async move {
+                    let result = process::run_job(id, params, &settings2);
+                    if let Ok(mut guard) = slot2.lock() {
+                        *guard = Some(result);
+                    }
+                    done2.store(true, Ordering::SeqCst);
+                })
+                .detach();
+            loop {
+                let keep = this
+                    .update(cx, |this, cx| {
+                        this.process_jobs = process::snapshot_jobs();
+                        cx.notify();
+                        !done.load(Ordering::SeqCst)
+                    })
+                    .unwrap_or(false);
+                if !keep {
+                    break;
+                }
+                cx.background_executor()
+                    .timer(Duration::from_millis(80))
+                    .await;
+            }
+            this.update(cx, |this, cx| {
+                this.process_jobs = process::snapshot_jobs();
+                if let Ok(mut guard) = slot.lock() {
+                    match guard.take() {
+                        Some(Ok(result)) => {
+                            if result.insert_tray {
+                                if let Some(out) = result.output.as_ref() {
+                                    if let Ok(item) = process::insert_output(out) {
+                                        if !this.files.iter().any(|f| f.path == item.path) {
+                                            this.files.push(item);
+                                            let _ = files::save_file_tray(this.files.clone());
+                                        }
+                                    }
+                                }
+                            }
+                            this.show_process_hud(result.hud, cx);
+                        }
+                        Some(Err(err)) => this.show_process_hud(err, cx),
+                        None => {}
+                    }
+                }
+                cx.notify();
+            })
+            .ok();
+        })
+        .detach();
+    }
+
+    pub(crate) fn show_process_hud(&mut self, message: String, cx: &mut Context<Self>) {
+        self.process_hud = Some((message, Instant::now()));
+        self.preferred = Some(CompactMode::Process);
+        nook_core::haptics::trigger(Some(nook_core::haptics::HapticConfig {
+            pattern: nook_core::haptics::HapticPattern::Success,
+            intensity: 0.7,
+        }));
+        cx.notify();
+    }
+
+    pub(crate) fn begin_kind_job(&mut self, path: String, kind: JobKind, cx: &mut Context<Self>) {
+        let settings = &self.settings.file_actions;
+        let mime = files::mime_from_path(&path);
+        let params = match kind {
+            JobKind::Convert => JobParams::Convert {
+                format: if mime == "image" {
+                    settings.default_image_format.clone()
+                } else if mime == "audio" {
+                    "m4a".into()
+                } else {
+                    settings.default_video_format.clone()
+                },
+            },
+            JobKind::TargetSize => JobParams::TargetSize {
+                bytes: 8 * 1024 * 1024,
+            },
+            JobKind::CompressPdf => JobParams::CompressPdf {
+                preset: settings.pdf_preset,
+            },
+            JobKind::RemoveBg => JobParams::RemoveBg,
+            JobKind::Ocr => JobParams::Ocr,
+        };
+        self.begin_process_job(path, params, cx);
+    }
+}
+
+pub(crate) fn process_hud_expired(at: Instant) -> bool {
+    at.elapsed() >= Duration::from_millis(2500)
+}


### PR DESCRIPTION
## Summary

User-triggered file-processing suite for files dropped on the island: convert, video target-size, PDF compress, AI background removal, and OCR. System frameworks only in v1 — **no bundled ffmpeg**.

Implements [WP20](docs/CLOUD_AGENT_HANDOFF.md) from the cloud-agent handoff.

## What landed

- **`crates/nook-core/src/process/`** — job queue + imageconv (`image` crate + ImageIO HEIC), avconv (AVAssetReader/Writer + target-size bitrate math), pdf (PDFKit JPEG/optimize; QuartzFilter fallback; rasterize last resort), vision (VNGenerateForegroundInstanceMaskRequest macOS 14+, person-seg fallback, VNRecognizeTextRequest), ffmpeg.rs as a PATH presence wrapper only.
- **`files.rs`** — capability matrix per mime; processed outputs inserted into the tray.
- **Island file cards** — Convert / Target size / Compress PDF / Remove BG / Copy Text; Convert + OCR drop chips while dragging.
- **`widgets/process.rs`** — job list + progress via `cx.spawn` + `background_executor` (same pattern as speed.rs).
- Compact Live Activity while a job runs; completion HUD.
- Settings: enable, output folder (alongside / Downloads), JPEG quality, PDF preset, ffmpeg toggle that **only enables if a user-installed ffmpeg is on PATH** (no auto-download).
- OCR of dropped images/PDFs (`PDFKit.string` first). Optional screen-region OCR via `/usr/sbin/screencapture -i` degrades without Screen Recording TCC.

## Hard limits (v1)

- No MP3/Opus encode.
- No mkv read.
- No webm/av1 write without a user-installed ffmpeg.
- Target-size is ABR ±5% (4% undershoot + one retry; VideoToolbox has no two-pass).
- Background removal is persons-only on macOS 12–13 (`VNGeneratePersonSegmentationRequest`).
- Do **not** use Ghostscript (AGPL) or GPL ffmpeg. Do **not** download or bundle ffmpeg.
- AVIF encode is out of scope (ImageIO cannot encode it).

## Battery / GPUI

- Strictly user-triggered. No idle loops, no resident models, no `window.resize` in render.
- Progress UI dirties only while a job is live or the HUD is showing.
- `NSProcessInfo` UserInitiated activity around jobs so App Nap does not throttle them; ended immediately after.
- Settings toggle (File Actions).

## Tests

`cargo test -p nook -p nook-core` green on Linux:

- nook-core: 95 passed
- nook: 82 passed

Unit coverage: bitrate math, mime capability matrix (mkv/webm gated on ffmpeg), job state machine, PNG→JPEG convert, settings defaults, compact Process mode.

macOS APIs are `cfg`-gated. Host cannot compile-check AVFoundation / PDFKit / Vision `msg_send!` interop — that needs a macOS CI or local build.

## Files

18 files, +3513 / −14. Commit `ed4b4ed`.

## Follow-ups / blockers

- macOS compile + device smoke of AVAssetWriter pull-model, PDFKit write options, Vision mask/OCR, and ImageIO HEIC.
- Screen-region OCR needs Screen Recording TCC; unsigned/ad-hoc builds lose the grant on re-sign.
- Optional later: user-supplied LGPL ffmpeg for mkv/webm/mp3/opus (still no GPL statics, still no auto-download in this PR).