### PR TITLE
fix(nook-core): sample Linux pointer via X11 QueryPointer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,7 @@ dependencies = [
  "tokio",
  "windows 0.52.0",
  "winreg",
+ "x11rb",
  "zbus 4.4.0",
 ]
 

--- a/crates/nook-core/Cargo.toml
+++ b/crates/nook-core/Cargo.toml
@@ -39,3 +39,4 @@ futures-executor = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 zbus = "4.0"
+x11rb = "0.13"

--- a/crates/nook-core/src/mouse.rs
+++ b/crates/nook-core/src/mouse.rs
@@ -238,8 +238,75 @@ fn read_mouse_logical() -> (f64, f64) {
     }
     #[cfg(target_os = "linux")]
     {
-        (0.0, 0.0)
+        linux_read_pointer()
     }
+}
+
+/// X11 `QueryPointer` on the root window. `root_x`/`root_y` are already
+/// screen-logical y-down, matching [`update_ui_bounds`].
+///
+/// Soft-fail: missing `DISPLAY`, X11 connect failure, or Wayland-only
+/// (no XWayland) logs once and keeps returning `(0.0, 0.0)` so the app still runs.
+#[cfg(target_os = "linux")]
+fn linux_read_pointer() -> (f64, f64) {
+    use std::sync::OnceLock;
+    use x11rb::protocol::xproto::ConnectionExt as _;
+    use x11rb::rust_connection::RustConnection;
+
+    static CONN: OnceLock<Option<(RustConnection, u32)>> = OnceLock::new();
+
+    let Some((conn, root)) = CONN
+        .get_or_init(|| match open_x11_pointer() {
+            Ok(pair) => Some(pair),
+            Err(reason) => {
+                log::warn!("linux pointer: {reason}; hover-to-expand disabled");
+                None
+            }
+        })
+        .as_ref()
+    else {
+        return (0.0, 0.0);
+    };
+
+    conn.query_pointer(*root)
+        .ok()
+        .and_then(|cookie| cookie.reply().ok())
+        .map(|reply| x11_root_to_logical(reply.root_x, reply.root_y))
+        .unwrap_or((0.0, 0.0))
+}
+
+#[cfg(target_os = "linux")]
+fn linux_pointer_block_reason(display: Option<&std::ffi::OsStr>) -> Option<&'static str> {
+    if display.is_none() {
+        Some("DISPLAY unset (Wayland-only or headless)")
+    } else {
+        None
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn open_x11_pointer() -> Result<(x11rb::rust_connection::RustConnection, u32), String> {
+    use x11rb::connection::Connection;
+
+    if let Some(reason) = linux_pointer_block_reason(std::env::var_os("DISPLAY").as_deref()) {
+        return Err(reason.into());
+    }
+    let (conn, screen_num) =
+        x11rb::connect(None).map_err(|err| format!("X11 connect failed: {err}"))?;
+    let root = conn
+        .setup()
+        .roots
+        .get(screen_num)
+        .map(|screen| screen.root)
+        .ok_or_else(|| "X11 screen missing".to_string())?;
+    Ok((conn, root))
+}
+
+/// QueryPointer root pixels are already y-down from the root origin.
+/// Do not flip against screen height the way macOS `NSEvent` does.
+#[cfg(target_os = "linux")]
+fn x11_root_to_logical(root_x: i16, root_y: i16) -> (f64, f64) {
+    (f64::from(root_x), f64::from(root_y))
 }
 
 #[cfg(test)]
@@ -354,5 +421,21 @@ mod tests {
             "padded capture box around the island still works"
         );
         super::DRAG_ACTIVE.store(false, Ordering::Relaxed);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn x11_root_coords_stay_y_down() {
+        assert_eq!(super::x11_root_to_logical(850, 12), (850.0, 12.0));
+        assert_eq!(super::x11_root_to_logical(0, 0), (0.0, 0.0));
+        assert_eq!(super::x11_root_to_logical(-8, 40), (-8.0, 40.0));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn linux_pointer_soft_fails_without_display() {
+        let reason = super::linux_pointer_block_reason(None).expect("headless is a soft-fail");
+        assert!(reason.contains("DISPLAY unset"), "{reason}");
+        assert!(super::linux_pointer_block_reason(Some(std::ffi::OsStr::new(":1"))).is_none());
     }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Linux `read_mouse_logical` always returned `(0.0, 0.0)`, so the hover poll in `start_polling` / `sample_now` never hit the published island bounds. Hover-to-expand stayed dead on GPUI Linux builds. macOS already samples `NSEvent`; Windows already samples `GetCursorPos`.

## Scope

- `crates/nook-core/src/mouse.rs`: Linux path calls X11 `QueryPointer` on the root window. `root_x`/`root_y` stay y-down screen-logical, matching `update_ui_bounds`.
- Soft-fail: missing `DISPLAY`, X11 connect failure, or Wayland-only (no XWayland) logs once and keeps returning `(0.0, 0.0)`. No panic.
- `crates/nook-core/Cargo.toml`: `x11rb = "0.13"` under `[target.'cfg(target_os = "linux")'.dependencies]`.
- `Cargo.lock`: add the existing `x11rb` crate as a `nook-core` dep.
- Unit tests cover the y-down contract and the DISPLAY-missing soft-fail reason. No live X server required.

Out of scope: Wayland native protocol, `#79`, decorations, Observe polling, launch-page frames, macOS, Windows, Tauri `#50`.

## Tradeoffs

Cached one X11 connection in a `OnceLock` instead of connecting on every 20–33 ms sample. A failed connect stays failed for the process.

## Blast Radius

Linux GPUI hover and click-through only. Other platforms keep their existing readers. Headless / Wayland-only Linux still boots.

## Verification

- `cargo test -p nook-core --locked --lib`: **78 passed** (agent, rustc 1.98).
- Live X11 probe on `DISPLAY=:1` (XFCE 1920×1200) via `start_polling` + `current_mouse_logical` against idle island bounds `859.5,0 201x34`:

```
BEFORE (main stub): always sample=0.0,0.0 → hit=false
AFTER outside: sample=100.0,100.0 xdotool=x:100 y:100 hit=false
AFTER over:    sample=960.0,10.0  xdotool=x:960 y:10  hit=true
AFTER below:   sample=960.0,80.0  xdotool=x:960 y:80  hit=false
AFTER left:    sample=800.0,10.0  xdotool=x:800 y:10  hit=false
```

- Cursor at top-center while over-island sample ran:

[Cursor at top-center island hit region](https://cursor.com/agents/bc-696e9a00-afe6-4e4f-8cb1-d287020b72dc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnook82-cursor-over-island.png)

- Proof log: `/opt/cursor/artifacts/nook82-pointer-samples.txt`
- Full GPUI compact→expand screenshot blocked here: `nook` links, then panics with `Unable to init GPU context` / `NoSupportedDeviceFound` (no Vulkan device in this agent). Log: `/opt/cursor/artifacts/nook82-gpui-no-gpu.log`

Captain merges. No auto-merge.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-696e9a00-afe6-4e4f-8cb1-d287020b72dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-696e9a00-afe6-4e4f-8cb1-d287020b72dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

