### PR TITLE
Stop Observe from polling warmUP every 5s without a token

### DIFF
--- a/crates/nook-core/src/observe.rs
+++ b/crates/nook-core/src/observe.rs
@@ -16,6 +16,8 @@ const MAX_ALERTS: usize = 8;
 const MAX_SERIES: usize = 3;
 const MAX_POINTS: usize = 48;
 const WARMUP_METRICS_PATH: &str = "/admin/metrics";
+const WARMUP_TOKEN_NEEDED: &str =
+    "warmUP /admin/metrics needs a bearer token (Settings or WARMUP_METRICS_TOKEN)";
 const CHART_POINTS: usize = 60;
 const STORE_SLACK_MS: u64 = 120_000;
 const DAY_MS: u64 = 24 * 60 * 60 * 1000;
@@ -376,7 +378,7 @@ pub struct SeriesValue {
     pub value: f64,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct FiringAlert {
     pub name: String,
     pub severity: String,
@@ -444,6 +446,24 @@ fn warmup_bearer(config: &ObserveConfig) -> Option<String> {
     is_warmup_url(&config.prometheus_url)
         .then(|| metrics_token(config))
         .filter(|token| !token.is_empty())
+}
+
+/// The approved warmUP origin requires a bearer. Hitting it without one is a
+/// guaranteed 401 — and the island retries that miss every 5s by default.
+fn missing_warmup_token(config: &ObserveConfig) -> bool {
+    is_warmup_url(&config.prometheus_url) && warmup_bearer(config).is_none()
+}
+
+/// Whether publishing `next` should dirty the island.
+///
+/// A stable disconnect (same error, still down, no alerts) must not trigger a
+/// Metal frame. The poll loop retries that path every 5s. Live data always
+/// repaints so sparklines keep moving.
+pub fn should_repaint(prev: &ObserveSnapshot, next: &ObserveSnapshot) -> bool {
+    if next.connected || prev.connected {
+        return true;
+    }
+    prev.error != next.error || prev.alerts != next.alerts
 }
 
 async fn response_text(response: reqwest::Response) -> Result<String, String> {
@@ -921,6 +941,12 @@ pub async fn poll(config: &ObserveConfig) -> ObserveSnapshot {
 }
 
 async fn poll_warmup(config: &ObserveConfig) -> ObserveSnapshot {
+    if missing_warmup_token(config) {
+        return ObserveSnapshot {
+            error: Some(WARMUP_TOKEN_NEEDED.into()),
+            ..ObserveSnapshot::default()
+        };
+    }
     let base = match normalize_base_url(&config.prometheus_url) {
         Ok(url) => url,
         Err(err) => {
@@ -952,10 +978,7 @@ async fn poll_warmup(config: &ObserveConfig) -> ObserveSnapshot {
                 Ok(body) => {
                     if status.as_u16() == 401 {
                         return ObserveSnapshot {
-                            error: Some(
-                                "warmUP /admin/metrics needs a bearer token (Settings or WARMUP_METRICS_TOKEN)"
-                                    .into(),
-                            ),
+                            error: Some(WARMUP_TOKEN_NEEDED.into()),
                             ..ObserveSnapshot::default()
                         };
                     }
@@ -1680,6 +1703,59 @@ mod tests {
             ..approved
         };
         assert_eq!(warmup_bearer(&unapproved), None);
+    }
+
+    #[test]
+    fn approved_warmup_without_token_is_not_fetched() {
+        assert!(missing_warmup_token(&ObserveConfig::default()));
+        let mut with_token = ObserveConfig::default();
+        with_token.metrics_token = "x".into();
+        assert!(!missing_warmup_token(&with_token));
+        let local = ObserveConfig {
+            source: ObserveSourceKind::Warmup,
+            prometheus_url: "http://127.0.0.1:9090".into(),
+            ..ObserveConfig::default()
+        };
+        assert!(
+            !missing_warmup_token(&local),
+            "a non-approved origin still polls (local warmup / tests)"
+        );
+    }
+
+    #[test]
+    fn stable_observe_miss_does_not_repaint() {
+        let miss = ObserveSnapshot {
+            error: Some(WARMUP_TOKEN_NEEDED.into()),
+            ..ObserveSnapshot::default()
+        };
+        assert!(
+            should_repaint(&ObserveSnapshot::default(), &miss),
+            "first miss must show the error"
+        );
+        assert!(
+            !should_repaint(&miss, &miss),
+            "the 5s retry must not dirty a stable miss"
+        );
+        let live = ObserveSnapshot {
+            connected: true,
+            ..ObserveSnapshot::default()
+        };
+        assert!(should_repaint(&miss, &live));
+        assert!(should_repaint(&live, &miss));
+        let other = ObserveSnapshot {
+            error: Some("Can't reach Prometheus".into()),
+            ..ObserveSnapshot::default()
+        };
+        assert!(should_repaint(&miss, &other));
+    }
+
+    #[tokio::test]
+    async fn default_warmup_without_token_skips_the_network() {
+        let snap = tokio::time::timeout(Duration::from_millis(50), poll(&ObserveConfig::default()))
+            .await
+            .expect("tokenless default warmup must not touch the network");
+        assert!(!snap.connected);
+        assert_eq!(snap.error.as_deref(), Some(WARMUP_TOKEN_NEEDED));
     }
 
     #[test]

--- a/crates/nook/src/island/mod.rs
+++ b/crates/nook/src/island/mod.rs
@@ -704,8 +704,11 @@ impl Island {
         let mut snapshot = snapshot;
         nook_core::observe::record_history_range(&mut self.observe_history, &mut snapshot, range);
         nook_core::observe::apply_user_alerts(&self.settings.observe, &mut snapshot);
+        let repaint = nook_core::observe::should_repaint(&self.observe, &snapshot);
         self.observe = snapshot;
-        cx.notify();
+        if repaint {
+            cx.notify();
+        }
     }
 
     pub(crate) fn refresh_observe(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Default Observe is on and pointed at the approved warmUP origin, with no bearer. That path is a guaranteed 401, but the island still fetched it every 5s and dirtied a Metal frame on every identical miss.

## What changed

- Skip the HTTP call to the approved warmUP origin until a token exists (Settings or `WARMUP_METRICS_TOKEN`). Same error string as the 401 path.
- Only `cx.notify()` when the published snapshot actually changes. Live connected data still repaints so sparklines keep moving.
- Local / non-approved origins still poll (existing `polls_warmup_admin_metrics` test).

Smallest idle fix on current `main`. Does not touch #79 or Linux hover/frames.

## Proof

**Before** (current `main`):

1. Fresh install / empty settings: `show_observe = true`, `prometheus_url = https://api.warmup-gamelauncher.com`, empty token.
2. Island Observe loop: `wait = connected ? 15 : 5` → **5s**.
3. Every 5s: HTTP GET `{origin}/admin/metrics` → 401 → `apply_observe_snapshot` → **`cx.notify()`** (Metal frame) even though the error text did not change.

**After:**

1. Same default settings.
2. `poll()` returns the token error **without opening a socket**.
3. First miss still notifies (error appears). Identical retries do not.

Verified on this Linux VM (`cargo test -p nook-core --locked --lib`): **79 passed**, including:

```
approved_warmup_without_token_is_not_fetched ... ok
stable_observe_miss_does_not_repaint         ... ok
default_warmup_without_token_skips_the_network ... ok
polls_warmup_admin_metrics                   ... ok
polls_prometheus_http                        ... ok
```

`default_warmup_without_token_skips_the_network` times out the default-URL poll at 50ms — if the early-return were missing it would try `api.warmup-gamelauncher.com` and fail the timeout.

Repro:

```sh
cargo test -p nook-core --locked --lib observe::tests::default_warmup_without_token_skips_the_network
cargo test -p nook-core --locked --lib observe::tests::stable_observe_miss_does_not_repaint
cargo test -p nook-core --locked --lib
```

A token in Settings or `WARMUP_METRICS_TOKEN` restores the existing fetch. Do not merge until CI is green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0fed403-f89c-4506-b3f1-1baa86413af7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0fed403-f89c-4506-b3f1-1baa86413af7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

