### PR TITLE
Fix Linux island WM chrome with Client decorations

### DIFF
--- a/crates/nook/src/island/render.rs
+++ b/crates/nook/src/island/render.rs
@@ -8,8 +8,8 @@ use crate::theme;
 use gpui::{
     div, point, prelude::*, px, rgba, AnyElement, App, Bounds, Context, CursorStyle,
     ExternalPaths, FontFallbacks, FontWeight, MouseButton, MouseDownEvent, MouseMoveEvent,
-    MouseUpEvent, ScrollWheelEvent, Window, WindowBackgroundAppearance, WindowBounds, WindowKind,
-    WindowOptions,
+    MouseUpEvent, ScrollWheelEvent, Window, WindowBackgroundAppearance, WindowBounds,
+    WindowDecorations, WindowKind, WindowOptions,
 };
 use nook_core::notch;
 use std::any::Any;
@@ -472,7 +472,7 @@ pub fn open_island(cx: &mut App) {
             is_resizable: false,
             is_minimizable: false,
             window_background: WindowBackgroundAppearance::Transparent,
-            window_decorations: None,
+            window_decorations: Some(WindowDecorations::Client),
             app_id: Some("com.jonasvogel.opennook-gpui".into()),
             ..Default::default()
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Re-lands #54 onto `main`. That change was absorbed into #79 but #79 never merged, so `open_island` on `main` still had `window_decorations: None`.

## Proof

Two-line change in `crates/nook/src/island/render.rs`:

1. Import `WindowDecorations` from gpui (alongside existing `WindowOptions` imports).
2. Set `window_decorations: Some(WindowDecorations::Client)` in the `WindowOptions` for `open_island`.

`None` falls through to gpui's `WindowDecorations::Server`, which on X11 writes `_MOTIF_WM_HINTS decorations=1` and XFCE/xfwm draws a title bar + min/max/close. `Client` writes `decorations=0` and strips WM chrome.

Settings stays a normal decorated window. No #79, no hover, no Observe.

## Screenshots

Prior: NOOK-75 (`01-compact-undecorated.png`).

Verified today on this agent's XFCE desktop (`DISPLAY=:1`):

- Log: `x11: compositor present: true, gtk_frame_extents_supported: true`
- `_MOTIF_WM_HINTS = 0x2, 0x0, 0x0, 0x0, 0x0` (decorations=0)
- xfwm frame size matches client (`1920×100`) — no title-bar strip

[Compact island without XFCE title bar](https://cursor.com/agents/bc-af458782-01cf-4137-8a2b-85838dd87917/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F01-compact-undecorated.png)

[Full XFCE desktop with undecorated compact island](https://cursor.com/agents/bc-af458782-01cf-4137-8a2b-85838dd87917/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2F01-compact-undecorated-full.png)

Captain merges. Do not auto-merge.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af458782-01cf-4137-8a2b-85838dd87917?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af458782-01cf-4137-8a2b-85838dd87917&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

